### PR TITLE
fix: move top-level linter settings into `lint` section

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [tool.ruff]
 line-length = 128
 # select = ["E", "F"]
-select = [
+lint.select = [
   "E",  # pycodestyle (includes missing newline at EOF, etc.)
   "F",  # pyflakes
   "W",  # pycodestyle warnings
@@ -16,4 +16,4 @@ select = [
   "Q",  # quote-conventions
  # "PL", # pylint (useful for layout, blank lines, etc.)
 ]
-ignore = ["E741"]
+lint.ignore = ["E741"]


### PR DESCRIPTION
This patch fixes the following linter warning:

```text
warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `pyproject.toml`:
  - 'ignore' -> 'lint.ignore'
  - 'select' -> 'lint.select'
```