### PR TITLE
ReactiveRoutingController: dynamic path computation

### DIFF
--- a/examples/3_nodes_purif.py
+++ b/examples/3_nodes_purif.py
@@ -37,7 +37,7 @@ def run_simulation(t_cohere: float, seed: int):
             init_fidelity=0.7,
         )
         .proactive_centralized()
-        .path("S-D")
+        .request("S-D")
         .make_network()
     )
 

--- a/examples/3_nodes_thruput.py
+++ b/examples/3_nodes_thruput.py
@@ -22,7 +22,6 @@ from tap import Tap
 
 from mqns.network.builder import CTRL_DELAY, EprTypeLiteral, LinkArchLiteral, NetworkBuilder, tap_configure
 from mqns.network.fw import Forwarder
-from mqns.network.network import TimingModeSync
 from mqns.network.protocol.link_layer import LinkLayerCounters
 from mqns.simulator import Simulator
 from mqns.utils import log, rng
@@ -36,7 +35,8 @@ class Args(Tap):
     workers: int = 1  # number of workers for parallel execution
     runs: int = 100  # number of trials per parameter set
     sim_duration: float = 3  # simulation duration in seconds
-    mode: Literal["P", "R"] = "P"  # choose proactive or reactive mode
+    mode: Literal["PCA", "RCS"] = "PCA"
+    sync_timing: list[float]
     L: tuple[float, float] = (32, 18)  # qchannel lengths (km)
     t_cohere: list[float] = [0.002, 0.005, 0.01, 0.015, 0.02, 0.025, 0.05, 0.1]  # memory coherence time (s)
     qchannel_capacity: int = 1  # qchannel capacity
@@ -48,7 +48,6 @@ class Args(Tap):
 
     @override
     def configure(self) -> None:
-        super().configure()
         tap_configure(self)
 
 
@@ -66,15 +65,7 @@ class Stats(TypedDict):
 def run_simulation(seed: int, args: Args, t_cohere: float) -> Stats:
     rng.reseed(seed)
 
-    match args.mode:
-        case "P":
-            b = NetworkBuilder()
-            total_duration = args.sim_duration + CTRL_DELAY
-        case "R":
-            b = NetworkBuilder(timing=TimingModeSync(t_ext=0.03, t_rtg=0.00005, t_int=0.0002))
-            total_duration = args.sim_duration
-
-    b.topo_linear(
+    b = NetworkBuilder().topo_linear(
         nodes=("S", "R", "D"),
         t_cohere=t_cohere,
         channel_length=args.L,
@@ -83,10 +74,12 @@ def run_simulation(seed: int, args: Args, t_cohere: float) -> Stats:
     )
 
     match args.mode:
-        case "P":
+        case "PCA":
+            total_duration = args.sim_duration + CTRL_DELAY
             b.proactive_centralized().path("S-D")
-        case "R":
-            b.reactive_centralized()
+        case "RCS":
+            total_duration = args.sim_duration
+            b.reactive_centralized(timing=args.sync_timing)
 
     net = b.make_network()
     del b

--- a/examples/3_nodes_thruput.py
+++ b/examples/3_nodes_thruput.py
@@ -76,7 +76,7 @@ def run_simulation(seed: int, args: Args, t_cohere: float) -> Stats:
     match args.mode:
         case "PCA":
             total_duration = args.sim_duration + CTRL_DELAY
-            b.proactive_centralized().path("S-D")
+            b.proactive_centralized().request("S-D")
         case "RCS":
             total_duration = args.sim_duration
             b.reactive_centralized(timing=args.sync_timing)

--- a/examples/3_nodes_thruput.py
+++ b/examples/3_nodes_thruput.py
@@ -76,11 +76,12 @@ def run_simulation(seed: int, args: Args, t_cohere: float) -> Stats:
     match args.mode:
         case "PCA":
             total_duration = args.sim_duration + CTRL_DELAY
-            b.proactive_centralized().request("S-D")
+            b.proactive_centralized()
         case "RCS":
             total_duration = args.sim_duration
             b.reactive_centralized(timing=args.sync_timing)
 
+    b.request("S-D")
     net = b.make_network()
     del b
 

--- a/examples/3_nodes_wait.py
+++ b/examples/3_nodes_wait.py
@@ -46,7 +46,6 @@ class Args(Tap):
 
     @override
     def configure(self) -> None:
-        super().configure()
         tap_configure(self)
 
 

--- a/examples/3_nodes_wait.py
+++ b/examples/3_nodes_wait.py
@@ -70,7 +70,7 @@ def run_simulation(seed: int, args: Args, t_cohere: float, t_wait: float):
             init_fidelity=None if args.link_arch_sim else 0.99,
         )
         .proactive_centralized()
-        .path(
+        .request(
             "S-D",
             swap=[1, 0, 1],
             swap_cutoff=[0, t_wait, 0],

--- a/examples/asymmetric_channel_3_nodes.py
+++ b/examples/asymmetric_channel_3_nodes.py
@@ -61,7 +61,7 @@ def run_simulation(
             t_cohere=t_cohere,
         )
         .proactive_centralized()
-        .path("S-D")
+        .request("S-D")
         .make_network()
     )
 

--- a/examples/asymmetric_channel_memory.py
+++ b/examples/asymmetric_channel_memory.py
@@ -28,7 +28,7 @@ def run_simulation(seed: int, args: Args):
             t_cohere=0.01,
         )
         .proactive_centralized()
-        .path("S-D", swap="l2r")
+        .request("S-D", swap="l2r")
         .make_network()
     )
 

--- a/examples/extctrl/Cargo.lock
+++ b/examples/extctrl/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "async-nats"
-version = "0.45.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86dde77d8a733a9dbaf865a9eb65c72e09c88f3d14d3dd0d2aecf511920ee4fe"
+checksum = "07d6f157065c3461096d51aacde0c326fa49f3f6e0199e204c566842cdaa5299"
 dependencies = [
  "base64",
  "bytes",
@@ -29,15 +29,14 @@ dependencies = [
  "memchr",
  "nkeys",
  "nuid",
- "once_cell",
  "pin-project",
  "portable-atomic",
  "rand",
  "regex",
  "ring",
  "rustls-native-certs",
- "rustls-pemfile",
- "rustls-webpki 0.102.8",
+ "rustls-pki-types",
+ "rustls-webpki",
  "serde",
  "serde_json",
  "serde_nanos",
@@ -68,9 +67,9 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -83,9 +82,9 @@ dependencies = [
 
 [[package]]
 name = "bpaf"
-version = "0.9.23"
+version = "0.9.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a59e5c2bac9ccb280150ef4b58e07e4169d8c5c6ce0f70170e3c0b7c7b6124"
+checksum = "0b8d4b90317451025bfa1f7d359a5fa698a5f745927ff27696429b7fbd7c0c48"
 dependencies = [
  "bpaf_derive",
 ]
@@ -112,9 +111,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -134,9 +133,9 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "core-foundation"
-version = "0.9.4"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -364,12 +363,13 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -377,9 +377,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -390,9 +390,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -404,15 +404,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -424,15 +424,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -466,21 +466,21 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -505,9 +505,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -525,6 +525,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -553,21 +554,21 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.6"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "parking_lot"
@@ -651,9 +652,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -693,9 +694,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -784,38 +785,28 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.9",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.7.3"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
  "rustls-pki-types",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]
@@ -829,19 +820,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.8"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
-dependencies = [
- "rustls-pki-types",
- "untrusted",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.103.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -850,9 +831,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -865,9 +846,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
-version = "2.11.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -888,9 +869,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1123,9 +1104,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -1133,9 +1114,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -1150,9 +1131,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1257,9 +1238,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicode-ident"
@@ -1309,14 +1290,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -1411,15 +1392,15 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -1428,9 +1409,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1440,18 +1421,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.41"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96e13bc581734df6250836c59a5f44f3c57db9f9acb9dc8e3eaabdaf6170254d"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.41"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3545ea9e86d12ab9bba9fcd99b54c1556fd3199007def5a03c375623d05fac1c"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1460,18 +1441,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1487,9 +1468,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -1498,9 +1479,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -1509,9 +1490,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/examples/extctrl/Cargo.toml
+++ b/examples/extctrl/Cargo.toml
@@ -4,10 +4,11 @@ version = "0.0.0"
 edition = "2024"
 
 [dependencies]
-anyhow = "^1.0.100"
-async-nats = { version = "^0.45.0", features = ["websockets"] }
-bpaf = { version = "^0.9.22", features = ["derive"] }
+anyhow = "^1.0.102"
+async-nats = { version = "^0.47.0", features = ["websockets"] }
+bpaf = { version = "^0.9.24", features = ["derive"] }
 bytes = "^1.11.0"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-tokio = { version = "^1.48.0", features = ["full"] }
+serde = { version = "^1.0.228", features = ["derive"] }
+serde_json = "^1.0.149"
+tokio = { version = "^1.50.0", features = ["full"] }
+tokio-stream = "^0.1.18"

--- a/examples/extctrl/README.md
+++ b/examples/extctrl/README.md
@@ -53,10 +53,16 @@ bash run.sh
 bash run.sh --sim_accuracy 200000
 
 # proactive-centralized-async mode, enable S1-D1 path with asap swap order
-bash run.sh -- --mode PCA -- --path1 asap --path2 disabled
+bash run.sh --mode PCA -- -- --path1 asap --path2 disabled
 
 # proactive-centralized-async mode, enable both paths with r2l swap order, install paths at different times
-bash run.sh -- --mode PCA -- --sim_duration 60 --path1 r2l --path1_i 0 --path2 r2l --path2_i 30
+bash run.sh --mode PCA -- -- --sim_duration 60 --path1 r2l --path1_i 0 --path2 r2l --path2_i 30
+
+# reactive-centralized-sync mode
+bash run.sh --mode RCS
+
+# reactive-centralized-sync mode, set coherence time and sync timing (both must be specified)
+bash run.sh --mode RCS --sync_timing 0.026950 0.000050 0.003000 -- --t_cohere 0.030000
 ```
 
 During the scenario execution, you can view NATS messages on a separate console:

--- a/examples/extctrl/README.md
+++ b/examples/extctrl/README.md
@@ -34,29 +34,29 @@ See `ClassicBridge` and `ClassicConnector` class documentation for details.
 Apart from MQNS library, the following dependencies are required:
 
 * Rust toolchain: see [Rust book](https://doc.rust-lang.org/stable/book/ch01-01-installation.html)
-* NATS library in the Python venv: `pip install 'nats-py>=2.14.0,<3'`
+* NATS library in the Python venv: `pip install -r examples/extctrl/requirements.txt`
 * NATS Messaging service with JetStream enabled: `docker run -d --name nats_server -p 4222:4222 nats:2 -addr :: -js`
 * `nats` CLI client: see [release page](https://github.com/nats-io/natscli/releases)
 
-The **demo.sh** script orchestrates the execution.
+The **run.sh** script orchestrates the execution.
 It creates necessary NATS JetStream objects, and launches both Python script and Rust program with appropriate flags.
 To start the example, cd to this directory, and then execute some of these sample commands:
 
 ```bash
 # view help
-bash demo.sh --help
+bash run.sh --help
 
-# default: proactive, enable S1-D1 path with l2r swap order
-bash demo.sh
+# default: proactive-centralized-async mode, enable S1-D1 path with l2r swap order
+bash run.sh
 
 # change simulation accuracy
-bash demo.sh --sim_accuracy 200000
+bash run.sh --sim_accuracy 200000
 
-# proactive mode, enable S1-D1 path with asap swap order
-bash demo.sh -- --mode P -- --path1 asap --path2 disabled
+# proactive-centralized-async mode, enable S1-D1 path with asap swap order
+bash run.sh -- --mode PCA -- --path1 asap --path2 disabled
 
-# proactive mode, enable both paths with r2l swap order, install paths at different times
-bash demo.sh -- --mode P -- --sim_duration 60 --path1 r2l --path1_i 0 --path2 r2l --path2_i 30
+# proactive-centralized-async mode, enable both paths with r2l swap order, install paths at different times
+bash run.sh -- --mode PCA -- --sim_duration 60 --path1 r2l --path1_i 0 --path2 r2l --path2_i 30
 ```
 
 During the scenario execution, you can view NATS messages on a separate console:

--- a/examples/extctrl/README.md
+++ b/examples/extctrl/README.md
@@ -62,5 +62,5 @@ bash demo.sh -- --mode P -- --sim_duration 60 --path1 r2l --path1_i 0 --path2 r2
 During the scenario execution, you can view NATS messages on a separate console:
 
 ```bash
-nats sub 'mqns.classicbridge.*.*'
+nats sub 'mqns.classicbridge.>'
 ```

--- a/examples/extctrl/demo.sh
+++ b/examples/extctrl/demo.sh
@@ -61,7 +61,8 @@ nats stream rm $STREAM -f || true
 
 info Defining NATS stream
 nats stream add $STREAM \
-  --subjects "$NATS_PREFIX.*.*" \
+  --subjects "$NATS_PREFIX.I.*.*" \
+  --subjects "$NATS_PREFIX.O.*.*" \
   --storage memory \
   --retention limits \
   --discard old \

--- a/examples/extctrl/extctrl_dp.py
+++ b/examples/extctrl/extctrl_dp.py
@@ -18,11 +18,16 @@ class Args(Tap):
     seed: int | None = None  # random seed
     mode: Literal["PCA", "RCS"] = "PCA"
     sync_timing: list[float]
+    L: tuple[float, float] = (50, 10)  # qchannel lengths (km)
+    M: tuple[int, int] = (2, 4)  # qchannel capacity
+    t_cohere: float = 0.05  # memory coherence time (s)
     epr_type: EprTypeLiteral  # network-wide EPR type
 
     @override
     def configure(self) -> None:
         tap_configure(self)
+        self.add_argument("--L", metavar=("L_edge", "L_center"))
+        self.add_argument("--M", metavar=("M_edge", "M_center"))
 
 
 def run_simulation(args: Args) -> dict[str, ForwarderCounters]:
@@ -33,13 +38,13 @@ def run_simulation(args: Args) -> dict[str, ForwarderCounters]:
     )
     b.topo(
         channels=[
-            ("S1-R1", 50, 2),
-            ("S2-R1", 50, 2),
-            ("R1-R2", 10, 4),
-            ("R2-D1", 50, 2),
-            ("R2-D2", 50, 2),
+            ("S1-R1", args.L[0], args.M[0]),
+            ("S2-R1", args.L[0], args.M[0]),
+            ("R1-R2", args.L[1], args.M[1]),
+            ("R2-D1", args.L[0], args.M[0]),
+            ("R2-D2", args.L[0], args.M[0]),
         ],
-        t_cohere=0.05,
+        t_cohere=args.t_cohere,
     )
 
     match args.mode:

--- a/examples/extctrl/extctrl_dp.py
+++ b/examples/extctrl/extctrl_dp.py
@@ -16,12 +16,12 @@ class Args(Tap):
     nats_prefix: str = ClassicBridge.DEFAULT_NATS_PREFIX  # prefix of NATS subjects
     sim_accuracy: int = 1_000_000  # simulation accuracy in time slots per second
     seed: int | None = None  # random seed
-    mode: Literal["P", "R"] = "P"  # choose proactive or reactive mode
+    mode: Literal["PCA", "RCS"] = "PCA"
+    sync_timing: list[float]
     epr_type: EprTypeLiteral  # network-wide EPR type
 
     @override
     def configure(self) -> None:
-        super().configure()
         tap_configure(self)
 
 
@@ -38,14 +38,15 @@ def run_simulation(args: Args) -> dict[str, ForwarderCounters]:
             ("R1-R2", 10, 4),
             ("R2-D1", 50, 2),
             ("R2-D2", 50, 2),
-        ]
+        ],
+        t_cohere=0.05,
     )
 
     match args.mode:
-        case "P":
+        case "PCA":
             b.proactive_centralized()
-        case "R":
-            b.reactive_centralized()
+        case "RCS":
+            b.reactive_centralized(timing=args.sync_timing)
 
     b.external_controller(nats_prefix=args.nats_prefix)
 

--- a/examples/extctrl/run.sh
+++ b/examples/extctrl/run.sh
@@ -24,7 +24,7 @@ for A in "$@"; do
     continue
   fi
   if [[ "$A" == '-h' || "$A" == '--help' ]]; then
-    info 'Usage: bash demo.sh [COMMON-ARGS] -- [PY-ARGS] -- [RS-ARGS]'
+    info 'Usage: bash run.sh [COMMON-ARGS] -- [PY-ARGS] -- [RS-ARGS]'
     info '  COMMON-ARGS: passed to both Python and Rust'
     info '  PY-ARGS: passed to Python script'
     info '  RS-ARGS: passed to Rust crate'

--- a/examples/extctrl/src/lib.rs
+++ b/examples/extctrl/src/lib.rs
@@ -3,8 +3,8 @@ use async_nats::{self, HeaderMap, jetstream};
 use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use serde_json;
-use std::collections::HashMap;
-use tokio::sync::mpsc;
+use std::{collections::HashMap, sync::Arc};
+use tokio::sync::{Mutex, mpsc};
 use tokio_stream::StreamExt;
 
 pub const CTRL_DELAY: f64 = 5e-6;
@@ -67,24 +67,55 @@ pub struct LinkStateEntry {
 }
 
 /// Southbound interface to interact with simulated quantum nodes.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Southbound {
     js: jetstream::Context,
     nats_prefix: String,
     gate_subject: String,
+    gate_stream: Arc<Mutex<jetstream::consumer::pull::Stream>>,
 }
 
 impl Southbound {
+    async fn create_pull_stream(
+        js: &jetstream::Context,
+        subject: String,
+    ) -> Result<jetstream::consumer::pull::Stream> {
+        let stream_name = js.stream_by_subject(&subject).await?;
+        let stream = js.get_stream(stream_name).await?;
+        let consumer = stream
+            .create_consumer(jetstream::consumer::pull::Config {
+                filter_subject: subject,
+                ..Default::default()
+            })
+            .await?;
+
+        let messages = consumer.messages().await?;
+        Ok(messages)
+    }
+
+    fn extract_header_t(message: &jetstream::message::Message) -> u64 {
+        message
+            .headers
+            .as_ref()
+            .and_then(|h| h.get("t"))
+            .and_then(|s| s.as_str().parse::<u64>().ok())
+            .unwrap_or(0)
+    }
+
     /// Construct southbound interface.
-    pub fn new(js: jetstream::Context, nats_prefix: &str) -> Self {
-        Self {
+    pub async fn new(nc: async_nats::Client, nats_prefix: &str) -> Result<Self> {
+        let js = jetstream::new(nc);
+        let gate_stream =
+            Self::create_pull_stream(&js, format!("{}.O._.gate", nats_prefix)).await?;
+        Ok(Self {
             js,
             nats_prefix: nats_prefix.into(),
             gate_subject: format!("{nats_prefix}.I._.gate"),
-        }
+            gate_stream: Arc::new(Mutex::new(gate_stream)),
+        })
     }
 
-    /// Send update_gate command.
+    /// Send update_gate command and wait for data plane to reach the clock gate.
     ///
     /// * `t`: Clock gate in time slots.
     pub async fn update_gate(&self, t: u64) -> Result<()> {
@@ -94,7 +125,19 @@ impl Southbound {
             .publish_with_headers(self.gate_subject.clone(), headers, "".into())
             .await?
             .await?;
-        Ok(())
+
+        let mut messages = self.gate_stream.lock().await;
+        while let Some(Ok(message)) = messages.next().await {
+            let now = Self::extract_header_t(&message);
+            message.ack().await.map_err(|e| anyhow::anyhow!(e))?;
+            if now >= t {
+                return Ok(());
+            }
+        }
+        Err(anyhow::anyhow!(
+            "{}.O._.gate stream ended unexpectedly",
+            self.nats_prefix
+        ))
     }
 
     /// Schedule simulation stop.
@@ -175,26 +218,12 @@ impl Southbound {
 
     pub async fn recv_link_states(&self, ch: mpsc::Sender<LinkStateMsg>) -> Result<()> {
         let subject = format!("{}.O.ctrl.*", self.nats_prefix);
-        let stream_name = self.js.stream_by_subject(&subject).await?;
-        let stream = self.js.get_stream(stream_name).await?;
-        let consumer = stream
-            .create_consumer(jetstream::consumer::pull::Config {
-                filter_subject: subject,
-                ..Default::default()
-            })
-            .await?;
-
-        let mut messages = consumer.messages().await?;
+        let mut messages = Self::create_pull_stream(&self.js, subject).await?;
         while let Some(result) = messages.next().await {
             match result {
                 Ok(message) => {
-                    let t = message
-                        .headers
-                        .as_ref()
-                        .and_then(|h| h.get("t"))
-                        .and_then(|s| s.as_str().parse::<u64>().ok())
-                        .unwrap_or(0);
-                    message.ack().await.ok();
+                    let t = Self::extract_header_t(&message);
+                    message.ack().await.map_err(|e| anyhow::anyhow!(e))?;
 
                     if let Ok(mut msg) = serde_json::from_slice::<LinkStateMsg>(&message.payload) {
                         if msg.cmd == CMD_LS {

--- a/examples/extctrl/src/lib.rs
+++ b/examples/extctrl/src/lib.rs
@@ -4,9 +4,19 @@ use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use serde_json;
 use std::collections::HashMap;
+use tokio::sync::mpsc;
+use tokio_stream::StreamExt;
+
+pub const CTRL_DELAY: f64 = 5e-6;
+
+/// Convert seconds to time slots at given accuracy.
+pub fn sec_to_time_slot(sec: f64, accuracy: u64) -> u64 {
+    (sec * accuracy as f64).round() as u64
+}
 
 const CMD_INSTALL_PATH: &str = "INSTALL_PATH";
 const CMD_UNINSTALL_PATH: &str = "UNINSTALL_PATH";
+const CMD_LS: &str = "LS";
 
 #[derive(Debug, Clone, Serialize)]
 struct InstallPathCmd<'a> {
@@ -31,6 +41,21 @@ pub struct PathInstructions {
     pub swap_cutoff: Vec<i32>,
     pub m_v: Option<Vec<Vec<i32>>>,
     pub purif: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct LinkStateMsg {
+    #[serde(skip)]
+    pub t: u64,
+    pub cmd: String, // CMD_LS
+    pub ls: Vec<LinkStateEntry>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct LinkStateEntry {
+    pub node: String,
+    pub neighbor: String,
+    pub qubit: i32,
 }
 
 /// Southbound interface to interact with simulated quantum nodes.
@@ -137,6 +162,45 @@ impl Southbound {
                 return Err(anyhow!("Failed to deliver instructions to {}: {}", dst, e));
             }
         }
+        Ok(())
+    }
+
+    pub async fn recv_link_states(&self, ch: mpsc::Sender<LinkStateMsg>) -> Result<()> {
+        let subject = format!("{}.O.ctrl.*", self.nats_prefix);
+        let stream_name = self.js.stream_by_subject(&subject).await?;
+        let stream = self.js.get_stream(stream_name).await?;
+        let consumer = stream
+            .create_consumer(jetstream::consumer::pull::Config {
+                filter_subject: subject,
+                ..Default::default()
+            })
+            .await?;
+
+        let mut messages = consumer.messages().await?;
+        while let Some(result) = messages.next().await {
+            match result {
+                Ok(message) => {
+                    let t = message
+                        .headers
+                        .as_ref()
+                        .and_then(|h| h.get("t"))
+                        .and_then(|s| s.as_str().parse::<u64>().ok())
+                        .unwrap_or(0);
+                    message.ack().await.ok();
+
+                    if let Ok(mut msg) = serde_json::from_slice::<LinkStateMsg>(&message.payload) {
+                        if msg.cmd == CMD_LS {
+                            msg.t = t;
+                            if let Err(_) = ch.send(msg).await {
+                                break; // channel receiver closed
+                            }
+                        }
+                    }
+                }
+                Err(e) => return Err(anyhow!(e)),
+            }
+        }
+
         Ok(())
     }
 }

--- a/examples/extctrl/src/lib.rs
+++ b/examples/extctrl/src/lib.rs
@@ -39,8 +39,16 @@ pub struct PathInstructions {
     pub route: Vec<String>,
     pub swap: Vec<i32>,
     pub swap_cutoff: Vec<i32>,
-    pub m_v: Option<Vec<Vec<i32>>>,
+    pub m_v: Option<Vec<MultiplexingVectorElem>>,
     pub purif: HashMap<String, String>,
+}
+
+/// Multiplexing Vector element in PathInstructions.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum MultiplexingVectorElem {
+    Count(i32, i32),
+    Key(String),
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -55,7 +63,7 @@ pub struct LinkStateMsg {
 pub struct LinkStateEntry {
     pub node: String,
     pub neighbor: String,
-    pub qubit: i32,
+    pub qubit: String,
 }
 
 /// Southbound interface to interact with simulated quantum nodes.

--- a/examples/extctrl/src/lib.rs
+++ b/examples/extctrl/src/lib.rs
@@ -1,29 +1,29 @@
-use anyhow::Result;
+use anyhow::{Result, anyhow};
 use async_nats::{self, HeaderMap, jetstream};
 use bytes::Bytes;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json;
 use std::collections::HashMap;
 
 const CMD_INSTALL_PATH: &str = "INSTALL_PATH";
 const CMD_UNINSTALL_PATH: &str = "UNINSTALL_PATH";
 
-#[derive(Serialize)]
+#[derive(Debug, Clone, Serialize)]
 struct InstallPathCmd<'a> {
-    cmd: String,
+    cmd: String, // CMD_INSTALL_PATH
     path_id: u32,
     instructions: &'a PathInstructions,
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 struct UninstallPathCmd {
-    cmd: String,
+    cmd: String, // CMD_UNINSTALL_PATH
     path_id: u32,
 }
 
 /// Instructions from the controller to forwarders regarding a routing path.
 /// See mqns.network.fw.PathInstructions struct for details.
-#[derive(Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct PathInstructions {
     pub req_id: u32,
     pub route: Vec<String>,
@@ -34,6 +34,7 @@ pub struct PathInstructions {
 }
 
 /// Southbound interface to interact with simulated quantum nodes.
+#[derive(Debug, Clone)]
 pub struct Southbound {
     js: jetstream::Context,
     nats_prefix: String,
@@ -46,7 +47,7 @@ impl Southbound {
         Self {
             js,
             nats_prefix: nats_prefix.into(),
-            gate_subject: format!("{nats_prefix}._.gate"),
+            gate_subject: format!("{nats_prefix}.I._.gate"),
         }
     }
 
@@ -67,7 +68,7 @@ impl Southbound {
     ///
     /// * `t`: Simulation stop time in time slots.
     pub async fn stop(&self, t: u64) -> Result<()> {
-        let subject = format!("{}._.stop", self.nats_prefix);
+        let subject = format!("{}.I._.stop", self.nats_prefix);
         let mut headers = HeaderMap::new();
         headers.insert("t", t.to_string());
         self.js
@@ -123,14 +124,18 @@ impl Southbound {
         instructions: &PathInstructions,
     ) -> Result<()> {
         for dst in &instructions.route {
-            let subject = format!("{}.{dst}.ctrl", self.nats_prefix);
+            let subject = format!("{}.I.{dst}.ctrl", self.nats_prefix);
             let mut headers = HeaderMap::new();
             headers.insert("t", t.to_string());
             headers.insert("fmt", "json");
-            self.js
+            if let Err(e) = self
+                .js
                 .publish_with_headers(subject, headers, payload.clone())
                 .await?
-                .await?;
+                .await
+            {
+                return Err(anyhow!("Failed to deliver instructions to {}: {}", dst, e));
+            }
         }
         Ok(())
     }

--- a/examples/extctrl/src/main.rs
+++ b/examples/extctrl/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use async_nats::{self, jetstream};
+use async_nats;
 use bpaf::Bpaf;
 use mqns_example_extctrl::{
     LinkStateEntry, LinkStateMsg, MultiplexingVectorElem, PathInstructions, Southbound,
@@ -8,7 +8,6 @@ use mqns_example_extctrl::{
 use std::{
     collections::{HashMap, HashSet},
     env,
-    time::Duration,
 };
 use tokio::sync::mpsc;
 
@@ -135,9 +134,7 @@ async fn main() -> Result<()> {
     let args = args().run();
 
     let nc = async_nats::connect(nats_url).await?;
-    let js = jetstream::new(nc);
-
-    let sb = Southbound::new(js, &args.nats_prefix);
+    let sb = Southbound::new(nc, &args.nats_prefix).await?;
 
     match args.mode {
         Mode::PCA => tx_loop_pca(&args, &sb).await,
@@ -198,10 +195,9 @@ async fn tx_loop_pca(args: &Args, sb: &Southbound) -> Result<()> {
 
         if args.sim_duration == sec {
             sb.stop(t).await?;
+        } else {
+            sb.update_gate(t).await?;
         }
-
-        sb.update_gate(t).await?;
-        tokio::time::sleep(Duration::from_millis(100)).await;
     }
 
     Ok(())
@@ -284,7 +280,6 @@ async fn tx_loop_rcs(
 
         println!("Simulation Time: {} / {}", t, t_stop);
         sb.update_gate(t).await?;
-        tokio::time::sleep(Duration::from_millis(1000)).await;
 
         tls.clear();
         while let Ok(msg) = link_state_ch.try_recv() {
@@ -319,7 +314,6 @@ async fn tx_loop_rcs(
     }
 
     sb.stop(t_stop).await?;
-    sb.update_gate(t_stop).await?;
 
     Ok(())
 }

--- a/examples/extctrl/src/main.rs
+++ b/examples/extctrl/src/main.rs
@@ -108,7 +108,7 @@ struct Args {
     #[bpaf(argument("MODE"), fallback(Mode::PCA))]
     mode: Mode,
 
-    #[bpaf(external, fallback(SyncTiming{_sync_timing:(), t_ext:0.024995, t_rtg:0.000010, t_int:0.024995}))]
+    #[bpaf(external, fallback(SyncTiming{_sync_timing:(), t_ext:0.024990, t_rtg:0.000020, t_int:0.024990}))]
     sync_timing: SyncTiming,
 
     /// S1-D1 path enablement and swap order (asap|l2r|r2l|disabled)

--- a/examples/extctrl/src/main.rs
+++ b/examples/extctrl/src/main.rs
@@ -1,8 +1,51 @@
 use anyhow::Result;
 use async_nats::{self, jetstream};
 use bpaf::Bpaf;
-use mqns_example_extctrl::{PathInstructions, Southbound};
+use mqns_example_extctrl::{
+    LinkStateEntry, LinkStateMsg, PathInstructions, Southbound, sec_to_time_slot,
+};
 use std::{collections::HashMap, env, time::Duration};
+use tokio::sync::mpsc;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Bpaf)]
+enum Mode {
+    /// Proactive forwarding, Centralized control, Async timing
+    PCA,
+    /// Reactive forwarding, Centralized control, Sync timing
+    RCS,
+}
+
+impl std::str::FromStr for Mode {
+    type Err = String;
+
+    fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
+        match s.to_uppercase().as_str() {
+            "PCA" => Ok(Mode::PCA),
+            "RCS" => Ok(Mode::RCS),
+            _ => Err(format!("invalid mode: {s}")),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Bpaf)]
+#[bpaf(adjacent)]
+struct SyncTiming {
+    /// SYNC timing mode phase durations in seconds
+    #[bpaf(long("sync_timing"))]
+    _sync_timing: (),
+
+    /// EXTERNAL phase duration in seconds
+    #[bpaf(positional("t_ext"))]
+    t_ext: f64,
+
+    /// ROUTING phase duration in seconds
+    #[bpaf(positional("t_rtg"))]
+    t_rtg: f64,
+
+    /// INTERNAL phase duration in seconds
+    #[bpaf(positional("t_int"))]
+    t_int: f64,
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Bpaf)]
 enum PathOpt {
@@ -57,6 +100,13 @@ struct Args {
     #[bpaf(long("sim_duration"), argument("DURATION"), fallback(60))]
     sim_duration: u64,
 
+    /// Application and timing mode
+    #[bpaf(argument("MODE"), fallback(Mode::PCA))]
+    mode: Mode,
+
+    #[bpaf(external, fallback(SyncTiming{_sync_timing:(), t_ext:0.024995, t_rtg:0.000010, t_int:0.024995}))]
+    sync_timing: SyncTiming,
+
     /// S1-D1 path enablement and swap order (asap|l2r|r2l|disabled)
     #[bpaf(fallback(PathOpt::L2R))]
     path1: PathOpt,
@@ -83,38 +133,50 @@ async fn main() -> Result<()> {
     let js = jetstream::new(nc);
 
     let sb = Southbound::new(js, &args.nats_prefix);
-    tx_loop(&args, &sb).await?;
+
+    match args.mode {
+        Mode::PCA => tx_loop_pca(&args, &sb).await,
+        Mode::RCS => {
+            let (tx, rx) = mpsc::channel(100);
+            let rx_handle = {
+                let sb = sb.clone();
+                tokio::spawn(async move { rx_loop_rcs(&sb, tx).await })
+            };
+            let tx_result = tx_loop_rcs(&args, &sb, rx).await;
+            rx_handle.abort();
+            tx_result
+        }
+    }?;
 
     Ok(())
 }
 
-async fn tx_loop(args: &Args, sb: &Southbound) -> Result<()> {
+fn make_path(req_id: u32, nodes: &str, opt: PathOpt) -> PathInstructions {
+    let route: Vec<String> = nodes.split('-').map(String::from).collect();
+    let len = route.len();
+    PathInstructions {
+        req_id,
+        route,
+        swap: opt.to_swap(),
+        swap_cutoff: vec![-1; len],
+        m_v: Some(vec![vec![1, 1]; len - 1]),
+        purif: HashMap::new(),
+    }
+}
+
+async fn tx_loop_pca(args: &Args, sb: &Southbound) -> Result<()> {
     for sec in 0..=args.sim_duration {
         println!("Simulation Time: {} / {}", sec, args.sim_duration);
         let t = sec * args.sim_accuracy;
 
         if args.path1 != PathOpt::Disabled && args.path1_i == sec {
-            let path = PathInstructions {
-                req_id: 10,
-                route: "S1-R1-R2-D1".split('-').map(String::from).collect(),
-                swap: args.path1.to_swap(),
-                swap_cutoff: vec![-1, -1, -1, -1],
-                m_v: Some(vec![vec![1, 1], vec![1, 1], vec![1, 1]]),
-                purif: HashMap::new(),
-            };
+            let path = make_path(10, "S1-R1-R2-D1", args.path1);
             println!("    Installing path1");
             sb.install_path(t, 10, &path).await?;
         }
 
         if args.path2 != PathOpt::Disabled && args.path2_i == sec {
-            let path = PathInstructions {
-                req_id: 20,
-                route: "S2-R1-R2-D2".split('-').map(String::from).collect(),
-                swap: args.path2.to_swap(),
-                swap_cutoff: vec![-1, -1, -1, -1],
-                m_v: Some(vec![vec![1, 1], vec![1, 1], vec![1, 1]]),
-                purif: HashMap::new(),
-            };
+            let path = make_path(20, "S2-R1-R2-D2", args.path2);
             println!("    Installing path2");
             sb.install_path(t, 20, &path).await?;
         }
@@ -126,6 +188,116 @@ async fn tx_loop(args: &Args, sb: &Southbound) -> Result<()> {
         sb.update_gate(t).await?;
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
+
+    Ok(())
+}
+
+async fn rx_loop_rcs(sb: &Southbound, link_state_ch: mpsc::Sender<LinkStateMsg>) -> Result<()> {
+    sb.recv_link_states(link_state_ch).await?;
+    Ok(())
+}
+
+#[derive(Debug, Clone)]
+struct TopoLinkState {
+    etgs: HashMap<String, i32>,
+}
+
+impl TopoLinkState {
+    fn new() -> Self {
+        Self {
+            etgs: ["S1-R1", "S2-R1", "R1-R2", "R2-D1", "R2-D2"]
+                .into_iter()
+                .map(|k| (k.to_string(), 0))
+                .collect(),
+        }
+    }
+
+    fn clear(&mut self) {
+        for value in self.etgs.values_mut() {
+            *value = 0;
+        }
+    }
+
+    fn add(&mut self, entry: &LinkStateEntry) {
+        let key = format!("{}-{}", entry.node, entry.neighbor);
+        if let Some(count) = self.etgs.get_mut(&key) {
+            *count += 1
+        }
+    }
+
+    fn try_consume(&mut self, route: &Vec<String>) -> bool {
+        for pair in route.windows(2) {
+            let key = format!("{}-{}", pair[0], pair[1]);
+            match self.etgs.get(&key) {
+                Some(&count) if count > 0 => continue,
+                _ => return false,
+            }
+        }
+
+        for pair in route.windows(2) {
+            let key = format!("{}-{}", pair[0], pair[1]);
+            let value = self.etgs.get_mut(&key).unwrap();
+            *value -= 1;
+        }
+
+        true
+    }
+}
+
+async fn tx_loop_rcs(
+    args: &Args,
+    sb: &Southbound,
+    mut link_state_ch: mpsc::Receiver<LinkStateMsg>,
+) -> Result<()> {
+    let t_ext = sec_to_time_slot(args.sync_timing.t_ext, args.sim_accuracy);
+    let t_rtg = sec_to_time_slot(args.sync_timing.t_rtg, args.sim_accuracy);
+    let t_int = sec_to_time_slot(args.sync_timing.t_int, args.sim_accuracy);
+    let t_slot = t_ext + t_rtg + t_int;
+    let t_stop = sec_to_time_slot(args.sim_duration as f64, args.sim_accuracy) / t_slot * t_slot;
+    let t_offset = t_ext + t_rtg / 2;
+
+    let mut tls = TopoLinkState::new();
+    let mut t = t_offset;
+    while t < t_stop {
+        let sec = t / args.sim_accuracy;
+        let t_ext_lbound = t - t_offset;
+
+        println!("Simulation Time: {} / {}", t, t_stop);
+        sb.update_gate(t).await?;
+        tokio::time::sleep(Duration::from_millis(1000)).await;
+
+        tls.clear();
+        while let Ok(msg) = link_state_ch.try_recv() {
+            if msg.t < t_ext_lbound {
+                continue;
+            }
+            for entry in &msg.ls {
+                tls.add(entry);
+            }
+        }
+        println!("    {:?}", tls);
+
+        if args.path1 != PathOpt::Disabled && args.path1_i <= sec {
+            let path = make_path(10, "S1-R1-R2-D1", args.path1);
+            if tls.try_consume(&path.route) {
+                println!("    Installing path1");
+                sb.install_path(t, 10, &path).await?;
+            }
+        }
+
+        if args.path2 != PathOpt::Disabled && args.path2_i <= sec {
+            let path = make_path(20, "S2-R1-R2-D2", args.path2);
+            if tls.try_consume(&path.route) {
+                println!("    Installing path2");
+                sb.install_path(t, 20, &path).await?;
+            }
+        }
+
+        t += t_slot;
+    }
+
+    sb.stop(t_stop).await?;
+    sb.update_gate(t_stop).await?;
 
     Ok(())
 }

--- a/examples/extctrl/src/main.rs
+++ b/examples/extctrl/src/main.rs
@@ -57,20 +57,20 @@ struct Args {
     #[bpaf(long("sim_duration"), argument("DURATION"), fallback(60))]
     sim_duration: u64,
 
-    /// S1-D1 path enablement and swap order
+    /// S1-D1 path enablement and swap order (asap|l2r|r2l|disabled)
     #[bpaf(fallback(PathOpt::L2R))]
     path1: PathOpt,
 
     /// S1-D1 path install time in seconds
-    #[bpaf(long("path1_i"), fallback(0))]
+    #[bpaf(long("path1_i"), argument("SEC"), fallback(0))]
     path1_i: u64,
 
-    /// S2-D2 path enablement and swap order
+    /// S2-D2 path enablement and swap order (asap|l2r|r2l|disabled)
     #[bpaf(fallback(PathOpt::Disabled))]
     path2: PathOpt,
 
     /// S2-D2 path install time in seconds
-    #[bpaf(long("path2_i"), fallback(0))]
+    #[bpaf(long("path2_i"), argument("SEC"), fallback(0))]
     path2_i: u64,
 }
 

--- a/examples/extctrl/src/main.rs
+++ b/examples/extctrl/src/main.rs
@@ -2,9 +2,14 @@ use anyhow::Result;
 use async_nats::{self, jetstream};
 use bpaf::Bpaf;
 use mqns_example_extctrl::{
-    LinkStateEntry, LinkStateMsg, PathInstructions, Southbound, sec_to_time_slot,
+    LinkStateEntry, LinkStateMsg, MultiplexingVectorElem, PathInstructions, Southbound,
+    sec_to_time_slot,
 };
-use std::{collections::HashMap, env, time::Duration};
+use std::{
+    collections::{HashMap, HashSet},
+    env,
+    time::Duration,
+};
 use tokio::sync::mpsc;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Bpaf)]
@@ -159,9 +164,19 @@ fn make_path(req_id: u32, nodes: &str, opt: PathOpt) -> PathInstructions {
         route,
         swap: opt.to_swap(),
         swap_cutoff: vec![-1; len],
-        m_v: Some(vec![vec![1, 1]; len - 1]),
+        m_v: Some(vec![MultiplexingVectorElem::Count(1, 1); len - 1]),
         purif: HashMap::new(),
     }
+}
+
+fn replace_path_mv(mut path: PathInstructions, qubits: Vec<String>) -> PathInstructions {
+    path.m_v = Some(
+        qubits
+            .iter()
+            .map(|key| MultiplexingVectorElem::Key(key.clone()))
+            .collect(),
+    );
+    path
 }
 
 async fn tx_loop_pca(args: &Args, sb: &Southbound) -> Result<()> {
@@ -199,7 +214,7 @@ async fn rx_loop_rcs(sb: &Southbound, link_state_ch: mpsc::Sender<LinkStateMsg>)
 
 #[derive(Debug, Clone)]
 struct TopoLinkState {
-    etgs: HashMap<String, i32>,
+    etgs: HashMap<String, HashSet<String>>,
 }
 
 impl TopoLinkState {
@@ -207,40 +222,45 @@ impl TopoLinkState {
         Self {
             etgs: ["S1-R1", "S2-R1", "R1-R2", "R2-D1", "R2-D2"]
                 .into_iter()
-                .map(|k| (k.to_string(), 0))
+                .map(|link| (link.to_string(), HashSet::new()))
                 .collect(),
         }
     }
 
     fn clear(&mut self) {
-        for value in self.etgs.values_mut() {
-            *value = 0;
+        for qubits in self.etgs.values_mut() {
+            qubits.clear();
         }
     }
 
     fn add(&mut self, entry: &LinkStateEntry) {
-        let key = format!("{}-{}", entry.node, entry.neighbor);
-        if let Some(count) = self.etgs.get_mut(&key) {
-            *count += 1
+        let link = format!("{}-{}", entry.node, entry.neighbor);
+        if let Some(qubits) = self.etgs.get_mut(&link) {
+            qubits.insert(entry.qubit.clone());
         }
     }
 
-    fn try_consume(&mut self, route: &Vec<String>) -> bool {
+    fn try_consume(&mut self, route: &Vec<String>) -> Option<Vec<String>> {
+        let mut path = Vec::with_capacity(route.len() - 1);
+
         for pair in route.windows(2) {
-            let key = format!("{}-{}", pair[0], pair[1]);
-            match self.etgs.get(&key) {
-                Some(&count) if count > 0 => continue,
-                _ => return false,
+            let link = format!("{}-{}", pair[0], pair[1]);
+            if let Some(qubits) = self.etgs.get(&link) {
+                if let Some(qubit) = qubits.iter().next() {
+                    path.push(qubit.clone());
+                    continue;
+                }
             }
+            return None;
         }
 
-        for pair in route.windows(2) {
-            let key = format!("{}-{}", pair[0], pair[1]);
-            let value = self.etgs.get_mut(&key).unwrap();
-            *value -= 1;
+        for (i, pair) in route.windows(2).enumerate() {
+            let link = format!("{}-{}", pair[0], pair[1]);
+            let qubits = self.etgs.get_mut(&link).unwrap();
+            qubits.remove(&path[i]);
         }
 
-        true
+        Some(path)
     }
 }
 
@@ -279,16 +299,18 @@ async fn tx_loop_rcs(
 
         if args.path1 != PathOpt::Disabled && args.path1_i <= sec {
             let path = make_path(10, "S1-R1-R2-D1", args.path1);
-            if tls.try_consume(&path.route) {
-                println!("    Installing path1");
+            if let Some(consumed) = tls.try_consume(&path.route) {
+                let path = replace_path_mv(path, consumed);
+                println!("    Installing path1: {:?}", path.m_v);
                 sb.install_path(t, 10, &path).await?;
             }
         }
 
         if args.path2 != PathOpt::Disabled && args.path2_i <= sec {
             let path = make_path(20, "S2-R1-R2-D2", args.path2);
-            if tls.try_consume(&path.route) {
-                println!("    Installing path2");
+            if let Some(consumed) = tls.try_consume(&path.route) {
+                let path = replace_path_mv(path, consumed);
+                println!("    Installing path2: {:?}", path.m_v);
                 sb.install_path(t, 20, &path).await?;
             }
         }

--- a/examples/linear_attempts.py
+++ b/examples/linear_attempts.py
@@ -86,7 +86,7 @@ def run_simulation(seed: int, sim_duration: float, L: list[float], M: int, link_
             t_cohere=0.1,
         )
         .proactive_centralized()
-        .path("S-D", swap="disabled")
+        .request("S-D", swap="disabled")
         .make_network()
     )
 

--- a/examples/multi_request_single_path.py
+++ b/examples/multi_request_single_path.py
@@ -52,8 +52,8 @@ def run_simulation(seed: int, args: Args, mux: MuxScheme, t_cohere: float):
             t_cohere=t_cohere,
         )
         .proactive_centralized(mux=mux)
-        .path("S1-D1")
-        .path("S2-D2")
+        .request("S1-D1")
+        .request("S2-D2")
         .make_network()
     )
 

--- a/examples/multiplexing.py
+++ b/examples/multiplexing.py
@@ -181,11 +181,11 @@ def build_network(mux: MuxScheme, active_flows: Sequence[FlowDef]):
         # Explicit static paths with per-hop MVs
         active_flows_set = set(f.label for f in active_flows)
         for flow in active_flows:
-            b.path(RoutingPathStatic(flow.route, m_v=_mv_for_flow(flow.label, flow.route, active_flows_set), swap="asap"))
+            b.request(RoutingPathStatic(flow.route, m_v=_mv_for_flow(flow.label, flow.route, active_flows_set), swap="asap"))
     else:
         # Statistical: best-effort usage; no pre-split
         for flow in active_flows:
-            b.path(RoutingPathStatic(flow.route, m_v=QubitAllocationType.DISABLED, swap="asap"))
+            b.request(RoutingPathStatic(flow.route, m_v=QubitAllocationType.DISABLED, swap="asap"))
 
     return b.make_network()
 

--- a/examples/single_request_multipath.py
+++ b/examples/single_request_multipath.py
@@ -47,7 +47,7 @@ def run_simulation(seed: int, args: Args):
             t_cohere=0.01,
         )
         .proactive_centralized()
-        .path("S-D", swap="r2l")
+        .request("S-D", swap="r2l")
         .make_network()
     )
 

--- a/examples/swapping_policies_6_nodes.py
+++ b/examples/swapping_policies_6_nodes.py
@@ -63,7 +63,7 @@ def run_simulation(
             channel_capacity=ch_capacities,
         )
         .proactive_centralized()
-        .path("S-D", swap=swapping_order)
+        .request("S-D", swap=swapping_order)
         .make_network()
     )
 

--- a/examples/template_linear.py
+++ b/examples/template_linear.py
@@ -181,7 +181,7 @@ def run_simulation(
             p_swap=P_SWAP,
         )
         .proactive_centralized()
-        .path("S-D", swap=swap)
+        .request("S-D", swap=swap)
         .make_network()
     )
 

--- a/examples/template_routing.py
+++ b/examples/template_routing.py
@@ -282,7 +282,7 @@ def build_network(route_algo: Any, t_cohere: float) -> QuantumNetwork:
     b.proactive_centralized(mux=SC.mux)
 
     for flow in SC.install_paths:
-        b.path(flow)
+        b.request(flow)
 
     return b.make_network()
 

--- a/examples/vora_evaluation.py
+++ b/examples/vora_evaluation.py
@@ -125,7 +125,7 @@ class ParameterSet:
                 channel_capacity=self.qchannel_capacity,
             )
             .proactive_centralized()
-            .path("S-D", swap=swap)
+            .request("S-D", swap=swap)
             .make_network()
         )
 

--- a/mqns/network/builder.py
+++ b/mqns/network/builder.py
@@ -26,7 +26,7 @@ from mqns.network.fw import (
     RoutingPathSingle,
     SwapSequenceInput,
 )
-from mqns.network.network import QuantumNetwork, TimingMode, TimingModeAsync
+from mqns.network.network import QuantumNetwork, TimingMode, TimingModeAsync, TimingModeSync
 from mqns.network.proactive import ProactiveForwarder, ProactiveRoutingController
 from mqns.network.protocol.classicbridge import ClassicBridge
 from mqns.network.protocol.link_layer import LinkLayer
@@ -68,6 +68,11 @@ def tap_configure(tap: Tap) -> None:
     """
     When called from ``Tap.configure()`` function, define command line arguments for supported literal types.
 
+    Recognized keys:
+
+    * ``mode``
+    * ``sync_timing``
+
     Recognized types:
 
     * ``EprTypeLiteral``
@@ -76,7 +81,24 @@ def tap_configure(tap: Tap) -> None:
     * ``TimeDecayInput``
     """
     for key, typ in tap._annotations.items():
-        if typ is EprTypeLiteral:
+        if key == "mode":
+            tap.add_argument(
+                f"--{key}",
+                help=f"(default={getattr(tap, key)}) choose mode: [P]roactive/[R]eactive forwarding, "
+                "[C]entralized/[D]istributed control, [A]sync/[S]ync timing",
+            )
+        elif key == "sync_timing":
+            dflt = getattr(tap, key, [])
+            dflt_desc = f"default={dflt}" if dflt else "default: derive from t_cohere"
+            tap.add_argument(
+                f"--{key}",
+                type=float,
+                nargs=3,
+                default=dflt,
+                metavar=("t_ext", "t_rtg", "t_int"),
+                help=f"(3*float, {dflt_desc}) SYNC timing mode phase durations in seconds",
+            )
+        elif typ is EprTypeLiteral:
             tap.add_argument(f"--{key}", type=str, default="W", choices=EPR_TYPE_MAP.keys())
         elif typ is LinkArchLiteral:
             tap.add_argument(f"--{key}", type=str, default="DIM-BK-SeQUeNCe", choices=LINK_ARCH_MAP.keys())
@@ -115,6 +137,14 @@ class TopoCommonArgs(TypedDict, total=False):
     """Entanglement source frequency, defaults to ``1_000_000``."""
     p_swap: float
     """Probability of successful entanglement swapping in forwarder, defaults to ``0.5``."""
+
+
+class AppsCommonArgs(TypedDict, total=False):
+    timing: TimingMode | Sequence[float] | None
+    """
+    Network timing mode, defaults to ASYNC.
+    If specified as three floats, construct ``TimingModeSync`` with these durations.
+    """
 
 
 def _broadcast[T](name: str, input: T | Sequence[T], n: int) -> Sequence[T]:
@@ -159,7 +189,6 @@ class NetworkBuilder:
         self,
         *,
         route: RouteAlgorithm[QNode, QuantumChannel] = DijkstraRouteAlgorithm(),
-        timing: TimingMode = TimingModeAsync(),
         epr_type: type[Entanglement] | EprTypeLiteral = "W",
     ):
         """
@@ -167,12 +196,10 @@ class NetworkBuilder:
 
         Args:
             route: Route algorithm, defaults to Dijkstra.
-            timing: Network timing mode, defaults to ASYNC.
             epr_type: Network-wide EPR model, defaults to Werner state.
         """
 
         self.route = route
-        self.timing = timing
         self.epr_type = epr_type if isinstance(epr_type, type) else EPR_TYPE_MAP[epr_type]
 
         self.qnodes: list[TopoQNode] = []
@@ -373,6 +400,17 @@ class NetworkBuilder:
         if len(self.qnode_apps) + len(self.controller_apps) > 0:
             raise TypeError("applications already installed")
 
+    def _parse_apps_args(self, d: AppsCommonArgs) -> None:
+        timing = d.get("timing")
+        if isinstance(timing, TimingMode):
+            self.timing = timing
+        elif timing is None:
+            self.timing = TimingModeAsync()
+        else:
+            if len(timing) == 0:
+                timing = (self.t_cohere / 2 - CTRL_DELAY, 2 * CTRL_DELAY, self.t_cohere / 2 - CTRL_DELAY)
+            self.timing = TimingModeSync(durations=timing)
+
     def _add_link_layer(self):
         self.qnode_apps.append(
             LinkLayer(
@@ -388,6 +426,7 @@ class NetworkBuilder:
         self,
         *,
         mux: MuxScheme | None = None,
+        **kwargs: Unpack[AppsCommonArgs],
     ) -> Self:
         """
         Choose proactive forwarding with centralized control.
@@ -396,6 +435,7 @@ class NetworkBuilder:
             mux: Multiplexing scheme, default is buffer-space.
         """
         self._assert_can_add_apps()
+        self._parse_apps_args(kwargs)
 
         if mux is None or isinstance(mux, MuxSchemeBufferSpace):
             self.qubit_allocation = QubitAllocationType.FOLLOW_QCHANNEL
@@ -425,6 +465,7 @@ class NetworkBuilder:
         *,
         mux: MuxScheme | None = None,
         swap: SwapSequenceInput = "asap",
+        **kwargs: Unpack[AppsCommonArgs],
     ) -> Self:
         """
         Choose reactive forwarding with centralized control.
@@ -439,6 +480,7 @@ class NetworkBuilder:
             swap: SwapSequence for S-R-D route.
         """
         self._assert_can_add_apps()
+        self._parse_apps_args(kwargs)
 
         self._add_link_layer()
         self.qnode_apps.append(

--- a/mqns/network/builder.py
+++ b/mqns/network/builder.py
@@ -412,7 +412,7 @@ class NetworkBuilder:
             self.timing = TimingModeAsync()
         else:
             if len(timing) == 0:
-                timing = (self.t_cohere / 2 - CTRL_DELAY, 2 * CTRL_DELAY, self.t_cohere / 2 - CTRL_DELAY)
+                timing = (self.t_cohere / 2 - 2 * CTRL_DELAY, 4 * CTRL_DELAY, self.t_cohere / 2 - 2 * CTRL_DELAY)
             self.timing = TimingModeSync(durations=timing)
 
     def _add_link_layer(self):

--- a/mqns/network/builder.py
+++ b/mqns/network/builder.py
@@ -472,14 +472,11 @@ class NetworkBuilder:
         """
         Choose reactive forwarding with centralized control.
 
-        Note:
-            This feature is in early stage.
-            Currently it only works with S-R-D topology and has one route.
-            ``.request()`` method cannot be used.
-
         Args:
             mux: Multiplexing scheme, default is buffer-space.
             swap: SwapPolicy for routes.
+
+        ``.request()`` method only accepts src-dst nodes, but does not support ``RoutingPath``.
         """
         self._assert_can_add_apps()
         self._parse_apps_args(kwargs)
@@ -537,6 +534,13 @@ class NetworkBuilder:
     @_add_request.register
     def _(self, ctrl: ProactiveRoutingController, arg1: RoutingPath | NodePair, d: RoutingPathInitArgs) -> None:
         ctrl.paths.append(self._to_path(arg1, d))
+
+    @_add_request.register
+    def _(self, ctrl: ReactiveRoutingController, arg1: RoutingPath | NodePair, d: RoutingPathInitArgs) -> None:
+        _ = d
+        if isinstance(arg1, RoutingPath):
+            raise TypeError(f"{type(ctrl)} does not support .request(RoutingPath)")
+        self.requests.append(_split_node_pair(arg1))
 
     @overload
     def request(self, src_dst: NodePair, /, **kwargs: Unpack[RoutingPathInitArgs]) -> Self:
@@ -603,6 +607,8 @@ class NetworkBuilder:
             timing=self.timing,
             epr_type=self.epr_type,
         )
+        for src, dst in self.requests:
+            net.add_request(net.get_node(src), net.get_node(dst))
 
         if connect_controller and topo.controller:
             topo.connect_controller(net.nodes, delay=CTRL_DELAY)

--- a/mqns/network/builder.py
+++ b/mqns/network/builder.py
@@ -1,3 +1,4 @@
+import functools
 from collections.abc import Mapping, Sequence
 from typing import Literal, Self, TypedDict, Unpack, cast, overload
 
@@ -24,7 +25,7 @@ from mqns.network.fw import (
     RoutingPathInitArgs,
     RoutingPathMulti,
     RoutingPathSingle,
-    SwapSequenceInput,
+    SwapPolicy,
 )
 from mqns.network.network import QuantumNetwork, TimingMode, TimingModeAsync, TimingModeSync
 from mqns.network.proactive import ProactiveForwarder, ProactiveRoutingController
@@ -181,7 +182,7 @@ class NetworkBuilder:
 
     1. Call one ``.topo*()`` method to define topology shape.
     2. Call one ``.{proactive|reactive}_{centralized|distributed}()`` method to choose applications.
-    3. Call ``.path()`` method one or more times to install routes.
+    3. Call ``.request()`` method to define end-to-end requests or routing paths.
     4. Call ``.make_network()`` method to construct ``QuantumNetwork`` ready for simulation.
     """
 
@@ -206,6 +207,9 @@ class NetworkBuilder:
         self.qnode_apps: list[Application] = []
         self.qchannels: list[TopoQChannel] = []
         self.controller_apps: list[Application] = []
+
+        self.qubit_allocation = QubitAllocationType.DISABLED
+        self.requests: list[tuple[str, str]] = []
 
     def _parse_topo_args(self, d: TopoCommonArgs) -> None:
         self.t_cohere = d.get("t_cohere", 0.02)
@@ -441,8 +445,6 @@ class NetworkBuilder:
             self.qubit_allocation = QubitAllocationType.FOLLOW_QCHANNEL
         elif isinstance(self.route, YenRouteAlgorithm):
             raise TypeError("YenRouteAlgorithm is only compatible with MuxSchemeBufferSpace")
-        else:
-            self.qubit_allocation = QubitAllocationType.DISABLED
 
         self._add_link_layer()
         self.qnode_apps.append(
@@ -464,7 +466,7 @@ class NetworkBuilder:
         self,
         *,
         mux: MuxScheme | None = None,
-        swap: SwapSequenceInput = "asap",
+        swap: SwapPolicy = "asap",
         **kwargs: Unpack[AppsCommonArgs],
     ) -> Self:
         """
@@ -473,11 +475,11 @@ class NetworkBuilder:
         Note:
             This feature is in early stage.
             Currently it only works with S-R-D topology and has one route.
-            ``.path()`` method cannot be used.
+            ``.request()`` method cannot be used.
 
         Args:
             mux: Multiplexing scheme, default is buffer-space.
-            swap: SwapSequence for S-R-D route.
+            swap: SwapPolicy for routes.
         """
         self._assert_can_add_apps()
         self._parse_apps_args(kwargs)
@@ -513,44 +515,50 @@ class NetworkBuilder:
         The internal controller application is deleted and replaced with ``ClassicBridge``, which allows
         the controller logic to be implemented in an external program connected over NATS.
 
-        ``.path()`` method cannot be used.
-        Instead, routing paths should be defined in the external controller.
+        ``.request()`` method cannot be used.
+        Instead, requests or routing paths should be defined in the external controller.
         """
         self.controller_apps.clear()
         self.controller_apps.append(ClassicBridge(nats_prefix=nats_prefix))
         return self
 
-    def _assert_can_add_paths(self) -> None:
-        if len(self.controller_apps) == 0:
-            raise TypeError("must install applications first")
+    def _to_path(self, arg1: RoutingPath | NodePair, d: RoutingPathInitArgs) -> RoutingPath:
+        if isinstance(arg1, RoutingPath):
+            return arg1
+        if isinstance(self.route, YenRouteAlgorithm):
+            return RoutingPathMulti(*_split_node_pair(arg1), **d)
+        return RoutingPathSingle(*_split_node_pair(arg1), **d, qubit_allocation=self.qubit_allocation)
+
+    @functools.singledispatchmethod
+    def _add_request(self, ctrl: Application, arg1: RoutingPath | NodePair, d: RoutingPathInitArgs) -> None:
+        _ = arg1, d
+        raise NotImplementedError(f"{type(ctrl)} does not support .request() method")
+
+    @_add_request.register
+    def _(self, ctrl: ProactiveRoutingController, arg1: RoutingPath | NodePair, d: RoutingPathInitArgs) -> None:
+        ctrl.paths.append(self._to_path(arg1, d))
 
     @overload
-    def path(self, rp: RoutingPath, /) -> Self: ...
+    def request(self, src_dst: NodePair, /, **kwargs: Unpack[RoutingPathInitArgs]) -> Self:
+        """
+        Define a request that may use one or more paths determined by routing algorithm.
+        """
 
     @overload
-    def path(self, src_dst: NodePair, /, **kwargs: Unpack[RoutingPathInitArgs]) -> Self: ...
+    def request(self, rp: RoutingPath, /) -> Self:
+        """
+        Define a request that is constrained to a specific path.
+        """
 
-    def path(
+    def request(
         self,
         arg1: RoutingPath | NodePair,
         /,
         **kwargs: Unpack[RoutingPathInitArgs],
     ) -> Self:
-        """
-        Add a routing path.
-        """
-        self._assert_can_add_paths()
-        ctrl = self.controller_apps[0]
-        if not isinstance(ctrl, ProactiveRoutingController):
-            raise NotImplementedError
-
-        if isinstance(arg1, RoutingPath):
-            path = arg1
-        elif isinstance(self.route, YenRouteAlgorithm):
-            path = RoutingPathMulti(*_split_node_pair(arg1), **kwargs)
-        else:
-            path = RoutingPathSingle(*_split_node_pair(arg1), **kwargs, qubit_allocation=self.qubit_allocation)
-        ctrl.paths.append(path)
+        if len(self.controller_apps) == 0:
+            raise TypeError("must install controller application first")
+        self._add_request(self.controller_apps[0], arg1, kwargs)
         return self
 
     def make_topo(self) -> Topology:

--- a/mqns/network/fw/forwarder.py
+++ b/mqns/network/fw/forwarder.py
@@ -196,22 +196,23 @@ class Forwarder(ForwarderClassicMixin, Application[QNode]):
         """
         Handle timing phase signals, only used in SYNC timing mode.
 
-        Upon entering EXTERNAL phase:
-
-        1. Clear ``remote_swapped_eprs``.
-           All memory qubits are being discarded by LinkLayer, so that these have become useless.
-
         Upon entering INTERNAL phase:
 
         1. Start processing elementary entanglements that arrived during EXTERNAL phase.
+
+        Upon exiting INTERNAL phase:
+
+        1. Clear ``remote_swapped_eprs``.
+           All memory qubits are being discarded by LinkLayer, so that these have become useless.
         """
-        if event.phase is TimingPhase.EXTERNAL:
-            self.swap.remote_swapped_eprs.clear()
-        elif event.phase is TimingPhase.INTERNAL:
-            log.debug(f"{self.node}: there are {len(self.waiting_etg)} etg qubits to process")
-            for etg_event in self.waiting_etg:
-                self.qubit_is_entangled(etg_event)
-            self.waiting_etg.clear()
+        match event.action:
+            case TimingPhase.INTERNAL, True:
+                log.debug(f"{self.node}: there are {len(self.waiting_etg)} etg qubits to process")
+                for etg_event in self.waiting_etg:
+                    self.qubit_is_entangled(etg_event)
+                self.waiting_etg.clear()
+            case TimingPhase.INTERNAL, False:
+                self.swap.remote_swapped_eprs.clear()
 
     @fw_control_cmd_handler("INSTALL_PATH")
     def handle_install_path(self, msg: InstallPathMsg):

--- a/mqns/network/fw/message.py
+++ b/mqns/network/fw/message.py
@@ -1,7 +1,11 @@
+from collections.abc import Sequence
 from typing import Literal, NotRequired, TypedDict
 
-type SwapSequence = list[int]
-type MultiplexingVector = list[tuple[int, int]]
+type SwapSequence = Sequence[int]
+"""Swap sequence -- nonnegative integers to control swapping order."""
+
+type MultiplexingVector = Sequence[tuple[int, int] | str]
+"""Multiplexing vector -- guides memory allocation in buffer-space multiplexing scheme."""
 
 
 class PathInstructions(TypedDict):
@@ -49,7 +53,7 @@ class PathInstructions(TypedDict):
 
     m_v: NotRequired[MultiplexingVector]
     """
-    Multiplexing vector, used in buffer-space multiplexing scheme only.
+    Multiplexing vector -- guides memory allocation in buffer-space multiplexing scheme.
 
     This list shall have one element per qchannel, i.e. one less than ``route``.
     Each element is a pair of nonnegative integers, corresponding to left and right qchannels.
@@ -63,6 +67,9 @@ class PathInstructions(TypedDict):
     * S should allocate 4 qubits on S-R channel.
     * R should allocate 2 qubits on S-R channel and 3 qubits on R-D channel.
     * D should allocate all qubits assigned to R-D channel.
+
+    In reactive forwarding, each element can also be a qubit reservation key.
+    Only the qubit with that specific reservation key would be allocated.
     """
 
     purif: dict[str, int]

--- a/mqns/network/fw/mux_buffer_space.py
+++ b/mqns/network/fw/mux_buffer_space.py
@@ -83,11 +83,14 @@ class MuxSchemeBufferSpace(MuxSchemeFibBase):
         assert "m_v" in instructions
         mv = instructions["m_v"]
         mv_offset, ch_side = (-1, 1) if direction == PathDirection.L else (0, 0)
-        mv_element = mv[fib_entry.own_idx + mv_offset]
+        mv_index = fib_entry.own_idx + mv_offset
+        mv_element = mv[mv_index]
 
         if isinstance(mv_element, str):
             # allocate a specific memory qubit identified with reservation key (only used in reactive forwarding)
-            qubit, _ = next(self.memory.find(lambda q, _: q.active == mv_element))
+            qubit, _ = next(self.memory.find(lambda q, _: q.active == mv_element), (None, None))
+            if qubit is None:
+                raise ValueError(f"m_v[{mv_index}] refers to non-existent qubit {mv_element}")
             qubit.path_id, qubit.path_direction = fib_entry.path_id, direction
             addrs = [qubit.addr]
         else:

--- a/mqns/network/fw/mux_buffer_space.py
+++ b/mqns/network/fw/mux_buffer_space.py
@@ -81,16 +81,24 @@ class MuxSchemeBufferSpace(MuxSchemeFibBase):
     ) -> None:
         _ = neighbor
         assert "m_v" in instructions
-        m_v = instructions["m_v"]
-        m_v_offset, ch_side = (-1, 1) if direction == PathDirection.L else (0, 0)
+        mv = instructions["m_v"]
+        mv_offset, ch_side = (-1, 1) if direction == PathDirection.L else (0, 0)
+        mv_element = mv[fib_entry.own_idx + mv_offset]
 
-        n_qubits = m_v[fib_entry.own_idx + m_v_offset][ch_side]
-        addrs = self.memory.allocate(
-            qchannel,
-            fib_entry.path_id,
-            direction,
-            n="all" if n_qubits == 0 else n_qubits,
-        )
+        if isinstance(mv_element, str):
+            # allocate a specific memory qubit identified with reservation key (only used in reactive forwarding)
+            qubit, _ = next(self.memory.find(lambda q, _: q.active == mv_element))
+            qubit.path_id, qubit.path_direction = fib_entry.path_id, direction
+            addrs = [qubit.addr]
+        else:
+            # allocate memory qubit(s) assigned to the channel (typically used in proactive forwarding)
+            n_qubits = mv_element[ch_side]
+            addrs = self.memory.allocate(
+                qchannel,
+                fib_entry.path_id,
+                direction,
+                n="all" if n_qubits == 0 else n_qubits,
+            )
         log.debug(f"{self.node}: allocated {direction} qubits: {addrs}")
 
     @override

--- a/mqns/network/fw/mux_dynamic_epr.py
+++ b/mqns/network/fw/mux_dynamic_epr.py
@@ -89,8 +89,8 @@ class MuxSchemeDynamicEpr(MuxSchemeFibBase, MuxSchemeDynamicBase):
             fib_entry = selected_path if type(selected_path) is FibEntry else self.fib.get(selected_path)
             epr.tmp_path_ids = frozenset([fib_entry.path_id])
         else:
-            assert len(epr.tmp_path_ids) == 1
-            fib_entry = self.fib.get(next(epr.tmp_path_ids.__iter__()))
+            (path_id,) = epr.tmp_path_ids
+            fib_entry = self.fib.get(path_id)
 
         log.debug(f"{self.node}: qubit {qubit} has selected path_id {fib_entry.path_id}")
 

--- a/mqns/network/fw/routing.py
+++ b/mqns/network/fw/routing.py
@@ -100,7 +100,7 @@ class RoutingPath(ABC):
             They will be installed into the nodes.
         """
 
-    def _query_routes(self, net: QuantumNetwork) -> Iterator[list[str]]:
+    def _query_routes(self, net: QuantumNetwork) -> list[list[str]]:
         """
         Query routes from source node to destination node.
         """
@@ -109,8 +109,7 @@ class RoutingPath(ABC):
         route_result = net.query_route(src, dst)
         if len(route_result) == 0:
             raise RuntimeError(f"ROUTING: No route from {src} to {dst}")
-        for _, _, route_nodes in route_result:
-            yield [node.name for node in route_nodes]
+        return [[node.name for node in route_nodes] for _, _, route_nodes in route_result]
 
     def _make_path_instructions(
         self,
@@ -176,7 +175,7 @@ class RoutingPathSingle(RoutingPath):
 
     @override
     def compute_paths(self, net: QuantumNetwork) -> Iterator[PathInstructions]:
-        route = next(self._query_routes(net))
+        route = self._query_routes(net)[0]
         log.debug(f"ROUTING: Computed path #{self.path_id}: {route}")
         yield self._make_path_instructions(net, route, _compute_mv(net, route, self.qubit_allocation))
 
@@ -202,7 +201,7 @@ class RoutingPathMulti(RoutingPath):
     @override
     def compute_paths(self, net: QuantumNetwork) -> Iterator[PathInstructions]:
         # Get all shortest paths (M ≥ 1)
-        routes = list(self._query_routes(net))
+        routes = self._query_routes(net)
 
         # Count usage of each quantum channel across all paths
         qchannel_use_count = defaultdict[str, int](lambda: 0)

--- a/mqns/network/fw/routing.py
+++ b/mqns/network/fw/routing.py
@@ -46,7 +46,7 @@ class RoutingPathInitArgs(TypedDict, total=False):
     path_id: int
     """Path identifier for the first path, defaults to auto-assignment."""
     swap: SwapSequenceInput
-    """Predefined or explicitly specified swapping order, defaults to ASAP."""
+    """Swap sequence or swap policy, defaults to ASAP."""
     swap_cutoff: list[float] | None
     """Swap cut-off times in seconds."""
     purif: dict[str, int] | None

--- a/mqns/network/fw/routing.py
+++ b/mqns/network/fw/routing.py
@@ -55,7 +55,7 @@ class RoutingPathInitArgs(TypedDict, total=False):
 
 class RoutingPath(ABC):
     """
-    Compute routing path(s) for installing through ProactiveRoutingController.
+    Compute routing path(s) for installing through RoutingController.
     """
 
     def __init__(self, src: str, dst: str, **kwargs: Unpack[RoutingPathInitArgs]):
@@ -138,7 +138,7 @@ class RoutingPath(ABC):
 
 class RoutingPathStatic(RoutingPath):
     """
-    Define a static routing path for installing through ProactiveRoutingController.
+    Define a static routing path for installing through RoutingController.
     """
 
     def __init__(
@@ -160,7 +160,7 @@ class RoutingPathStatic(RoutingPath):
 
 class RoutingPathSingle(RoutingPath):
     """
-    Compute a single shortest path for installing through ProactiveRoutingController.
+    Compute a single shortest path for installing through RoutingController.
     """
 
     def __init__(
@@ -183,7 +183,7 @@ class RoutingPathSingle(RoutingPath):
 
 class RoutingPathMulti(RoutingPath):
     """
-    Compute multiple shortest paths for installing through ProactiveRoutingController.
+    Compute multiple shortest paths for installing through RoutingController.
 
     This should be used with YenRouteAlgorithm in the QuantumNetwork.
     The number of paths for each request is determined by the routing algorithm.

--- a/mqns/network/fw/swap_sequence.py
+++ b/mqns/network/fw/swap_sequence.py
@@ -17,11 +17,11 @@ Swap policies.
 type SwapSequenceInput = SwapSequence | SwapPolicy
 
 
-def _l2r(n: int) -> SwapSequence:
+def _l2r(n: int) -> list[int]:
     return [n] + list(range(n + 1))
 
 
-def _baln(n: int) -> SwapSequence:
+def _baln(n: int) -> list[int]:
     if n == 0:
         return [0, 0]
     so = [0] * (n + 1)

--- a/mqns/network/network/__init__.py
+++ b/mqns/network/network/__init__.py
@@ -1,10 +1,11 @@
 from mqns.network.network.network import QuantumNetwork
-from mqns.network.network.request import Request
+from mqns.network.network.request import Request, RequestAttr
 from mqns.network.network.timing import TimingMode, TimingModeAsync, TimingModeSync, TimingPhase, TimingPhaseEvent
 
 __all__ = [
     "QuantumNetwork",
     "Request",
+    "RequestAttr",
     "TimingMode",
     "TimingModeAsync",
     "TimingModeSync",

--- a/mqns/network/network/network.py
+++ b/mqns/network/network/network.py
@@ -32,7 +32,7 @@ from mqns.entity.cchannel import ClassicChannel
 from mqns.entity.node import Controller, Node, QNode
 from mqns.entity.qchannel import QuantumChannel
 from mqns.models.epr import Entanglement, WernerStateEntanglement
-from mqns.network.network.request import Request
+from mqns.network.network.request import Request, RequestAttr
 from mqns.network.network.timing import TimingMode, TimingModeAsync
 from mqns.network.route import DijkstraRouteAlgorithm, RouteAlgorithm, RouteQueryResult
 from mqns.network.topology import ClassicTopology, Topology
@@ -151,9 +151,10 @@ class QuantumNetwork:
         if self.controller:
             self.all_nodes.append(self.controller)
 
+        self.timing.install(self)
+
         for node in self.all_nodes:
             node.install(simulator)
-        self.timing.install(self)
 
     def add_node(self, node: QNode):
         """
@@ -263,26 +264,20 @@ class QuantumNetwork:
             src: the source node
             dest: the destination node
 
-        Returns:
-            A list of route paths. The result should be sorted by the priority.
-            The element is a tuple containing: metric, the next-hop and the whole path.
-
+        Returns: list of route paths, sorted by priority.
         """
         return self.route.query(src, dest)
 
-    def add_request(self, src: QNode, dst: QNode, attr: dict = {}):
+    def add_request(self, src: QNode, dst: QNode, attr: RequestAttr | None = None):
         """
-        Add a request (src, dst) pair to the network.
-
-        The request is placed in ``self.requests`` list.
-        The scenario must manually pass these requests to relevant applications (e.g. ProactiveRoutingController).
+        Add a request (src, dst) pair to the network, placed in ``self.requests`` list.
 
         Args:
-            src: the source node
-            dst: the destination node
-            attr: other attributions
+            src: Source node.
+            dst: Destination node.
+            attr: Other attributes.
         """
-        req = Request(src, dst, attr)
+        req = Request(src, dst, **(attr or {}))
         self.requests.append(req)
 
     def random_requests(
@@ -293,26 +288,22 @@ class QuantumNetwork:
         allow_overlay=False,
         min_hops=1,
         max_hops=10,
-        attr: dict | None = None,
+        attr: RequestAttr | None = None,
         forbid_endpoint_internal=True,  # reject endpoint-vs-internal conflicts
     ):
         """
-        Generate random (src, dst) pairs requests.
-
-        The requests are placed in ``self.requests`` list.
-        The scenario must manually pass these requests to relevant applications (e.g. ProactiveRoutingController).
+        Generate random (src, dst) pairs requests into ``self.requests`` list.
 
         Args:
-            n: number of requests to generate
-            clear: if True, clear existing requests in ``self.requests``
-            allow_overlay: allow nodes to be the source or destination in multiple requests
-            min_hops: minimum number of hops (inclusive)
-            max_hops: maximum number of hops (inclusive)
-            attr: request attributes
-            forbid_endpoint_internal: if True, eliminate requests that
+            n: Number of requests to generate.
+            clear: If True, clear existing requests in ``self.requests``.
+            allow_overlay: Allow nodes to be the source or destination in multiple requests.
+            min_hops: Minimum number of hops (inclusive).
+            max_hops: Maximum number of hops (inclusive).
+            attr: Request attributes.
+            forbid_endpoint_internal: If True, eliminate requests that
                 would fail the rank-based endpoint-vs-internal check in SWAP-ASAP.
         """
-        attr = {} if attr is None else attr
         used_nodes: list[int] = []
         nnodes = len(self.nodes)
 

--- a/mqns/network/network/request.py
+++ b/mqns/network/network/request.py
@@ -1,36 +1,29 @@
-#    SimQN: a discrete-event simulator for the quantum networks
-#    Copyright (C) 2021-2022 Lutong Chen, Jian Li, Kaiping Xue
-#    University of Science and Technology of China, USTC.
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU General Public License as published by
-#    the Free Software Foundation, either version 3 of the License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU General Public License for more details.
-#
-#    You should have received a copy of the GNU General Public License
-#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+from typing import TypedDict, Unpack
 
 from mqns.entity.node import QNode
+
+
+class RequestAttr(TypedDict, total=False):
+    """
+    Request attributes.
+
+    This is currently empty.
+    In the future, it may contain properties such as minimum fidelity and desired throughput.
+    """
 
 
 class Request:
     """Requests entanglement pairs between a source and a destination."""
 
-    def __init__(self, src: QNode, dst: QNode, attr: dict = {}) -> None:
-        """Args:
-        src: the source node
-        dest: the destination node
-        attr: other attributions
-
+    def __init__(self, src: QNode, dst: QNode, **attr: Unpack[RequestAttr]):
+        """
+        Args:
+            src: Left node to receive one of the entangled qubits.
+            dst: Right node to receive one of the entangled qubits.
         """
         self.src = src
         self.dst = dst
-        self.attr = attr
+        _ = attr
 
     def __repr__(self) -> str:
-        return f"<Request {self.src}->{self.dst}>"
+        return f"<Request {self.src}-{self.dst}>"

--- a/mqns/network/network/timing.py
+++ b/mqns/network/network/timing.py
@@ -1,7 +1,8 @@
 from abc import ABC, abstractmethod
 from collections import deque
+from collections.abc import Iterable
 from enum import Enum, auto
-from typing import TYPE_CHECKING, final, override
+from typing import TYPE_CHECKING, final, overload, override
 
 from mqns.simulator import Event, Time, func_to_event
 from mqns.utils import log
@@ -90,6 +91,7 @@ class TimingModeAsync(TimingMode):
 
     def __init__(self, *, name="ASYNC"):
         super().__init__(name)
+        log.info(f"TIME_SYNC: using {name} mode")
 
     @override
     def is_async(self) -> bool:
@@ -106,6 +108,7 @@ class TimingModeSync(TimingMode):
     Synchronous application timing mode.
     """
 
+    @overload
     def __init__(
         self,
         *,
@@ -117,23 +120,60 @@ class TimingModeSync(TimingMode):
         """
         Args:
             t_ext: EXTERNAL phase duration in seconds.
-            t_rtg: ROUTING phase duration in seconds, defaults to 0.
+            t_rtg: ROUTING phase duration in seconds, defaults to zero.
             t_int: INTERNAL phase duration in seconds.
         """
+
+    @overload
+    def __init__(
+        self,
+        *,
+        name="SYNC",
+        durations: Iterable[float],
+    ):
+        """
+        Args:
+            durations: EXTERNAL, ROUTING, INTERNAL phase durations in seconds.
+        """
+
+    def __init__(
+        self,
+        *,
+        name="SYNC",
+        t_ext: float = 0,
+        t_rtg: float = 0,
+        t_int: float = 0,
+        durations: Iterable[float] | None = None,
+    ):
         super().__init__(name)
 
+        if durations is not None:
+            try:
+                t_ext, t_rtg, t_int = durations
+            except ValueError:
+                raise ValueError("durations= must have exactly three values")
+
         self.sequence = deque[tuple[TimingPhase, float]]()
-        assert t_ext > 0
+
+        if t_ext <= 0:
+            raise ValueError("EXTERNAL phase duration must be positive")
         self.sequence.append((TimingPhase.EXTERNAL, t_ext))
-        if t_rtg > 0:
+
+        if t_rtg < 0:
+            raise ValueError("ROUTING phase duration must be non-negative")
+        elif t_rtg > 0:
             self.sequence.append((TimingPhase.ROUTING, t_rtg))
-        assert t_int > 0
+
+        if t_int <= 0:
+            raise ValueError("INTERNAL phase duration must be positive")
         self.sequence.append((TimingPhase.INTERNAL, t_int))
 
         self.phase = self.sequence[-1][0]
         """Current phase."""
         self.end_time = Time.SENTINEL
         """Current phase end time (exclusive)."""
+
+        log.info(f"TIME_SYNC: using {name} mode, t_ext={t_ext}, t_rtg={t_rtg}, t_int={t_int}")
 
     @override
     def install(self, network: "QuantumNetwork"):

--- a/mqns/network/network/timing.py
+++ b/mqns/network/network/timing.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from collections import deque
-from collections.abc import Iterable
+from collections.abc import Sequence
 from enum import Enum, auto
 from typing import TYPE_CHECKING, final, overload, override
 
@@ -136,7 +136,7 @@ class TimingModeSync(TimingMode):
         self,
         *,
         name="SYNC",
-        durations: Iterable[float],
+        durations: Sequence[float],
     ):
         """
         Args:
@@ -150,42 +150,49 @@ class TimingModeSync(TimingMode):
         t_ext: float = 0,
         t_rtg: float = 0,
         t_int: float = 0,
-        durations: Iterable[float] | None = None,
+        durations: Sequence[float] | None = None,
     ):
         super().__init__(name)
 
-        if durations is not None:
-            try:
-                t_ext, t_rtg, t_int = durations
-            except ValueError:
-                raise ValueError("durations= must have exactly three values")
-
-        self.sequence = deque[tuple[TimingPhase, float]]()
-
-        if t_ext <= 0:
-            raise ValueError("EXTERNAL phase duration must be positive")
-        self.sequence.append((TimingPhase.EXTERNAL, t_ext))
-
-        if t_rtg < 0:
-            raise ValueError("ROUTING phase duration must be non-negative")
-        elif t_rtg > 0:
-            self.sequence.append((TimingPhase.ROUTING, t_rtg))
-
-        if t_int <= 0:
-            raise ValueError("INTERNAL phase duration must be positive")
-        self.sequence.append((TimingPhase.INTERNAL, t_int))
-
-        self.phase = self.sequence[-1][0]
-        """Current phase."""
-        self.end_time = Time.SENTINEL
-        """Current phase end time (exclusive)."""
-
-        log.info(f"TIME_SYNC: using {name} mode, t_ext={t_ext}, t_rtg={t_rtg}, t_int={t_int}")
+        self._seconds = (t_ext, t_rtg, t_int) if durations is None else durations
+        if len(self._seconds) != 3:
+            raise ValueError("durations= must have exactly three values")
 
     @override
     def install(self, network: "QuantumNetwork"):
         super().install(network)
+
+        t_ext, t_rtg, t_int = self._seconds
+        if t_ext <= 0:
+            raise ValueError("EXTERNAL phase duration must be positive")
+        if t_rtg < 0:
+            raise ValueError("ROUTING phase duration must be non-negative")
+        if t_int <= 0:
+            raise ValueError("INTERNAL phase duration must be positive")
+
+        self.t_ext = self.simulator.time(sec=t_ext)
+        """EXTERNAL phase duration."""
+        self.t_rtg = self.simulator.time(sec=t_rtg)
+        """ROUTING phase duration."""
+        self.t_int = self.simulator.time(sec=t_int)
+        """INTERNAL phase duration."""
+
+        log.info(
+            f"TIME_SYNC: using {self.name} mode, "
+            f"t_ext={self.t_ext.time_slot}, t_rtg={self.t_rtg.time_slot}, t_int={self.t_int.time_slot}"
+        )
+
+        self._sequence = deque[tuple[TimingPhase, Time]]()
+        self._sequence.append((TimingPhase.EXTERNAL, self.t_ext))
+        if t_rtg > 0:
+            self._sequence.append((TimingPhase.ROUTING, self.t_rtg))
+        self._sequence.append((TimingPhase.INTERNAL, self.t_int))
+
+        self.phase = self._sequence[-1][0]
+        """Current phase."""
         self.end_time = self.simulator.ts
+        """Current phase end time (exclusive)."""
+
         self.simulator.add_event(func_to_event(self.simulator.ts, self._enter_phase))
 
     def _change_phase(self):
@@ -197,8 +204,8 @@ class TimingModeSync(TimingMode):
         self._enter_phase()
 
     def _enter_phase(self):
-        this_phase = self.sequence.popleft()
-        self.sequence.append(this_phase)
+        this_phase = self._sequence.popleft()
+        self._sequence.append(this_phase)
         phase, duration = this_phase
 
         self.phase = phase

--- a/mqns/network/network/timing.py
+++ b/mqns/network/network/timing.py
@@ -98,7 +98,11 @@ class TimingModeAsync(TimingMode):
 
     def __init__(self, *, name="ASYNC"):
         super().__init__(name)
-        log.info(f"TIME_SYNC: using {name} mode")
+
+    @override
+    def install(self, network: "QuantumNetwork"):
+        super().install(network)
+        log.info(f"TIME_SYNC: using {self.name} mode")
 
     @override
     def is_async(self) -> bool:

--- a/mqns/network/network/timing.py
+++ b/mqns/network/network/timing.py
@@ -23,15 +23,22 @@ class TimingPhaseEvent(Event):
     Event that indicates a timing phase change, emitted in SYNC timing mode only.
     """
 
-    def __init__(self, phase: TimingPhase, *, t: Time, name: str | None = None):
+    def __init__(self, phase: TimingPhase, *, enter: bool, t: Time, name: str | None = None):
         super().__init__(t, name)
         self.phase = phase
+        """Phase."""
+        self.enter = enter
+        """True when entering a phase, False when exiting a phase."""
 
     @override
     def invoke(self) -> None:
         # This event is directly dispatched onto nodes without going through the scheduler
         # for performance reasons, so that the invoke() method is unused.
         raise RuntimeError
+
+    @property
+    def action(self) -> tuple[TimingPhase, bool]:
+        return self.phase, self.enter
 
 
 class TimingMode(ABC):
@@ -179,9 +186,17 @@ class TimingModeSync(TimingMode):
     def install(self, network: "QuantumNetwork"):
         super().install(network)
         self.end_time = self.simulator.ts
-        self.simulator.add_event(func_to_event(self.simulator.ts, self.signal_phase))
+        self.simulator.add_event(func_to_event(self.simulator.ts, self._enter_phase))
 
-    def signal_phase(self):
+    def _change_phase(self):
+        log.debug(f"TIME_SYNC: exiting {self.phase.name} phase")
+        event = TimingPhaseEvent(self.phase, enter=False, t=self.simulator.tc)
+        for node in self.network.all_nodes:
+            node.handle(event)
+
+        self._enter_phase()
+
+    def _enter_phase(self):
         this_phase = self.sequence.popleft()
         self.sequence.append(this_phase)
         phase, duration = this_phase
@@ -190,10 +205,10 @@ class TimingModeSync(TimingMode):
         self.end_time = self.simulator.tc + duration
 
         # schedule next sync signal
-        self.simulator.add_event(func_to_event(self.end_time, self.signal_phase))
+        self.simulator.add_event(func_to_event(self.end_time, self._change_phase))
 
-        log.debug(f"TIME_SYNC: signal {phase.name} phase")
-        event = TimingPhaseEvent(phase, t=self.simulator.tc)
+        log.debug(f"TIME_SYNC: entering {phase.name} phase")
+        event = TimingPhaseEvent(phase, enter=True, t=self.simulator.tc)
         for node in self.network.all_nodes:
             node.handle(event)
 

--- a/mqns/network/proactive/controller.py
+++ b/mqns/network/proactive/controller.py
@@ -24,6 +24,9 @@ class ProactiveRoutingController(RoutingController):
     """
     Centralized control plane for proactive routing.
     Works with ``ProactiveForwarder`` on quantum nodes.
+
+    This controller does not pick up requests from ``QuantumNetwork.requests`` list.
+    If desired, scenario script should manually pass requests to ``ProactiveRoutingController.install_path()``.
     """
 
     def __init__(

--- a/mqns/network/protocol/classicbridge.py
+++ b/mqns/network/protocol/classicbridge.py
@@ -3,7 +3,7 @@ import os
 import queue
 import threading
 from dataclasses import dataclass
-from typing import override
+from typing import Protocol, override
 
 from mqns.entity.cchannel import ClassicPacket, RecvClassicPacket
 from mqns.entity.node import Application, Node
@@ -16,13 +16,29 @@ except ImportError:
     nats = None
 
 
+class TransmittableItem(Protocol):
+    def encode(self) -> tuple[str, bytes, dict[str, str]]: ...
+
+
 @dataclass
-class ClassicBridgePacket:
+class GateReached(TransmittableItem):
+    t: int
+
+    def encode(self) -> tuple[str, bytes, dict[str, str]]:
+        return "_.gate", b"", {"t": f"{self.t}"}
+
+
+@dataclass
+class ClassicBridgePacket(TransmittableItem):
     t: int
     src: str
     dst: str
     payload: bytes
     is_json: bool
+
+    def encode(self) -> tuple[str, bytes, dict[str, str]]:
+        headers = {"t": f"{self.t}", "fmt": "json" if self.is_json else "bytes"}
+        return f"{self.dst}.{self.src}", self.payload, headers
 
 
 class ClassicConnector:
@@ -61,12 +77,18 @@ class ClassicConnector:
     * Subject: ``<PREFIX>.I._.gate`` (note: ``_`` is a keyword for ClassicConnector and cannot be used as a node name)
     * Header ``t``: new upper-bound in simulation time slots
 
+    When the simulator reaches the gate, it would notify the external program by publishing:
+
+    * Subject: ``<PREFIX>.O._.gate``
+    * Header ``t``: stop time in simulation time slots
+
     The external program may stop the simulator by publishing:
 
     * Subject: ``<PREFIX>.I._.stop``
     * Header ``t``: stop time in simulation time slots
 
-    The external program must also release the gate to or beyond the stop time, for stopping to occur.
+    Publishing the stop message implies releasing the gate to the stop time.
+    However, the simulator will not publish ``<PREFIX>.O._.gate`` before stopping.
 
     The external program must publish all packets and gate updates in non-decreasing order. In other words,
     the header ``t`` for every message must be greater than or equal to the timestamp on all previous messages.
@@ -85,10 +107,13 @@ class ClassicConnector:
         self.nats_servers = os.getenv("NATS_URL", "nats://127.0.0.1:4222").split(",")
         self.nats_prefix = nats_prefix
 
+        self._gate_subject = f"{nats_prefix}.O._.gate"
+        simulator.set_gate_reached_handler(lambda t: self.queue.put(GateReached(t)))
+
         self._last_t = 0
         self._last_gate_event: Event | None = None
 
-        self.queue = queue.Queue[ClassicBridgePacket](maxsize=4096)
+        self.queue = queue.Queue[TransmittableItem](maxsize=4096)
         self._worker_thread = threading.Thread(target=self._worker_loop, daemon=True)
         self._worker_thread.start()
 
@@ -131,17 +156,14 @@ class ClassicConnector:
 
             await asyncio.sleep(0)
 
-    async def _tx(self, cbp: ClassicBridgePacket):
+    async def _tx(self, item: TransmittableItem):
         from nats.js.errors import BadRequestError  # noqa: PLC0415
 
-        subject = f"{self.nats_prefix}.O.{cbp.dst}.{cbp.src}"
-        headers = {
-            "t": f"{cbp.t}",
-            "fmt": "json" if cbp.is_json else "bytes",
-        }
+        subject_suffix, payload, headers = item.encode()
+        subject = f"{self.nats_prefix}.O.{subject_suffix}"
 
         try:
-            ack = await self._js.publish(subject, cbp.payload, headers=headers)
+            ack = await self._js.publish(subject, payload, headers=headers)
             _ = ack.seq
         except BadRequestError:
             log.error(f"JetStream Error: Subject {subject} does not match a stream.")
@@ -181,7 +203,11 @@ class ClassicConnector:
                         self._last_gate_event.cancel()
                     self._last_gate_event = self.simulator.update_gate(t)
                 case "stop":
-                    self.simulator.add_event(func_to_event(t, self.simulator.stop))
+                    event = func_to_event(t, self.simulator.stop)
+                    event.name = "ClassicConnector.stop"
+                    event.priority = 0xFFFFFFFF
+                    self.simulator.add_event(event)
+                    self.simulator.update_gate(t)
                 case _:
                     log.error(f"ClassicConnector received unexpected special subject ._.{src}")
             return

--- a/mqns/network/protocol/classicbridge.py
+++ b/mqns/network/protocol/classicbridge.py
@@ -40,14 +40,14 @@ class ClassicConnector:
 
     When a *split node* receives a classic packet, it is published as:
 
-    * Subject: ``<PREFIX>.<dst>.<src>``
+    * Subject: ``<PREFIX>.O.<dst>.<src>``
     * Payload: the classic packet payload
     * Header ``t``: packet receipt time in simulation time slots
     * Header ``fmt``: packet format, either ``"json"`` or ``"bytes"``
 
     If the external program wants to transmit a packet out of a node *src*, it should publish:
 
-    * Subject: ``<PREFIX>.<dst>.<src>``
+    * Subject: ``<PREFIX>.I.<dst>.<src>``
     * Payload: the classic packet payload
     * Header ``t``: packet transmission time in simulation time slots
     * Header ``fmt``: packet format, either ``"json"`` or ``"bytes"``
@@ -58,12 +58,12 @@ class ClassicConnector:
     pausing the simulation at the first time slot until an external gate update is received.
     The external program is responsible for advancing this gate by publishing a heartbeat:
 
-    * Subject: ``<PREFIX>._.gate`` (note: ``_`` is a keyword for ClassicConnector and should not be used as a node name)
+    * Subject: ``<PREFIX>.I._.gate`` (note: ``_`` is a keyword for ClassicConnector and cannot be used as a node name)
     * Header ``t``: new upper-bound in simulation time slots
 
     The external program may stop the simulator by publishing:
 
-    * Subject: ``<PREFIX>._.stop``
+    * Subject: ``<PREFIX>.I._.stop``
     * Header ``t``: stop time in simulation time slots
 
     The external program must also release the gate to or beyond the stop time, for stopping to occur.
@@ -102,7 +102,7 @@ class ClassicConnector:
             log.info(f"ClassicConnector connected to NATS server {nc.connected_url} as client_id={nc.client_id}")
             async with nc:
                 self._js = nc.jetstream()
-                self._sub = await self._js.pull_subscribe(f"{self.nats_prefix}.*.*")
+                self._sub = await self._js.pull_subscribe(f"{self.nats_prefix}.I.*.*")
 
                 done, _ = await asyncio.wait(
                     [
@@ -134,7 +134,7 @@ class ClassicConnector:
     async def _tx(self, cbp: ClassicBridgePacket):
         from nats.js.errors import BadRequestError  # noqa: PLC0415
 
-        subject = f"{self.nats_prefix}.{cbp.dst}.{cbp.src}"
+        subject = f"{self.nats_prefix}.O.{cbp.dst}.{cbp.src}"
         headers = {
             "t": f"{cbp.t}",
             "fmt": "json" if cbp.is_json else "bytes",

--- a/mqns/network/protocol/link_layer.py
+++ b/mqns/network/protocol/link_layer.py
@@ -182,15 +182,18 @@ class LinkLayer(Application[QNode]):
 
         Upon entering EXTERNAL phase:
 
-        1. Clear existing memory qubits.
-        2. Run all active channels from reservation step.
+        1. Run all active channels from reservation step.
 
-        Upon entering INTERNAL phase: do nothing.
+        Upon exiting INTERNAL phase:
+
+        1. Clear existing memory qubits.
         """
-        if event.phase == TimingPhase.EXTERNAL:
-            self.memory.clear()
-            for (qchannel, path_id), (neighbor, _) in self.active_channels.items():
-                self.run_active_channel(qchannel, path_id, neighbor)
+        match event.action:
+            case TimingPhase.INTERNAL, False:
+                self.memory.clear()
+            case TimingPhase.EXTERNAL, True:
+                for (qchannel, path_id), (neighbor, _) in self.active_channels.items():
+                    self.run_active_channel(qchannel, path_id, neighbor)
 
     def RecvClassicPacketHandler(self, event: RecvClassicPacket) -> bool:
         msg = event.packet.get()

--- a/mqns/network/reactive/controller.py
+++ b/mqns/network/reactive/controller.py
@@ -101,7 +101,7 @@ class ReactiveRoutingController(ClassicCommandDispatcherMixin, RoutingController
         """
 
         if not self.node.timing.is_routing():  # should be in SYNC timing mode ROUTING phase
-            log.debug(f"{self.node}: received LS message from {pkt.src} outside of ROUTING phase | {msg}")
+            log.warning(f"{self.node}: received LS message from {pkt.src} outside of ROUTING phase | {msg}")
             return True
 
         log.debug(f"{self.node.name}: received LS message from {pkt.src} | {msg}")

--- a/mqns/network/reactive/controller.py
+++ b/mqns/network/reactive/controller.py
@@ -15,11 +15,15 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from typing import override
+from collections import defaultdict
+from itertools import pairwise
+from typing import cast, override
 
 from mqns.entity.cchannel import ClassicCommandDispatcherMixin, ClassicPacket, RecvClassicPacket, classic_cmd_handler
-from mqns.network.fw import RoutingController, RoutingPathStatic, SwapSequenceInput
+from mqns.network.fw import RoutingController, RoutingPathStatic, SwapPolicy
+from mqns.network.network import Request, TimingModeSync, TimingPhase, TimingPhaseEvent
 from mqns.network.reactive.message import LinkStateMsg
+from mqns.simulator import func_to_event
 from mqns.utils import json_encodable, log
 
 
@@ -30,42 +34,34 @@ class ReactiveRoutingControllerCounters:
     def __init__(self):
         self.n_ls = 0
         """How many link-state message arrived."""
-        self.n_decision = 0
-        """How many routing decisions sent."""
+        self.n_satisfy = 0
+        """How many requests satisfied."""
 
     def __repr__(self) -> str:
-        return f"ls={self.n_ls} decision={self.n_decision}"
+        return f"ls={self.n_ls} satisfy={self.n_satisfy}"
 
 
 class ReactiveRoutingController(ClassicCommandDispatcherMixin, RoutingController):
     """
     Centralized control plane for reactive routing.
     Works with ``ReactiveForwarder`` on quantum nodes.
+
+    This controller is only compatible with SYNC timing mode.
+    It can automatically pick up requests from ``QuantumNetwork.requests`` list.
     """
 
     def __init__(
         self,
         *,
-        route: list[str] = ["S", "R", "D"],
-        swap: SwapSequenceInput = "asap",
+        swap: SwapPolicy = "asap",
     ):
         """
         Args:
-            route: static path.
-            swap: swapping policy.
-
-        Note:
-            This feature is in early stage.
-            Currently it only installed a static path defined in ``route`` and ``swap``.
+            swap: Swapping policy applied to all paths.
         """
         super().__init__()
-        self.route = route
-        self.swap: SwapSequenceInput = swap
 
-        self.ls_messages: list[LinkStateMsg] = []
-        """
-        Received but unprocessed link-state messages.
-        """
+        self.swap: SwapPolicy = swap
 
         self.cnt = ReactiveRoutingControllerCounters()
         """
@@ -73,13 +69,30 @@ class ReactiveRoutingController(ClassicCommandDispatcherMixin, RoutingController
         """
 
         self.add_handler(self.handle_classic_command, RecvClassicPacket)
+        self.add_handler(self.handle_sync_phase, TimingPhaseEvent)
+
+        self._tls = defaultdict[tuple[str, str], set[str]](set)
+        """
+        Topology link state.
+
+        Key: node names, sorted.
+        Value: entanglement reservation keys.
+        """
 
     @override
     def install(self, node):
         super().install(node)
 
-        self.requests = self.net.requests
-        """Requests to satisfy in each routing phase."""
+        if self.node.timing.is_async():
+            raise TypeError("ReactiveRoutingController only works with SYNC timing mode")
+        self.timing = cast(TimingModeSync, self.node.timing)
+        self.d_rtg = self.simulator.time(time_slot=self.timing.t_rtg.time_slot // 2)
+
+    def handle_sync_phase(self, event: TimingPhaseEvent):
+        match event.action:
+            case TimingPhase.ROUTING, True:
+                self._tls.clear()
+                self.simulator.add_event(func_to_event(self.simulator.tc + self.d_rtg, self.do_routing))
 
     @classic_cmd_handler("LS")
     def handle_ls(self, pkt: ClassicPacket, msg: LinkStateMsg):
@@ -93,19 +106,55 @@ class ReactiveRoutingController(ClassicCommandDispatcherMixin, RoutingController
 
         log.debug(f"{self.node.name}: received LS message from {pkt.src} | {msg}")
         self.cnt.n_ls += 1
-        self.ls_messages.append(msg)
 
-        if len(self.ls_messages) == len(self.route):
-            self.do_routing()
-            self.ls_messages.clear()
+        for entry in msg["ls"]:
+            n0, n1 = entry["node"], entry["neighbor"]
+            if n0 < n1:
+                self._tls[(n0, n1)].add(entry["qubit"])
 
         return True
 
     def do_routing(self):
-        rpath = RoutingPathStatic(self.route, swap=self.swap)
-        self.install_path(rpath)
+        """
+        Attempt to satisfy each active request in ``QuantumNetwork.requests`` list with available entanglements.
+        Repeat multiple rounds until no more requests can be satisfied.
+        """
+        some_satisfied = True
+        while some_satisfied:
+            some_satisfied = False
+            for req in self.net.requests:
+                if self._try_satisfy(req):
+                    self.cnt.n_satisfy += 1
+                    some_satisfied = True
 
-    @override
-    def install_path(self, rp):
-        self.cnt.n_decision += 1
-        super().install_path(rp)
+    def _try_satisfy(self, req: Request) -> bool:
+        """
+        Attempt to satisfy an active request with available entanglements.
+        If the routing algorithm returns multiple routes, they will be tried in order.
+        """
+        route_result = self.net.query_route(req.src, req.dst)
+        for _, _, route_nodes in route_result:
+            route = [node.name for node in route_nodes]
+
+            if (qubits := self._try_consume(route)) is None:
+                continue
+
+            self.install_path(RoutingPathStatic(route, m_v=qubits, swap=self.swap))
+            return True
+
+        return False
+
+    def _try_consume(self, route: list[str]) -> list[str] | None:
+        """
+        Attempt to match a computed route with available entanglements.
+        The entanglements are removed from ``self._tls`` only if every link along the path has an entanglement.
+        """
+        link_etgs: list[set[str]] = []
+
+        for n0, n1 in pairwise(route):
+            etgs = self._tls.get((n0, n1) if n0 < n1 else (n1, n0))
+            if etgs is None or len(etgs) == 0:
+                return None
+            link_etgs.append(etgs)
+
+        return [etgs.pop() for etgs in link_etgs]

--- a/mqns/network/reactive/forwarder.py
+++ b/mqns/network/reactive/forwarder.py
@@ -84,12 +84,18 @@ class ReactiveForwarder(Forwarder):
                 self.memory.deallocate(*(qubit.addr for qubit, _ in self.memory.find(lambda q, _: q.path_id is not None)))
 
     @override
-    def handle_path_change(self, **_):
+    def handle_path_change(self, *, path_id: int, uninstall: bool, **_):
         """
         Process LinkLayer changes after a path has been installed or uninstalled.
 
         This does nothing because LinkLayer is always running based on topology.
         """
+        if uninstall:
+            raise ValueError("ReactiveForwarder should not receive UNINSTALL_PATH command")
+        if not self.node.timing.is_routing():
+            log.warning(
+                f"{self.node}: received INSTALL_PATH message for path {path_id} outside of ROUTING phase; t_rtg is too short?"
+            )
 
     def send_link_state(self):
         """

--- a/mqns/network/reactive/forwarder.py
+++ b/mqns/network/reactive/forwarder.py
@@ -17,7 +17,6 @@
 
 from typing import override
 
-from mqns.entity.memory import MemoryQubit
 from mqns.network.fw import Forwarder
 from mqns.network.network import TimingPhase, TimingPhaseEvent
 from mqns.network.protocol.event import ManageActiveChannels
@@ -69,13 +68,20 @@ class ReactiveForwarder(Forwarder):
 
         1. Send to controller link states corresponding to entangled qubits that arrived during EXTERNAL phase
            and wait for routing instructions.
+
+        Upon exiting INTERNAL phase:
+
+        1. Clear path assignments.
+           In reactive forwarding, path assignments are only useful for one slot.
         """
-        if event.phase == TimingPhase.ROUTING:
-            log.debug(f"{self.node}: there are {len(self.waiting_etg)} etg qubits to process")
-            log.debug(f"{self.node}: send link_state for {len(self.waiting_etg)} etg qubits")
-            self.send_link_state()
-        else:
-            super().handle_sync_phase(event)
+        super().handle_sync_phase(event)
+
+        match event.action:
+            case TimingPhase.ROUTING, True:
+                log.debug(f"{self.node}: send link_state for {len(self.waiting_etg)} etg qubits")
+                self.send_link_state()
+            case TimingPhase.INTERNAL, False:
+                self.memory.deallocate(*(qubit.addr for qubit, _ in self.memory.find(lambda q, _: q.path_id is not None)))
 
     @override
     def handle_path_change(self, **_):
@@ -103,17 +109,3 @@ class ReactiveForwarder(Forwarder):
             "ls": link_states,
         }
         self.send_ctrl(msg)
-
-    @override
-    def release_qubit(self, qubit: MemoryQubit, *, need_remove=False):
-        """
-        Release a qubit.
-
-        Args:
-            need_remove: whether to remove the data associated with the qubit.
-                         This should be set to True unless .read(remove=True) is already performed.
-        """
-        super().release_qubit(qubit, need_remove=need_remove)
-
-        # in Reactive: remove path allocation for next routing cycle
-        self.memory.deallocate(qubit.addr)

--- a/mqns/network/reactive/forwarder.py
+++ b/mqns/network/reactive/forwarder.py
@@ -91,7 +91,8 @@ class ReactiveForwarder(Forwarder):
         """
         link_states: list[LinkStateEntry] = []
         for event in self.waiting_etg:
-            link_states.append({"node": event.node.name, "neighbor": event.neighbor.name, "qubit": event.qubit.addr})
+            assert event.qubit.active is not None
+            link_states.append({"node": event.node.name, "neighbor": event.neighbor.name, "qubit": event.qubit.active})
 
         if len(link_states) == 0:
             log.debug(f"{self.node}: no link_state to send")

--- a/mqns/network/reactive/message.py
+++ b/mqns/network/reactive/message.py
@@ -3,8 +3,11 @@ from typing import Literal, TypedDict
 
 class LinkStateEntry(TypedDict):
     node: str
+    """Node name of the node sending link state report."""
     neighbor: str
-    qubit: int
+    """Node name of the other node sharing an entanglement with this node."""
+    qubit: str
+    """Reservation key of the qubit."""
 
 
 class LinkStateMsg(TypedDict):

--- a/mqns/network/topology/customtopo.py
+++ b/mqns/network/topology/customtopo.py
@@ -142,10 +142,8 @@ class CustomTopology(Topology):
             link = QuantumChannel(name=f"q_{node1},{node2}", **ch["parameters"])
             qcl.append(link)
 
-            # Attach quantum channel to nodes
-            for qn in qnl:
-                if qn.name in (node1, node2):
-                    qn.add_qchannel(link)
+            cast(QNode, self._node_by_name[node1]).add_qchannel(link)
+            cast(QNode, self._node_by_name[node2]).add_qchannel(link)
 
             link.assign_memory_qubits(
                 capacity={
@@ -165,7 +163,7 @@ class CustomTopology(Topology):
     def add_cchannels(self, *, classic_topo: ClassicTopology = ClassicTopology.Empty, **_):
         if classic_topo == ClassicTopology.Follow:
             assert "cchannels" not in self.topo
-            return self._add_cchannels_from((_qchannel_to_cchannel(qc) for qc in self.topo["qchannels"]))
+            return self._add_cchannels_from(_qchannel_to_cchannel(qc) for qc in self.topo["qchannels"])
         else:
             assert classic_topo == ClassicTopology.Empty
             assert "cchannels" in self.topo

--- a/mqns/simulator/pool.py
+++ b/mqns/simulator/pool.py
@@ -2,6 +2,7 @@ import heapq
 import threading
 import time
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from typing import override
 
 from mqns.simulator.event import Event
@@ -40,6 +41,12 @@ class EventPool(ABC):
         Simulation is paused at this time slot until it's advanced.
         """
         _ = t
+
+    def set_gate_reached_handler(self, h: Callable[[int], None]) -> None:
+        """
+        Set a callback function when the gate time has been reached.
+        """
+        _ = h
 
     @abstractmethod
     def insert(self, event: Event) -> None:
@@ -91,10 +98,15 @@ class SynchronizedEventPool(EventPool):
     Synchronized event pool (thread safe).
     """
 
+    @staticmethod
+    def _gate_handler(t: int, /):
+        _ = t
+
     def __init__(self, ts: int, te: int | None):
         super().__init__(ts, te)
         self._cv = threading.Condition()
         self._gate = ts
+        self._reached = -1
 
     @override
     def stop(self) -> None:
@@ -108,6 +120,10 @@ class SynchronizedEventPool(EventPool):
         with self._cv:
             self._gate = t
             self._cv.notify_all()  # wake up .pop() if it's waiting at the gate
+
+    @override
+    def set_gate_reached_handler(self, h: Callable[[int], None]) -> None:
+        self._gate_handler = h
 
     @override
     def insert(self, event: Event) -> None:
@@ -132,9 +148,14 @@ class SynchronizedEventPool(EventPool):
                     if next_t <= self._gate:  # event is before gate and can be executed
                         event = heapq.heappop(self._list)
                         self.tc = next_t
+                        self._reached = -1
                         return event
 
                 # no event or event is after gate
+                if (reached := max(self.tc, self._gate)) > self._reached:
+                    # report reaching the gate, but don't send duplicate reports unless new events were executed
+                    self._reached = reached
+                    self._gate_handler(reached)
                 self._cv.wait(timeout=1)
 
             # release conditional variable so that the thread can be interrupted

--- a/mqns/simulator/simulator.py
+++ b/mqns/simulator/simulator.py
@@ -138,6 +138,9 @@ class Simulator:
                 profile.runcall(self._run)
             else:
                 self._run()
+        except BaseException as e:
+            log.error(f"Simulator exception {type(e)} occurred: {e}")
+            raise RuntimeError(f"simulation aborted at [{self.tc}] by exception: {e}") from e
         finally:
             self.stop()  # ensure s.running is False
 

--- a/mqns/simulator/simulator.py
+++ b/mqns/simulator/simulator.py
@@ -1,7 +1,7 @@
 import math
 import os
 import time
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from pstats import SortKey
 from typing import TYPE_CHECKING, Any, Literal, Protocol, overload
 
@@ -217,3 +217,9 @@ class Simulator:
         assert gate.accuracy == self.accuracy
         log.debug(f"Simulator.update_gate({gate.time_slot})")
         self._pool.update_gate(gate.time_slot)
+
+    def set_gate_reached_handler(self, h: Callable[[int], None]) -> None:
+        """
+        Set a callback function when the gate time has been reached.
+        """
+        self._pool.set_gate_reached_handler(h)

--- a/tests/fw/fw_common.py
+++ b/tests/fw/fw_common.py
@@ -5,7 +5,7 @@ from mqns.entity.memory import QubitState
 from mqns.entity.node import Application, Controller, QNode
 from mqns.entity.qchannel import LinkArchAlways, LinkArchDimBk, QuantumChannelInitKwargs
 from mqns.models.epr import Entanglement, WernerStateEntanglement
-from mqns.network.fw import Forwarder, MuxScheme, RoutingPath
+from mqns.network.fw import Forwarder, MuxScheme, RoutingController, RoutingPath
 from mqns.network.network import QuantumNetwork, TimingMode, TimingModeAsync
 from mqns.network.proactive import ProactiveForwarder, ProactiveRoutingController
 from mqns.network.protocol.event import QubitEntangledEvent
@@ -32,6 +32,7 @@ class BuildNetworkArgs(TypedDict, total=False):
     qchannel_capacity: int  # quantum channel capacity, defaults to 1
     qchannel_args: QuantumChannelInitKwargs
     cchannel_args: ClassicChannelInitKwargs
+    ctrl: RoutingController  # replacing controller application
     ps: float  # probability of successful swap, defaults to 0.5
     mux: MuxScheme  # multiplexing scheme, defaults to buffer-space
     end_time: float  # simulation end time, defaults to 10.0 seconds
@@ -73,11 +74,12 @@ def _build_network_finish(
 ):
     qchannel_capacity = d.get("qchannel_capacity", 1)
 
-    match d.get("mode", "P"):
-        case "P":
-            ctrl = ProactiveRoutingController()
-        case "R":
-            ctrl = ReactiveRoutingController(route=["n1", "n2", "n3"], swap=[1, 0, 1])
+    if (ctrl := d.get("ctrl")) is None:
+        match d.get("mode", "P"):
+            case "P":
+                ctrl = ProactiveRoutingController()
+            case "R":
+                ctrl = ReactiveRoutingController(route=["n1", "n2", "n3"], swap=[1, 0, 1])
     topo.controller = Controller("ctrl", apps=[ctrl])
 
     net = QuantumNetwork(

--- a/tests/fw/fw_common.py
+++ b/tests/fw/fw_common.py
@@ -236,7 +236,8 @@ def provide_entanglements(
 
         key = f"provide_entanglements.key:{uuid.uuid4().hex}"
         for node, neighbor, d_notify in (src, dst, d_notify_a), (dst, src, d_notify_b):
-            q, _ = next(node.memory.find(lambda _, v: v is None, qchannel=ch))
+            q, _ = next(node.memory.find(lambda _, v: v is None, qchannel=ch), (None, None))
+            assert q is not None, f"insufficient qubits assigned to {ch}"
             node.memory.write(q.addr, epr)
             q.active = key
             q._state = QubitState.ENTANGLED0

--- a/tests/fw/fw_common.py
+++ b/tests/fw/fw_common.py
@@ -80,7 +80,7 @@ def _build_network_finish(
             case "P":
                 ctrl = ProactiveRoutingController()
             case "R":
-                ctrl = ReactiveRoutingController(route=["n1", "n2", "n3"], swap=[1, 0, 1])
+                ctrl = ReactiveRoutingController()
     topo.controller = Controller("ctrl", apps=[ctrl])
 
     net = QuantumNetwork(

--- a/tests/fw/fw_common.py
+++ b/tests/fw/fw_common.py
@@ -1,3 +1,4 @@
+import uuid
 from typing import Literal, TypedDict, Unpack
 
 from mqns.entity.cchannel import ClassicChannelInitKwargs
@@ -233,8 +234,10 @@ def provide_entanglements(
         )
         epr.fidelity = fidelity
 
+        key = f"provide_entanglements.key:{uuid.uuid4().hex}"
         for node, neighbor, d_notify in (src, dst, d_notify_a), (dst, src, d_notify_b):
             q, _ = next(node.memory.find(lambda _, v: v is None, qchannel=ch))
             node.memory.write(q.addr, epr)
+            q.active = key
             q._state = QubitState.ENTANGLED0
             simulator.add_event(QubitEntangledEvent(node.node, neighbor.node, q, t=t_creation + d_notify))

--- a/tests/fw/test_p_swap.py
+++ b/tests/fw/test_p_swap.py
@@ -373,12 +373,13 @@ def test_tree2_statistical(
             chosen = candidates[0]
         elif fw is f2:  # n2-n1 choosing between n4-n2 and n5-n2
             partner = (f4, f5)[selected_qubit[0]]
-            chosen = next((mt1 for mt1 in candidates if mt1[1].src is partner.node))
+            chosen = next((mt1 for mt1 in candidates if mt1[1].src is partner.node), None)
         elif fw is f3:  # n1-n3 choosing between n3-n6 and n3-n7
             partner = (f6, f7)[selected_qubit[1]]
-            chosen = next((mt1 for mt1 in candidates if mt1[1].dst is partner.node))
+            chosen = next((mt1 for mt1 in candidates if mt1[1].dst is partner.node), None)
         else:
             raise RuntimeError()
+        assert chosen is not None
         return chosen
 
     def select_path(fw: Forwarder, epr0: Entanglement, epr1: Entanglement, path_ids: list[int]) -> int:

--- a/tests/fw/test_r_swap.py
+++ b/tests/fw/test_r_swap.py
@@ -2,14 +2,112 @@
 Test suite for ReactiveForwarder focused on swapping.
 """
 
+from mqns.entity.cchannel import ClassicCommandDispatcherMixin, ClassicPacket, RecvClassicPacket, classic_cmd_handler
+from mqns.entity.timer import Timer
+from mqns.network.fw import RoutingController, RoutingPathStatic
 from mqns.network.network import TimingModeSync
 from mqns.network.reactive import ReactiveForwarder, ReactiveRoutingController
+from mqns.network.reactive.message import LinkStateEntry, LinkStateMsg
 
-from .fw_common import (
-    build_linear_network,
-    print_fw_counters,
-    provide_entanglements,
-)
+from .fw_common import build_linear_network, build_tree_network, print_fw_counters, provide_entanglements
+
+
+class ManualController(ClassicCommandDispatcherMixin, RoutingController):
+    def __init__(self):
+        super().__init__()
+        self.add_handler(self.handle_classic_command, RecvClassicPacket)
+
+        self.ls_pkts: list[tuple[ClassicPacket, LinkStateMsg]] = []
+        self.ls_entries: list[LinkStateEntry] = []
+
+    @classic_cmd_handler("LS")
+    def handle_ls(self, pkt: ClassicPacket, msg: LinkStateMsg):
+        _ = pkt
+        self.ls_pkts.append((pkt, msg))
+        self.ls_entries.extend(msg["ls"])
+
+
+def test_tree2_one():
+    """Verify link state messages and test one path in tree (height=2) topology."""
+    ctrl = ManualController()
+    net, simulator = build_tree_network(
+        2,
+        mode="R",
+        ps=1.0,
+        end_time=0.010,
+        timing=TimingModeSync(t_ext=0.006, t_rtg=0.001, t_int=0.003),
+        ctrl=ctrl,
+    )
+    f4 = net.get_node("n4").get_app(ReactiveForwarder)
+    f2 = net.get_node("n2").get_app(ReactiveForwarder)
+    f1 = net.get_node("n1").get_app(ReactiveForwarder)
+    f3 = net.get_node("n3").get_app(ReactiveForwarder)
+    f6 = net.get_node("n6").get_app(ReactiveForwarder)
+
+    def do_routing():
+        assert len(ctrl.ls_pkts) == 5
+        assert len(ctrl.ls_entries) == 8
+        ctrl.install_path(RoutingPathStatic(["n4", "n2", "n1", "n3", "n6"], swap=[2, 0, 1, 0, 2]))
+
+    timer = Timer("do_routing", 0.0065, trigger_func=do_routing)
+    timer.install(simulator)
+
+    provide_entanglements(
+        (0.0011, f4, f2),
+        (0.0012, f2, f1),
+        (0.0013, f1, f3),
+        (0.0014, f3, f6),
+    )
+    simulator.run()
+    print_fw_counters(net)
+
+    assert f4.cnt.n_consumed == 1
+
+
+def test_tree2_two():
+    """Verify link state messages and test both paths in tree (height=2) topology."""
+    ctrl = ManualController()
+    net, simulator = build_tree_network(
+        2,
+        mode="R",
+        qchannel_capacity=2,
+        ps=1.0,
+        end_time=0.010,
+        timing=TimingModeSync(t_ext=0.006, t_rtg=0.001, t_int=0.003),
+        ctrl=ctrl,
+    )
+    f4 = net.get_node("n4").get_app(ReactiveForwarder)
+    f5 = net.get_node("n5").get_app(ReactiveForwarder)
+    f2 = net.get_node("n2").get_app(ReactiveForwarder)
+    f1 = net.get_node("n1").get_app(ReactiveForwarder)
+    f3 = net.get_node("n3").get_app(ReactiveForwarder)
+    f6 = net.get_node("n6").get_app(ReactiveForwarder)
+    f7 = net.get_node("n7").get_app(ReactiveForwarder)
+
+    def do_routing():
+        assert len(ctrl.ls_pkts) == 7
+        assert len(ctrl.ls_entries) == 16
+        ctrl.install_path(RoutingPathStatic(["n4", "n2", "n1", "n3", "n6"], swap=[2, 0, 1, 0, 2], m_v=[(1, 1)] * 4))
+        ctrl.install_path(RoutingPathStatic(["n5", "n2", "n1", "n3", "n7"], swap=[2, 0, 1, 0, 2], m_v=[(1, 1)] * 4))
+
+    timer = Timer("do_routing", 0.0065, trigger_func=do_routing)
+    timer.install(simulator)
+
+    provide_entanglements(
+        (0.0011, f4, f2),
+        (0.0012, f2, f1),
+        (0.0013, f1, f3),
+        (0.0014, f3, f6),
+        (0.0021, f5, f2),
+        (0.0022, f2, f1),
+        (0.0023, f1, f3),
+        (0.0024, f3, f7),
+    )
+    simulator.run()
+    print_fw_counters(net)
+
+    assert f4.cnt.n_consumed == 1
+    assert f5.cnt.n_consumed == 1
 
 
 def test_3_minimal():

--- a/tests/fw/test_r_swap.py
+++ b/tests/fw/test_r_swap.py
@@ -4,12 +4,14 @@ Test suite for ReactiveForwarder focused on swapping.
 
 from collections import defaultdict
 
+import pytest
+
 from mqns.entity.cchannel import ClassicCommandDispatcherMixin, ClassicPacket, RecvClassicPacket, classic_cmd_handler
-from mqns.entity.timer import Timer
 from mqns.network.fw import RoutingController, RoutingPathStatic
 from mqns.network.network import TimingModeSync
 from mqns.network.reactive import ReactiveForwarder, ReactiveRoutingController
 from mqns.network.reactive.message import LinkStateEntry, LinkStateMsg
+from mqns.simulator import func_to_event
 
 from .fw_common import build_linear_network, build_tree_network, print_fw_counters, provide_entanglements
 
@@ -51,8 +53,7 @@ def test_tree2_one():
         assert len(ctrl.ls_entries) == 8
         ctrl.install_path(RoutingPathStatic(["n4", "n2", "n1", "n3", "n6"], swap=[2, 0, 1, 0, 2]))
 
-    timer = Timer("do_routing", 0.0065, trigger_func=do_routing)
-    timer.install(simulator)
+    simulator.add_event(func_to_event(simulator.time(sec=0.0065), do_routing))
 
     provide_entanglements(
         (0.0011, f4, f2),
@@ -119,8 +120,7 @@ def test_tree2_two():
             )
         )
 
-    timer = Timer("do_routing", 0.0065, trigger_func=do_routing)
-    timer.install(simulator)
+    simulator.add_event(func_to_event(simulator.time(sec=0.0065), do_routing))
 
     provide_entanglements(
         (0.0011, f4, f2),
@@ -139,25 +139,50 @@ def test_tree2_two():
     assert f5.cnt.n_consumed == 1
 
 
-def test_3_minimal():
-    """Test 3-node minimal swap."""
-    net, simulator = build_linear_network(3, mode="R", ps=1.0, timing=TimingModeSync(t_ext=0.006, t_rtg=0.001, t_int=0.003))
+@pytest.mark.parametrize(
+    ("req_active", "etg12", "etg23", "cnt"),
+    [
+        # Request is active in both slots, EPRs arrive in first slot, request satisfied.
+        ((0, 0.020), [0.001], [0.002], (3, 1)),
+        # Request is active in both slots, EPRs arrive in second slot, request satisfied.
+        ((0, 0.020), [0.011], [0.012], (3, 1)),
+        # Request is active in both slots, EPRs arrive in both slots, request satisfied twice.
+        ((0, 0.020), [0.001, 0.011], [0.002, 0.012], (6, 2)),
+        # Request is active in both slots, EPRs arrive in separate slots, request unsatisfied.
+        ((0, 0.020), [0.001], [0.012], (4, 0)),
+        # Request is active in first slot, EPRs arrive in second slot, request unsatisfied.
+        ((0, 0.010), [0.011], [0.012], (3, 0)),
+        # Request is active in first slot, EPRs arrive twice in first slot, request satisfied twice.
+        ((0, 0.010), [0.001, 0.003], [0.002, 0.004], (3, 2)),
+    ],
+)
+def test_3_minimal(req_active: tuple[float, float], etg12: list[float], etg23: list[float], cnt: tuple[int, int]):
+    """Test 3-node minimal swap, two time slots."""
+    net, simulator = build_linear_network(
+        3,
+        qchannel_capacity=2,
+        mode="R",
+        ps=1.0,
+        end_time=0.020,
+        timing=TimingModeSync(t_ext=0.006, t_rtg=0.001, t_int=0.003),
+    )
     ctrl = net.get_controller().get_app(ReactiveRoutingController)
     f1 = net.get_node("n1").get_app(ReactiveForwarder)
     f2 = net.get_node("n2").get_app(ReactiveForwarder)
     f3 = net.get_node("n3").get_app(ReactiveForwarder)
 
+    simulator.add_event(func_to_event(simulator.time(sec=req_active[0]), lambda: net.add_request(f1.node, f3.node)))
+    simulator.add_event(func_to_event(simulator.time(sec=req_active[1]), net.requests.clear))
     provide_entanglements(
-        (1.001, f1, f2),
-        (1.002, f2, f3),
+        *((t, f1, f2) for t in etg12),
+        *((t, f2, f3) for t in etg23),
     )
     simulator.run()
     print(ctrl.cnt)
     print_fw_counters(net)
 
-    assert ctrl.cnt.n_ls == 3
-    assert ctrl.cnt.n_decision == 1
-    assert f1.cnt.n_consumed == 1
+    assert (ctrl.cnt.n_ls, ctrl.cnt.n_satisfy) == cnt
+    assert f1.cnt.n_consumed == cnt[1]
     assert f2.cnt.n_consumed == 0
-    assert f3.cnt.n_consumed == 1
-    assert f2.cnt.n_swapped == 1
+    assert f3.cnt.n_consumed == cnt[1]
+    assert f2.cnt.n_swapped == cnt[1]

--- a/tests/fw/test_r_swap.py
+++ b/tests/fw/test_r_swap.py
@@ -2,6 +2,8 @@
 Test suite for ReactiveForwarder focused on swapping.
 """
 
+from collections import defaultdict
+
 from mqns.entity.cchannel import ClassicCommandDispatcherMixin, ClassicPacket, RecvClassicPacket, classic_cmd_handler
 from mqns.entity.timer import Timer
 from mqns.network.fw import RoutingController, RoutingPathStatic
@@ -87,8 +89,35 @@ def test_tree2_two():
     def do_routing():
         assert len(ctrl.ls_pkts) == 7
         assert len(ctrl.ls_entries) == 16
-        ctrl.install_path(RoutingPathStatic(["n4", "n2", "n1", "n3", "n6"], swap=[2, 0, 1, 0, 2], m_v=[(1, 1)] * 4))
-        ctrl.install_path(RoutingPathStatic(["n5", "n2", "n1", "n3", "n7"], swap=[2, 0, 1, 0, 2], m_v=[(1, 1)] * 4))
+
+        qubits_by_channel = defaultdict[str, list[str]](lambda: [])
+        for entry in ctrl.ls_entries:
+            qubits_by_channel[f"{entry['node']}{entry['neighbor']}"].append(entry["qubit"])
+
+        ctrl.install_path(
+            RoutingPathStatic(
+                ["n4", "n2", "n1", "n3", "n6"],
+                swap=[2, 0, 1, 0, 2],
+                m_v=[
+                    qubits_by_channel["n4n2"].pop(),
+                    qubits_by_channel["n2n1"].pop(),
+                    qubits_by_channel["n1n3"].pop(),
+                    qubits_by_channel["n3n6"].pop(),
+                ],
+            )
+        )
+        ctrl.install_path(
+            RoutingPathStatic(
+                ["n5", "n2", "n1", "n3", "n7"],
+                swap=[2, 0, 1, 0, 2],
+                m_v=[
+                    qubits_by_channel["n5n2"].pop(),
+                    qubits_by_channel["n2n1"].pop(),
+                    qubits_by_channel["n1n3"].pop(),
+                    qubits_by_channel["n3n7"].pop(),
+                ],
+            )
+        )
 
     timer = Timer("do_routing", 0.0065, trigger_func=do_routing)
     timer.install(simulator)

--- a/tests/network/test_network.py
+++ b/tests/network/test_network.py
@@ -7,13 +7,18 @@ from mqns.simulator import Simulator
 class SyncCheckApp(Application[Node]):
     def __init__(self):
         super().__init__()
-        self.changes = 0
+        self.enters = 0
+        self.exits = 0
         self.add_handler(self.handle_sync_signal, TimingPhaseEvent)
 
     def handle_sync_signal(self, event: TimingPhaseEvent):
         t = self.simulator.tc.sec
-        assert (t % 5 == 0 and event.phase == TimingPhase.EXTERNAL) or (t % 5 == 4 and event.phase == TimingPhase.INTERNAL)
-        self.changes += 1
+        if event.enter:
+            assert (t % 5 == 0 and event.phase is TimingPhase.EXTERNAL) or (t % 5 == 4 and event.phase is TimingPhase.INTERNAL)
+            self.enters += 1
+        else:
+            assert (t % 5 == 0 and event.phase is TimingPhase.INTERNAL) or (t % 5 == 4 and event.phase is TimingPhase.EXTERNAL)
+            self.exits += 1
 
 
 def test_timing_mode_sync():
@@ -26,4 +31,5 @@ def test_timing_mode_sync():
 
     for node in net.nodes + [net.get_controller()]:
         app = node.get_app(SyncCheckApp)
-        assert app.changes == 12
+        assert app.enters == 12
+        assert app.exits == 11

--- a/tests/network/test_network.py
+++ b/tests/network/test_network.py
@@ -24,9 +24,14 @@ class SyncCheckApp(Application[Node]):
 def test_timing_mode_sync():
     topo = BasicTopology(2, nodes_apps=[SyncCheckApp()])
     topo.controller = Controller("ctrl", apps=[SyncCheckApp()])
-    net = QuantumNetwork(topo, timing=TimingModeSync(t_ext=4, t_int=1))
+    timing = TimingModeSync(t_ext=4, t_int=1)
+    net = QuantumNetwork(topo, timing=timing)
 
-    s = Simulator(0.0, 29.9, install_to=(net,))
+    s = Simulator(0.0, 29.9, accuracy=1000, install_to=(net,))
+    assert timing.t_ext.time_slot == 4000
+    assert timing.t_rtg.time_slot == 0
+    assert timing.t_int.time_slot == 1000
+
     s.run()
 
     for node in net.nodes + [net.get_controller()]:


### PR DESCRIPTION
closes #126

* Reactive LS message syntax and Multiplexing Vector syntax are revised so that each entangled qubit is identified by LinkLayer reservation key, which allows the controller to [assign a continuous sequence of qubits](https://github.com/usnistgov/mqns/issues/126#issuecomment-4180028939) that satisfies an end-to-end request.
  Note that [`epr.name` may contain hidden information](https://github.com/usnistgov/mqns/issues/92#issuecomment-4090762959) and cannot be used here.
* `TimingModeSync` is now tracking durations as `Time` type instead of `float` seconds.
  Its phase durations are exposed as attributes.
* In most examples, `--mode P` and `--mode R` are renamed to `--mode PCA` and `--mode RCS`.
  The three letters indicate Proactive/Reactive, Centralized/Distributed, Async/Sync-timing.
  Some examples also have a `--sync_timing` flag to specify phase durations.
* `ClassicConnector` NATS message subjects are changed to distinguish **O**utbound (Python to external) and **I**nbound (external to Python) messages.
* `ClassicConnector` gate logic is revised so that external program cannot run faster than Python simulation.
* The Rust program in `extctrl` example now supports reactive routing, where it attempts to satisfy each enabled path if EPRs are available on every link.
* `ReactiveRoutingController` implements the same logic as the Rust program, using `QuantumNetwork.requests` list to determine current demand.