### PR TITLE
fw: swap_delay and swap_error

### DIFF
--- a/examples/3_nodes_wait.py
+++ b/examples/3_nodes_wait.py
@@ -15,7 +15,7 @@ from tap import Tap
 
 from mqns.entity.base_channel import default_light_speed
 from mqns.models.error import TimeDecayInput
-from mqns.models.error.input import ErrorModelInputLength
+from mqns.models.error.input import ErrorModelInputBasic, ErrorModelInputLength
 from mqns.network.builder import CTRL_DELAY, EprTypeLiteral, LinkArchLiteral, NetworkBuilder, tap_configure
 from mqns.network.fw import CutoffSchemeWaitTime
 from mqns.network.proactive import ProactiveForwarder
@@ -39,6 +39,9 @@ class Args(Tap):
     link_arch: LinkArchLiteral  # link architecture
     link_arch_sim: bool = False  # determine fidelity with LinkArch mini simulation
     fiber_error: ErrorModelInputLength = "DEPOLAR:0.01"  # fiber error model with decoherence rate
+    bsa_error: ErrorModelInputBasic = "PERFECT"  # photonic Bell-state analyzer or absorptive memory capture error model
+    swap_delay: float = 0.0  # forwarder Bell-state analyzer delay
+    swap_error: ErrorModelInputBasic = "PERFECT"  # forwarder Bell-state analyzer error model
     csv: str = ""  # save stats as CSV file
     json: str = ""  # save stats and details as JSON file
     plt: str = ""  # save plot as image file
@@ -66,10 +69,14 @@ def run_simulation(seed: int, args: Args, t_cohere: float, t_wait: float):
             memory_decay=args.memory_decay,
             channel_length=args.L,
             fiber_error=args.fiber_error,
+            bsa_error=args.bsa_error,
             link_arch=args.link_arch,
             init_fidelity=None if args.link_arch_sim else 0.99,
         )
-        .proactive_centralized()
+        .proactive_centralized(
+            swap_delay=args.swap_delay,
+            swap_error=args.swap_error,
+        )
         .request(
             "S-D",
             swap=[1, 0, 1],

--- a/examples/scalability_randomtopo/srt_detail/defs.py
+++ b/examples/scalability_randomtopo/srt_detail/defs.py
@@ -111,7 +111,7 @@ def build_network(args: RunArgs) -> QuantumNetwork:
                 eta_s=eta_s,
                 frequency=frequency,
             ),
-            ProactiveForwarder(ps=p_swap, mux=MuxSchemeStatistical()),
+            ProactiveForwarder(p_swap=p_swap, mux=MuxSchemeStatistical()),
         ],
     )
     topo.controller = Controller("ctrl", apps=[ProactiveRoutingController()])

--- a/examples/template_linear.py
+++ b/examples/template_linear.py
@@ -119,7 +119,7 @@ FREQUENCY = 1e6  # entanglement source / memory frequency
 SWAP: SwapSequenceInput = "l2r"
 
 # p_swap:
-#   - Swapping success probability used by ProactiveForwarder(ps=p_swap)
+#   - Swapping success probability used by ProactiveForwarder(p_swap=p_swap)
 P_SWAP = 0.5
 
 

--- a/examples/template_linear.py
+++ b/examples/template_linear.py
@@ -178,9 +178,10 @@ def run_simulation(
             eta_d=ETA_D,
             eta_s=ETA_S,
             frequency=FREQUENCY,
+        )
+        .proactive_centralized(
             p_swap=P_SWAP,
         )
-        .proactive_centralized()
         .request("S-D", swap=swap)
         .make_network()
     )

--- a/examples/template_routing.py
+++ b/examples/template_routing.py
@@ -275,11 +275,13 @@ def build_network(route_algo: Any, t_cohere: float) -> QuantumNetwork:
         entg_attempt_rate=ENTG_ATTEMPT_RATE,
         frequency=MEMORY_FREQUENCY,
         init_fidelity=INIT_FIDELITY,
-        p_swap=P_SWAP,
         t_cohere=t_cohere,
     )
 
-    b.proactive_centralized(mux=SC.mux)
+    b.proactive_centralized(
+        p_swap=P_SWAP,
+        mux=SC.mux,
+    )
 
     for flow in SC.install_paths:
         b.request(flow)

--- a/examples/vora_evaluation.py
+++ b/examples/vora_evaluation.py
@@ -51,7 +51,7 @@ import pandas as pd
 from tap import Tap
 
 from mqns.network.builder import CTRL_DELAY, NetworkBuilder
-from mqns.network.fw import SwapPolicy, SwapSequenceInput
+from mqns.network.fw import SwapPolicy, SwapSequence, SwapSequenceInput
 from mqns.network.network import QuantumNetwork
 from mqns.network.proactive import ProactiveForwarder, compute_vora_swap_sequence
 from mqns.network.protocol.link_layer import LinkLayerCounters
@@ -169,7 +169,7 @@ def vora_train_row(p: ParameterSet, num_routers: int, dist_prop: str) -> str:
     return f"python linear_attempts.py --runs {p.n_runs} --L {L} --M 1 --csv $OUTDIR/{filename}"
 
 
-def vora_regen_row(p: ParameterSet, num_routers: int, dist_prop: str, indir: str) -> list[int]:
+def vora_regen_row(p: ParameterSet, num_routers: int, dist_prop: str, indir: str) -> SwapSequence:
     """
     Regenerate vora swapping order from the output of linear_attempts.py.
     """

--- a/mqns/entity/memory/memory_qubit.py
+++ b/mqns/entity/memory/memory_qubit.py
@@ -69,6 +69,11 @@ class QubitState(Enum):
 
     This state is set on the qubit only if own node has a swapping rank no less than the other node in the entanglement.
     """
+    SWAPPING = auto()
+    """
+    The forwarder is performing local swapping between this and another memory qubit.
+    If the qubit is released from this state, the local swapping would be aborted.
+    """
     RELEASE = auto()
     """
     Qubit is not used by the forwarder.
@@ -84,7 +89,8 @@ ALLOWED_STATE_TRANSITIONS: dict[QubitState, tuple[QubitState, ...]] = {
     QubitState.ENTANGLED1: (QubitState.RELEASE, QubitState.PURIF),
     QubitState.PURIF: (QubitState.RELEASE, QubitState.PENDING, QubitState.ELIGIBLE),
     QubitState.PENDING: (QubitState.RELEASE, QubitState.PURIF),
-    QubitState.ELIGIBLE: (QubitState.RELEASE,),
+    QubitState.ELIGIBLE: (QubitState.SWAPPING, QubitState.RELEASE),
+    QubitState.SWAPPING: (QubitState.RELEASE,),
     QubitState.RELEASE: (QubitState.RAW,),
 }
 
@@ -185,5 +191,5 @@ def _describe(mq: MemoryQubit) -> Iterable[str]:
     match mq._state:
         case QubitState.ACTIVE | QubitState.RESERVED:
             yield f"active={mq.active}"
-        case QubitState.PURIF | QubitState.PENDING | QubitState.ELIGIBLE:
+        case QubitState.PURIF | QubitState.PENDING | QubitState.ELIGIBLE | QubitState.SWAPPING:
             yield f"purif_rounds={mq.purif_rounds}"

--- a/mqns/entity/memory/memory_qubit.py
+++ b/mqns/entity/memory/memory_qubit.py
@@ -140,7 +140,7 @@ class MemoryQubit:
         if value not in ALLOWED_STATE_TRANSITIONS[self._state]:
             raise ValueError(f"MemoryQubit: unexpected state transition from <{self._state}> to <{value}>; {self}")
         self._state = value
-        if value == QubitState.RELEASE:
+        if value is QubitState.RELEASE:
             self._clear_events()
 
     def reset_state(self) -> None:

--- a/mqns/entity/qchannel/link_arch.py
+++ b/mqns/entity/qchannel/link_arch.py
@@ -6,8 +6,7 @@ from typing import NotRequired, Protocol, TypedDict, Unpack, override
 from mqns.entity.node import QNode
 from mqns.models.delay import DelayModel
 from mqns.models.epr import Entanglement, EntanglementInitKwargs, MixedStateEntanglement, WernerStateEntanglement
-from mqns.models.error import DepolarErrorModel, ErrorModel, TimeDecayFunc, time_decay_nop
-from mqns.models.error.input import ErrorModelInputBasic, parse_error
+from mqns.models.error import ErrorModel, TimeDecayFunc, time_decay_nop
 from mqns.simulator import Time
 
 type MakeEprFunc = Callable[[EntanglementInitKwargs], Entanglement]
@@ -32,6 +31,11 @@ class ChannelParameters(Protocol):
 
     If the LinkArch subclass needs to apply transfer error at a different length,
     it will clone the instance and adjust the length while preserving the decoherence rate.
+    """
+    bsa_error: ErrorModel
+    """
+    Bell-state analyzer or absorptive memory capture error model.
+    This is only used if ``init_fidelity`` is omitted or negative.
     """
 
 
@@ -70,11 +74,6 @@ class LinkArchParameters(TypedDict):
 
     Current limitation: if a qchannel is activated in two paths with opposite directions,
     and the two memories have different error models, the calculations would be incorrect.
-    """
-    bsa_error: NotRequired[ErrorModelInputBasic]
-    """
-    Bell-state analyzer or absorptive memory capture error model, defaults to perfect.
-    This is only used if ``init_fidelity`` is omitted.
     """
 
 
@@ -219,7 +218,7 @@ class LinkArchBase(ABC, LinkArch):
             store_dst=se1,
             transfer_full=ch.transfer_error,
             transfer_half=copy.deepcopy(ch.transfer_error).set(length=ch.length / 2),
-            bsa=parse_error(d.get("bsa_error"), DepolarErrorModel, -1),
+            bsa=ch.bsa_error,
         )
         assert type(epr) is epr_type
 

--- a/mqns/entity/qchannel/link_arch_dim.py
+++ b/mqns/entity/qchannel/link_arch_dim.py
@@ -72,10 +72,9 @@ class LinkArchDimBk(LinkArchBase):
         # so that both EPRs are subject to transfer errors.
         e0.apply_error(transfer_half)
         e1.apply_error(transfer_half)
-        e2 = Entanglement.swap(e0, e1, now=tc)
+        e2, local_success = Entanglement.swap(e0, e1, now=tc, error=bsa)
+        assert local_success is True
         del e0, e1
-        assert e2 is not None
-        e2.apply_error(bsa)
 
         # In round-2, physically each of A and B generates a memory-photo EPR that collects noise
         # and then swaps with e2, but this is equivalent to applying noise onto e2 directly.
@@ -182,9 +181,8 @@ class LinkArchDimDual(LinkArchBase):
         tc += tau_0 + tau_l2
         e0.apply_error(transfer_half)
         e1.apply_error(transfer_half)
-        e2 = Entanglement.swap(e0, e1, now=tc)
+        e2, local_success = Entanglement.swap(e0, e1, now=tc, error=bsa)
+        assert local_success is True
         del e0, e1
-        assert e2 is not None
-        e2.apply_error(bsa)
 
         return e2

--- a/mqns/entity/qchannel/qchannel.py
+++ b/mqns/entity/qchannel/qchannel.py
@@ -35,7 +35,7 @@ from mqns.entity.qchannel.link_arch_dim import LinkArchDimBkSeq
 from mqns.models.core import QuantumModel
 from mqns.models.epr import Entanglement
 from mqns.models.error import DepolarErrorModel
-from mqns.models.error.input import ErrorModelInputLength, parse_error
+from mqns.models.error.input import ErrorModelInputBasic, ErrorModelInputLength, parse_error
 from mqns.simulator import Event, Time
 
 
@@ -55,6 +55,13 @@ class QuantumChannelInitKwargs(BaseChannelInitKwargs, total=False):
     transfer_error: ErrorModelInputLength
     """
     Transfer error model for loss of quantum information.
+
+    In ``LinkArch``, this parameter determines the decoherence / quality of the state
+    given the photon arrived, but does not affect the success probability.
+    """
+    bsa_error: ErrorModelInputBasic
+    """
+    Bell-state analyzer or absorptive memory capture error model, defaults to perfect.
 
     In ``LinkArch``, this parameter determines the decoherence / quality of the state
     given the photon arrived, but does not affect the success probability.
@@ -89,6 +96,11 @@ class QuantumChannel(BaseChannel[QNode]):
 
         It reflects loss of quantum information when a qubit/EPR is sent through the fiber.
         It does not reflect loss of photons.
+        """
+
+        self.bsa_error = parse_error(kwargs.get("bsa_error"), DepolarErrorModel, -1)
+        """
+        Bell-state analyzer or absorptive memory capture (depending on link architecture) error model.
         """
 
     @override

--- a/mqns/models/epr/entanglement.py
+++ b/mqns/models/epr/entanglement.py
@@ -182,26 +182,16 @@ class Entanglement(QuantumModel):
         assert type(epr0) is type(epr1)
         assert epr0.dst == epr1.src  # it's okay for src and dst to be None
 
-        if epr0.is_decohered or epr1.is_decohered:
-            # XXX setting .is_decohered may leak information faster-than-light
-            epr0.is_decohered = True
-            epr1.is_decohered = True
-            return None
-
         if ps < 1.0 and rng.random() >= ps:  # swap failed
-            # XXX setting .is_decohered may leak information faster-than-light
-            epr0.is_decohered = True
-            epr1.is_decohered = True
             return None
 
         orig_eprs: list[E] = []
         for epr in (epr0, epr1):
             epr.apply_store_decays(now)
-
-            if epr.ch_index > -1:
-                orig_eprs.append(epr)
+            if epr.orig_eprs:
+                orig_eprs.extend(cast(list[E], epr.orig_eprs))
             else:
-                orig_eprs.extend(cast(list[E], epr.orig_eprs or []))
+                orig_eprs.append(epr)
 
         orig_names = "-".join((e.name for e in orig_eprs))
         name = hashlib.sha256(orig_names.encode()).hexdigest()[:32]  # same length as `uuid.uuid4().hex`
@@ -219,6 +209,7 @@ class Entanglement(QuantumModel):
             ),
         )
         ne.orig_eprs = orig_eprs
+        ne.is_decohered = epr0.is_decohered or epr1.is_decohered
         return ne
 
     @staticmethod
@@ -247,8 +238,6 @@ class Entanglement(QuantumModel):
         assert (self.src, self.dst) == (epr1.src, epr1.dst)  # it's okay for src and dst to be None
 
         if self.is_decohered or epr1.is_decohered:
-            self.is_decohered = True
-            epr1.is_decohered = True
             return False
 
         _ = now

--- a/mqns/models/epr/entanglement.py
+++ b/mqns/models/epr/entanglement.py
@@ -36,7 +36,7 @@ import numpy as np
 from mqns.models.core import QuantumModel
 from mqns.models.core.operator import OPERATOR_PAULI_I, Operator
 from mqns.models.core.state import QUBIT_STATE_P, QubitRho, build_qubit_state, qubit_state_to_rho
-from mqns.models.error import TimeDecayFunc, time_decay_nop
+from mqns.models.error import ErrorModel, PerfectErrorModel, TimeDecayFunc, time_decay_nop
 from mqns.models.qubit import QState, Qubit
 from mqns.models.qubit.gate import CNOT, H, U, X, Y, Z
 from mqns.simulator import Time
@@ -165,25 +165,25 @@ class Entanglement(QuantumModel):
         *,
         now: Time,
         ps=1.0,
-    ) -> E | None:
+        error: ErrorModel = PerfectErrorModel(),
+    ) -> tuple[E, bool]:
         """
         Perform swapping between ``epr0`` and ``epr1``, and distribute a new entanglement.
 
         Args:
-            epr0: left entanglement.
-            epr1: right entanglement.
-            now: current timestamp.
-            ps: probability of successful swapping.
+            epr0: Left entanglement.
+            epr1: Right entanglement.
+            now: Current timestamp.
+            ps: Probability of successful swapping.
+            error: BSA error model.
 
         Returns:
-            New entanglement, or None if swap failed.
+            [0]: New entanglement.
+            [1]: Whether success from local point of view.
         """
 
         assert type(epr0) is type(epr1)
         assert epr0.dst == epr1.src  # it's okay for src and dst to be None
-
-        if ps < 1.0 and rng.random() >= ps:  # swap failed
-            return None
 
         orig_eprs: list[E] = []
         for epr in (epr0, epr1):
@@ -209,8 +209,12 @@ class Entanglement(QuantumModel):
             ),
         )
         ne.orig_eprs = orig_eprs
-        ne.is_decohered = epr0.is_decohered or epr1.is_decohered
-        return ne
+
+        local_failure = ps < 1.0 and rng.random() >= ps
+        ne.is_decohered = epr0.is_decohered or epr1.is_decohered or local_failure
+        if not ne.is_decohered:
+            ne.apply_error(error)
+        return ne, not local_failure
 
     @staticmethod
     @abstractmethod

--- a/mqns/network/builder.py
+++ b/mqns/network/builder.py
@@ -18,7 +18,7 @@ from mqns.models.epr import Entanglement, MixedStateEntanglement, WernerStateEnt
 from mqns.models.error import TimeDecayInput
 from mqns.models.error.input import ErrorModelInputBasic, ErrorModelInputLength, ErrorModelInputTime
 from mqns.network.fw import (
-    MuxScheme,
+    ForwarderInitKwargs,
     MuxSchemeBufferSpace,
     QubitAllocationType,
     RoutingPath,
@@ -136,8 +136,6 @@ class TopoCommonArgs(TypedDict, total=False):
     """Source efficiency, defaults to ``0.95``."""
     frequency: float
     """Entanglement source frequency, defaults to ``1_000_000``."""
-    p_swap: float
-    """Probability of successful entanglement swapping in forwarder, defaults to ``0.5``."""
 
 
 class AppsCommonArgs(TypedDict, total=False):
@@ -145,6 +143,15 @@ class AppsCommonArgs(TypedDict, total=False):
     """
     Network timing mode, defaults to ASYNC.
     If specified as three floats, construct ``TimingModeSync`` with these durations.
+    """
+
+
+class AppsForwarderArgs(AppsCommonArgs, ForwarderInitKwargs):
+    """
+    Combination of AppsCommonArgs and ForwarderInitKwargs.
+
+    Args:
+        p_swap: Probability of successful entanglement swapping in forwarder, defaults to ``0.5``.
     """
 
 
@@ -219,7 +226,6 @@ class NetworkBuilder:
         self.eta_d = d.get("eta_d", 0.95)
         self.eta_s = d.get("eta_s", 0.95)
         self.frequency = d.get("frequency", 1e6)
-        self.p_swap = d.get("p_swap", 0.5)
 
     def _add_qnode(self, name: str, mem_cap: int) -> TopoQNode:
         node: TopoQNode = {
@@ -238,6 +244,7 @@ class NetworkBuilder:
         length: float,
         fiber_alpha: float,
         fiber_error: ErrorModelInputLength,
+        bsa_error: ErrorModelInputBasic,
         la: LinkArchDef,
     ):
         self.qchannels.append(
@@ -248,9 +255,10 @@ class NetworkBuilder:
                 "capacity2": cap2,
                 "parameters": {
                     "length": length,
+                    "link_arch": _convert_link_arch(la),
                     "alpha": fiber_alpha,
                     "transfer_error": fiber_error,
-                    "link_arch": _convert_link_arch(la),
+                    "bsa_error": bsa_error,
                 },
             }
         )
@@ -263,6 +271,7 @@ class NetworkBuilder:
         channel_capacity: int = 1,
         fiber_alpha: float = 0.2,
         fiber_error: ErrorModelInputLength = "DEPOLAR:0.01",
+        bsa_error: ErrorModelInputBasic = "PERFECT",
         link_arch: LinkArchDef | Sequence[LinkArchDef] = LinkArchDimBkSeq,
         **kwargs: Unpack[TopoCommonArgs],
     ) -> Self:
@@ -281,7 +290,9 @@ class NetworkBuilder:
                 for each qchannel, an integer applies to both sides, a tuple applies to (left,right) sides.
             channel_capacity: Qubit allocation per qchannel, if not specified in ``channels``.
             fiber_alpha: Fiber loss in dB/km, determines success probability.
-            fiber_rate: Fiber decoherence rate in km^{-1}, determines qualify of entangled state.
+            fiber_error: Fiber error model, determines qualify of entangled state.
+            bsa_error: Photonic Bell-state analyzer or absorptive memory capture error model,
+                       determines qualify of entangled state.
             link_arch: Link architecture per qchannel.
                 If specified as list, it must have same length as ``channel_length``.
                 If specified as instance/type/string, it is broadcast to all qchannels.
@@ -321,7 +332,7 @@ class NetworkBuilder:
             cap1, cap2 = _split_channel_capacity(opt_cap[0] if len(opt_cap) > 0 else channel_capacity)
             ensure_node(node1, cap1)
             ensure_node(node2, cap2)
-            self._add_qchannel(node1, node2, cap1, cap2, length, fiber_alpha, fiber_error, la)
+            self._add_qchannel(node1, node2, cap1, cap2, length, fiber_alpha, fiber_error, bsa_error, la)
 
         return self
 
@@ -334,6 +345,7 @@ class NetworkBuilder:
         channel_capacity: int | Sequence[int | tuple[int, int]] = 1,
         fiber_alpha: float = 0.2,
         fiber_error: ErrorModelInputLength = "DEPOLAR:0.01",
+        bsa_error: ErrorModelInputBasic = "PERFECT",
         link_arch: LinkArchDef | Sequence[LinkArchDef] = LinkArchDimBkSeq,
         **kwargs: Unpack[TopoCommonArgs],
     ) -> Self:
@@ -356,7 +368,9 @@ class NetworkBuilder:
                 If specified as number, it is broadcast to all qchannels.
                 For each qchannel, an integer applies to both sides, a tuple applies to (left,right) sides.
             fiber_alpha: Fiber loss in dB/km, determines success probability.
-            fiber_rate: Fiber decoherence rate in km^{-1}, determines qualify of entangled state.
+            fiber_error: Fiber error model, determines qualify of entangled state.
+            bsa_error: Photonic Bell-state analyzer or absorptive memory capture error model,
+                       determines qualify of entangled state.
             link_arch: Link architecture per qchannel.
                 If specified as list, it must have same length as ``channel_length``.
                 If specified as instance/type/string, it is broadcast to all qchannels.
@@ -394,7 +408,7 @@ class NetworkBuilder:
         for i, (length, caps, la) in enumerate(zip(channel_length, channel_capacity, link_arch, strict=True)):
             node1, node2 = nodes[i], nodes[i + 1]
             cap1, cap2 = _split_channel_capacity(caps)
-            self._add_qchannel(node1, node2, cap1, cap2, length, fiber_alpha, fiber_error, la)
+            self._add_qchannel(node1, node2, cap1, cap2, length, fiber_alpha, fiber_error, bsa_error, la)
 
         return self
 
@@ -404,8 +418,8 @@ class NetworkBuilder:
         if len(self.qnode_apps) + len(self.controller_apps) > 0:
             raise TypeError("applications already installed")
 
-    def _parse_apps_args(self, d: AppsCommonArgs) -> None:
-        timing = d.get("timing")
+    def _extract_apps_common_args(self, d: AppsCommonArgs) -> None:
+        timing = d.pop("timing", None)
         if isinstance(timing, TimingMode):
             self.timing = timing
         elif timing is None:
@@ -428,9 +442,7 @@ class NetworkBuilder:
 
     def proactive_centralized(
         self,
-        *,
-        mux: MuxScheme | None = None,
-        **kwargs: Unpack[AppsCommonArgs],
+        **kwargs: Unpack[AppsForwarderArgs],
     ) -> Self:
         """
         Choose proactive forwarding with centralized control.
@@ -439,8 +451,10 @@ class NetworkBuilder:
             mux: Multiplexing scheme, default is buffer-space.
         """
         self._assert_can_add_apps()
-        self._parse_apps_args(kwargs)
+        self._extract_apps_common_args(kwargs)
+        kwargs.setdefault("p_swap", 0.5)
 
+        mux = kwargs.get("mux")
         if mux is None or isinstance(mux, MuxSchemeBufferSpace):
             self.qubit_allocation = QubitAllocationType.FOLLOW_QCHANNEL
         elif isinstance(self.route, YenRouteAlgorithm):
@@ -448,10 +462,7 @@ class NetworkBuilder:
 
         self._add_link_layer()
         self.qnode_apps.append(
-            ProactiveForwarder(
-                p_swap=self.p_swap,
-                mux=mux,
-            )
+            ProactiveForwarder(**kwargs),
         )
         self.controller_apps.append(
             ProactiveRoutingController(),
@@ -465,9 +476,8 @@ class NetworkBuilder:
     def reactive_centralized(
         self,
         *,
-        mux: MuxScheme | None = None,
         swap: SwapPolicy = "asap",
-        **kwargs: Unpack[AppsCommonArgs],
+        **kwargs: Unpack[AppsForwarderArgs],
     ) -> Self:
         """
         Choose reactive forwarding with centralized control.
@@ -479,14 +489,12 @@ class NetworkBuilder:
         ``.request()`` method only accepts src-dst nodes, but does not support ``RoutingPath``.
         """
         self._assert_can_add_apps()
-        self._parse_apps_args(kwargs)
+        self._extract_apps_common_args(kwargs)
+        kwargs.setdefault("p_swap", 0.5)
 
         self._add_link_layer()
         self.qnode_apps.append(
-            ReactiveForwarder(
-                p_swap=self.p_swap,
-                mux=mux,
-            ),
+            ReactiveForwarder(**kwargs),
         )
         self.controller_apps.append(
             ReactiveRoutingController(swap=swap),

--- a/mqns/network/builder.py
+++ b/mqns/network/builder.py
@@ -449,7 +449,7 @@ class NetworkBuilder:
         self._add_link_layer()
         self.qnode_apps.append(
             ProactiveForwarder(
-                ps=self.p_swap,
+                p_swap=self.p_swap,
                 mux=mux,
             )
         )
@@ -484,7 +484,7 @@ class NetworkBuilder:
         self._add_link_layer()
         self.qnode_apps.append(
             ReactiveForwarder(
-                ps=self.p_swap,
+                p_swap=self.p_swap,
                 mux=mux,
             ),
         )

--- a/mqns/network/fw/__init__.py
+++ b/mqns/network/fw/__init__.py
@@ -1,7 +1,7 @@
 from mqns.network.fw.controller import RoutingController
 from mqns.network.fw.cutoff import CutoffScheme, CutoffSchemeWaitTime, CutoffSchemeWaitTimeCounters
 from mqns.network.fw.fib import Fib, FibEntry
-from mqns.network.fw.forwarder import Forwarder, ForwarderCounters
+from mqns.network.fw.forwarder import Forwarder, ForwarderCounters, ForwarderInitKwargs
 from mqns.network.fw.fw_classic import fw_control_cmd_handler, fw_signaling_cmd_handler
 from mqns.network.fw.message import MultiplexingVector, SwapSequence
 from mqns.network.fw.mux import MuxScheme
@@ -32,6 +32,7 @@ __all__ = [
     "FibEntry",
     "Forwarder",
     "ForwarderCounters",
+    "ForwarderInitKwargs",
     "fw_control_cmd_handler",
     "fw_signaling_cmd_handler",
     "MemoryEprIterator",

--- a/mqns/network/fw/forwarder.py
+++ b/mqns/network/fw/forwarder.py
@@ -50,7 +50,7 @@ from mqns.utils import json_encodable, log
 
 
 class ForwarderInitKwargs(TypedDict, total=False):
-    ps: float
+    p_swap: float
     """Probability of successful entanglement swapping, default is 1.0."""
     swap_delay: DelayInput
     """Swapping delay model, default is zero."""
@@ -169,7 +169,7 @@ class Forwarder(ForwarderClassicMixin, Application[QNode]):
         """FIB structure."""
         self.purif = ForwarderPurifProc()
         self.swap = ForwarderSwapProc(
-            ps=kwargs.get("ps", 1.0),
+            ps=kwargs.get("p_swap", 1.0),
             delay=parse_delay(kwargs.get("swap_delay", 0)),
             error=parse_error(kwargs.get("swap_error"), PerfectErrorModel, -1),
         )

--- a/mqns/network/fw/forwarder.py
+++ b/mqns/network/fw/forwarder.py
@@ -357,7 +357,7 @@ class Forwarder(ForwarderClassicMixin, Application[QNode]):
         self.cnt.n_entg += 1
 
         qubit = event.qubit
-        assert qubit.state == QubitState.ENTANGLED1
+        assert qubit.state is QubitState.ENTANGLED1, f"unexpected state {qubit.state}"
         _, epr = self.memory.read(qubit.addr, has=self.epr_type)
         log.debug(f"{self.node}: ENTANGLED {qubit} | {epr}")
         self.mux.qubit_is_entangled(qubit, epr, event.neighbor)
@@ -379,7 +379,7 @@ class Forwarder(ForwarderClassicMixin, Application[QNode]):
             fib_entry: FIB entry containing routing and purification instructions.
             partner: The node with which the qubit shares an EPR.
         """
-        assert qubit.state == QubitState.PURIF
+        assert qubit.state is QubitState.PURIF, f"unexpected state {qubit.state}"
         assert qubit.qchannel is not None
 
         own_idx, own_rank = fib_entry.own_idx, fib_entry.own_swap_rank
@@ -411,7 +411,7 @@ class Forwarder(ForwarderClassicMixin, Application[QNode]):
         candidates = self.memory.find(
             lambda q, v: (
                 q.addr != qubit.addr  # not the same qubit
-                and q.state == QubitState.PURIF  # in PURIF state
+                and q.state is QubitState.PURIF  # in PURIF state
                 and q.purif_rounds == qubit.purif_rounds  # with same number of purif rounds
                 and partner in (v.src, v.dst)  # with the same partner
                 and q.path_id == fib_entry.path_id  # on the same path_id
@@ -441,7 +441,7 @@ class Forwarder(ForwarderClassicMixin, Application[QNode]):
             qubit: The qubit that became eligible.
             fib_entry: FIB entry (not available with MuxSchemeStatistical).
         """
-        assert qubit.state == QubitState.ELIGIBLE
+        assert qubit.state is QubitState.ELIGIBLE, f"unexpected state {qubit.state}"
         if not self.node.timing.is_internal():
             log.debug(f"{self.node}: INT phase is over -> stop swaps")
             return
@@ -455,7 +455,7 @@ class Forwarder(ForwarderClassicMixin, Application[QNode]):
 
         swap_candidates = self.memory.find(
             lambda q, _: (
-                q.state == QubitState.ELIGIBLE  # in ELIGIBLE state
+                q.state is QubitState.ELIGIBLE  # in ELIGIBLE state
                 and q.qchannel != qubit.qchannel  # assigned to a different channel
                 and self.cutoff.filter_swap_candidate(q)
             ),

--- a/mqns/network/fw/forwarder.py
+++ b/mqns/network/fw/forwarder.py
@@ -24,7 +24,10 @@ import numpy as np
 from mqns.entity.memory import MemoryQubit, PathDirection, QubitState
 from mqns.entity.node import Application, QNode
 from mqns.entity.qchannel import QuantumChannel
+from mqns.models.delay import DelayInput, parse_delay
 from mqns.models.epr import Entanglement
+from mqns.models.error import PerfectErrorModel
+from mqns.models.error.input import ErrorModelInputBasic, parse_error
 from mqns.network.fw.cutoff import CutoffScheme, CutoffSchemeWaitTime
 from mqns.network.fw.fib import Fib, FibEntry
 from mqns.network.fw.fw_classic import ForwarderClassicMixin, fw_control_cmd_handler, fw_signaling_cmd_handler
@@ -49,6 +52,10 @@ from mqns.utils import json_encodable, log
 class ForwarderInitKwargs(TypedDict, total=False):
     ps: float
     """Probability of successful entanglement swapping, default is 1.0."""
+    swap_delay: DelayInput
+    """Swapping delay model, default is zero."""
+    swap_error: ErrorModelInputBasic
+    """Swapping error model, default is perfect."""
     cutoff: CutoffScheme | None
     """EPR age cut-off scheme, default is wait-time."""
     mux: MuxScheme | None
@@ -161,7 +168,11 @@ class Forwarder(ForwarderClassicMixin, Application[QNode]):
         self.fib = Fib()
         """FIB structure."""
         self.purif = ForwarderPurifProc()
-        self.swap = ForwarderSwapProc(ps=kwargs.get("ps", 1.0))
+        self.swap = ForwarderSwapProc(
+            ps=kwargs.get("ps", 1.0),
+            delay=parse_delay(kwargs.get("swap_delay", 0)),
+            error=parse_error(kwargs.get("swap_error"), PerfectErrorModel, -1),
+        )
 
         self.add_handler(self.handle_sync_phase, TimingPhaseEvent)
         self.add_handler(self.qubit_is_entangled, QubitEntangledEvent)
@@ -202,7 +213,7 @@ class Forwarder(ForwarderClassicMixin, Application[QNode]):
 
         Upon exiting INTERNAL phase:
 
-        1. Clear ``remote_swapped_eprs``.
+        1. Clear ``self.swap.remote_swapped``.
            All memory qubits are being discarded by LinkLayer, so that these have become useless.
         """
         match event.action:
@@ -212,7 +223,7 @@ class Forwarder(ForwarderClassicMixin, Application[QNode]):
                     self.qubit_is_entangled(etg_event)
                 self.waiting_etg.clear()
             case TimingPhase.INTERNAL, False:
-                self.swap.remote_swapped_eprs.clear()
+                self.swap.remote_swapped.clear()
 
     @fw_control_cmd_handler("INSTALL_PATH")
     def handle_install_path(self, msg: InstallPathMsg):

--- a/mqns/network/fw/fw_purif.py
+++ b/mqns/network/fw/fw_purif.py
@@ -92,7 +92,7 @@ class ForwarderPurifProc:
         # TODO: handle the exception case when an EPR is decohered and not found in memory
 
         for mq in (mq0, mq1):
-            assert mq.state == QubitState.PURIF
+            assert mq.state is QubitState.PURIF, f"unexpected state {mq.state}"
             assert mq.purif_rounds == msg["round"]
 
         assert msg["partner"] == self.node.name

--- a/mqns/network/fw/fw_swap.py
+++ b/mqns/network/fw/fw_swap.py
@@ -114,17 +114,17 @@ class ForwarderSwapProc:
             next_epr.ch_index = fib_entry.own_idx
 
         # Attempt the swap.
-        new_epr = Entanglement.swap(prev_epr, next_epr, now=self.simulator.tc, ps=self.ps)
-        log.debug(f"{self.node}: SWAP {'SUCC' if new_epr else 'FAILED'} | {prev_qubit} x {next_qubit} = {new_epr}")
+        new_epr, local_success = Entanglement.swap(prev_epr, next_epr, now=self.simulator.tc, ps=self.ps)
+        log.debug(f"{self.node}: SWAP {'SUCC' if local_success else 'FAILED'} | {prev_qubit} x {next_qubit} = {new_epr}")
 
-        if new_epr is not None:  # swapping succeeded
+        if local_success:  # swapping succeeded
             self.fw.cnt.n_swapped_s += 1
 
             # Inform multiplexing scheme.
             self.mux.swapping_succeeded(prev_epr, next_epr, new_epr)
 
         for (a_partner, a_qubit, a_epr), (b_partner, _, b_epr) in ((prev_tuple, next_tuple), (next_tuple, prev_tuple)):
-            if new_epr is not None:
+            if local_success:
                 # Keep records to support potential parallel swapping.
                 _, a_rank = fib_entry.find_index_and_swap_rank(a_partner.name)
                 if fib_entry.own_swap_rank == a_rank:
@@ -140,7 +140,7 @@ class ForwarderSwapProc:
                 "swapping_node": self.node.name,
                 "partner": b_partner.name,
                 "epr": a_epr.name,
-                "new_epr": None if new_epr is None else new_epr.name,
+                "new_epr": new_epr.name if local_success else None,
             }
             self.fw.send_msg(a_partner, su_msg, fib_entry)
 
@@ -287,11 +287,11 @@ class ForwarderSwapProc:
         # Merge the two swaps (physically already happened).
         new_epr.read = True
         if other_epr.dst == self.node:  # destination is to the left of own node
-            merged_epr = Entanglement.swap(other_epr, new_epr, now=self.simulator.tc)
+            merged_epr, _ = Entanglement.swap(other_epr, new_epr, now=self.simulator.tc)
             partner = cast(QNode, new_epr.dst)
             destination = cast(QNode, other_epr.src)
         else:  # destination is to the right of own node
-            merged_epr = Entanglement.swap(new_epr, other_epr, now=self.simulator.tc)
+            merged_epr, _ = Entanglement.swap(new_epr, other_epr, now=self.simulator.tc)
             partner = cast(QNode, new_epr.src)
             destination = cast(QNode, other_epr.dst)
         assert partner.name == msg["partner"]

--- a/mqns/network/fw/fw_swap.py
+++ b/mqns/network/fw/fw_swap.py
@@ -77,8 +77,8 @@ class ForwarderSwapProc:
         Partners are notified with SWAP_UPDATE messages.
         """
         assert mq0.addr != mq1.addr
-        assert mq0.state == QubitState.ELIGIBLE
-        assert mq1.state == QubitState.ELIGIBLE
+        assert mq0.state is QubitState.ELIGIBLE, f"unexpected state {mq0.state}"
+        assert mq1.state is QubitState.ELIGIBLE, f"unexpected state {mq1.state}"
 
         # Read both qubits and remove them from memory.
         #
@@ -150,7 +150,7 @@ class ForwarderSwapProc:
     def pop_waiting_su(self, qubit: MemoryQubit):
         su_args = self.waiting_su.pop(qubit.addr, None)
         if (
-            qubit.state != QubitState.RELEASE  # qubit was released due to uninstalled path
+            qubit.state is not QubitState.RELEASE  # qubit was released due to uninstalled path
             and su_args
         ):
             self.handle_update(*su_args)
@@ -188,7 +188,7 @@ class ForwarderSwapProc:
         qubit_pair = self.memory.read(epr_name)
         if qubit_pair is not None:
             qubit, _ = qubit_pair
-            if qubit.state == QubitState.ENTANGLED0:
+            if qubit.state is QubitState.ENTANGLED0:
                 if new_epr is not None:
                     self.remote_swapped_eprs[cast(str, new_epr_name)] = new_epr
                 self.waiting_su[qubit.addr] = (msg, fib_entry)

--- a/mqns/network/fw/fw_swap.py
+++ b/mqns/network/fw/fw_swap.py
@@ -1,17 +1,36 @@
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
 
 from mqns.entity.memory import MemoryQubit, QuantumMemory, QubitState
 from mqns.entity.node import QNode
+from mqns.models.delay import DelayModel
 from mqns.models.epr import Entanglement
+from mqns.models.error import ErrorModel
 from mqns.network.fw.fib import FibEntry
 from mqns.network.fw.message import SwapUpdateMsg
 from mqns.network.fw.mux import MuxScheme
 from mqns.network.network import QuantumNetwork
-from mqns.simulator import Simulator
+from mqns.simulator import Simulator, Time, func_to_event
 from mqns.utils import log
 
 if TYPE_CHECKING:
     from mqns.network.fw.forwarder import Forwarder
+
+
+@dataclass
+class SwapArm:
+    partner: QNode
+    """Partner node."""
+    index: int
+    """Partner node index within FIB entry."""
+    rank: int
+    """Partner node swap rank within FIB entry."""
+    qubit: MemoryQubit
+    """Local qubit entangled with partner."""
+    epr: Entanglement
+    """Logical EPR with partner."""
+    # phy: Entanglement
+    # """Physical EPR with partner."""
 
 
 class ForwarderSwapProc:
@@ -27,10 +46,14 @@ class ForwarderSwapProc:
     memory: QuantumMemory
     mux: MuxScheme
 
-    def __init__(self, *, ps: float):
+    def __init__(self, *, ps: float, delay: DelayModel, error: ErrorModel):
         self.ps = ps
         """Probability of successful entanglement swapping."""
         assert 0.0 <= self.ps <= 1.0
+        self.delay = delay
+        """Swapping delay model."""
+        self.error = error
+        """Swapping error model."""
 
         self.waiting_su: dict[int, tuple[SwapUpdateMsg, FibEntry]] = {}
         """
@@ -46,7 +69,7 @@ class ForwarderSwapProc:
         See ``_su_parallel`` method.
         """
 
-        self.remote_swapped_eprs: dict[str, Entanglement] = {}
+        self.remote_swapped: dict[str, Entanglement] = {}
         """
         EPRs that have been swapped remotely but the SwapUpdateMsg have not arrived.
         Each key is an EPR name; each value is the EPR.
@@ -58,9 +81,6 @@ class ForwarderSwapProc:
         XXX Current approach assumes cchannels do not have packet loss.
         """
 
-    def _deposit_remote_swapped_epr(self, target: QNode, epr: Entanglement):
-        target.get_app(type(self.fw)).swap.remote_swapped_eprs[epr.name] = epr
-
     def install(self, fw: "Forwarder"):
         self.fw = fw
         self.simulator = fw.simulator
@@ -69,6 +89,20 @@ class ForwarderSwapProc:
         self.node = fw.node
         self.memory = fw.memory
         self.mux = fw.mux
+
+    def _deposit_remote_swapped(self, target: QNode, epr: Entanglement):
+        target.get_app(type(self.fw)).swap.remote_swapped[epr.name] = epr
+
+    def _send_su(self, target: SwapArm, opposite_name: str, fib_entry: FibEntry, new_epr: Entanglement | None):
+        su_msg: SwapUpdateMsg = {
+            "cmd": "SWAP_UPDATE",
+            "path_id": fib_entry.path_id,
+            "swapping_node": self.node.name,
+            "partner": opposite_name,
+            "epr": target.epr.name,
+            "new_epr": new_epr and new_epr.name,
+        }
+        self.fw.send_msg(target.partner, su_msg, fib_entry)
 
     def start(self, mq0: MemoryQubit, mq1: MemoryQubit, fib_entry: FibEntry):
         """
@@ -80,72 +114,91 @@ class ForwarderSwapProc:
         assert mq0.state is QubitState.ELIGIBLE, f"unexpected state {mq0.state}"
         assert mq1.state is QubitState.ELIGIBLE, f"unexpected state {mq1.state}"
 
+        # Set SWAPPING state, so that forwarder cannot start another swapping on the same qubit.
+        mq0.state = QubitState.SWAPPING
+        mq1.state = QubitState.SWAPPING
+
+        # Schedule swap completion event.
+        self.simulator.add_event(
+            func_to_event(self.simulator.tc + self.delay.calculate(), self.finish_swap, mq0, mq1, fib_entry, self.simulator.tc)
+        )
+
+    def _retrieve_arm(self, mq: MemoryQubit, fib_entry: FibEntry) -> SwapArm | None:
+        if mq.state is not QubitState.SWAPPING:
+            return None
+
+        qubit, epr = self.memory.read(mq.addr, has=self.epr_type, remove=True)
+
+        if epr.dst is self.node:
+            partner = epr.src
+        elif epr.src is self.node:
+            partner = epr.dst
+        else:
+            raise RuntimeError(f"{self.node}: not in {epr} stored at {mq}")
+        assert partner is not None
+        index, rank = fib_entry.find_index_and_swap_rank(partner.name)
+
+        return SwapArm(partner, index, rank, qubit, epr)
+
+    def finish_swap(self, mq0: MemoryQubit, mq1: MemoryQubit, fib_entry: FibEntry, swap_start: Time):
         # Read both qubits and remove them from memory.
         #
+        # If either qubit is no longer in SWAPPING state, it implies that a SWAP_UPDATE message arrived that informs
+        # a failure for a parallel swap at a remote node, which caused the qubit to be released.
+        # In this case, the local swapping is treated as aborted, and the other involved qubit is released.
+        arm0 = self._retrieve_arm(mq0, fib_entry)
+        arm1 = self._retrieve_arm(mq1, fib_entry)
+        if arm0 is None or arm1 is None:
+            log.debug(f"{self.node}: SWAP ABORT | {mq0} x {mq1}")
+            for target in arm0, arm1:
+                if target:
+                    self.fw.release_qubit(target.qubit)
+                    self._send_su(target, "", fib_entry, None)
+            return
+
         # One of these qubits must be entangled with a partner node to the left of the current node.
         # This is determined by epr.dst==self.node condition, because LinkLayer establishes elementary
         # entanglements from left to right, and swapping maintains this condition.
-        # This qubit and related objects are assigned to prev_* variables.
+        # This qubit and related objects are assigned to `prev`.
         #
-        # Likewise, the other qubit entangled with a partner node to the right is assigned to next_*.
-        prev_tuple: tuple[QNode, MemoryQubit, Entanglement] | None = None
-        next_tuple: tuple[QNode, MemoryQubit, Entanglement] | None = None
-        for addr in (mq0.addr, mq1.addr):
-            qubit, epr = self.memory.read(addr, has=self.epr_type, remove=True)
-            if epr.dst == self.node:
-                assert epr.src is not None
-                prev_tuple = epr.src, qubit, epr
-            elif epr.src == self.node:
-                assert epr.dst is not None
-                next_tuple = epr.dst, qubit, epr
-            else:
-                raise Exception(f"Unexpected: swapping EPRs {mq0} x {mq1}")
-
-        # Make sure both partners are found.
-        assert prev_tuple is not None
-        assert next_tuple is not None
-        _, prev_qubit, prev_epr = prev_tuple
-        _, next_qubit, next_epr = next_tuple
+        # Likewise, the other qubit entangled with a partner node to the right is assigned to `next`.
+        prev, next = (arm0, arm1) if arm0.index < arm1.index else (arm1, arm0)
 
         # Save ch_index metadata field onto elementary EPR.
-        if not prev_epr.orig_eprs:
-            prev_epr.ch_index = fib_entry.own_idx - 1
-        if not next_epr.orig_eprs:
-            next_epr.ch_index = fib_entry.own_idx
+        if not prev.epr.orig_eprs:
+            prev.epr.ch_index = fib_entry.own_idx - 1
+        if not next.epr.orig_eprs:
+            next.epr.ch_index = fib_entry.own_idx
 
         # Attempt the swap.
-        new_epr, local_success = Entanglement.swap(prev_epr, next_epr, now=self.simulator.tc, ps=self.ps)
-        log.debug(f"{self.node}: SWAP {'SUCC' if local_success else 'FAILED'} | {prev_qubit} x {next_qubit} = {new_epr}")
+        new_epr, local_success = Entanglement.swap(prev.epr, next.epr, now=swap_start, ps=self.ps, error=self.error)
+        log.debug(f"{self.node}: SWAP {'SUCC' if local_success else 'FAILED'} | {prev.qubit} x {next.qubit} = {new_epr}")
+
+        # Release consumed qubits.
+        self.fw.release_qubit(prev.qubit)
+        self.fw.release_qubit(next.qubit)
 
         if local_success:  # swapping succeeded
             self.fw.cnt.n_swapped_s += 1
 
             # Inform multiplexing scheme.
-            self.mux.swapping_succeeded(prev_epr, next_epr, new_epr)
+            self.mux.swapping_succeeded(prev.epr, next.epr, new_epr)
 
-        for (a_partner, a_qubit, a_epr), (b_partner, _, b_epr) in ((prev_tuple, next_tuple), (next_tuple, prev_tuple)):
-            if local_success:
-                # Keep records to support potential parallel swapping.
-                _, a_rank = fib_entry.find_index_and_swap_rank(a_partner.name)
-                if fib_entry.own_swap_rank == a_rank:
-                    self.parallel_swappings[a_epr.name] = (a_epr, b_epr, new_epr)
+        # Send heralding.
+        self._herald_swap(prev, next, fib_entry, new_epr, local_success)
+        self._herald_swap(next, prev, fib_entry, new_epr, local_success)
 
-                # Deposit swapped EPR at the partner.
-                self._deposit_remote_swapped_epr(a_partner, new_epr)
+    def _herald_swap(self, target: SwapArm, opposite: SwapArm, fib_entry: FibEntry, new_epr: Entanglement, local_success: bool):
+        if local_success:
+            # Keep records to support potential parallel swapping.
+            if fib_entry.own_swap_rank == target.rank:
+                self.parallel_swappings[target.epr.name] = (target.epr, opposite.epr, new_epr)
 
-            # Send SWAP_UPDATE to the partner.
-            su_msg: SwapUpdateMsg = {
-                "cmd": "SWAP_UPDATE",
-                "path_id": fib_entry.path_id,
-                "swapping_node": self.node.name,
-                "partner": b_partner.name,
-                "epr": a_epr.name,
-                "new_epr": new_epr.name if local_success else None,
-            }
-            self.fw.send_msg(a_partner, su_msg, fib_entry)
+            # Deposit swapped EPR at the partner.
+            self._deposit_remote_swapped(target.partner, new_epr)
 
-            # Release old qubit.
-            self.fw.release_qubit(a_qubit)
+        # Send SWAP_UPDATE to the partner.
+        self._send_su(target, opposite.partner.name, fib_entry, new_epr if local_success else None)
 
     def pop_waiting_su(self, qubit: MemoryQubit):
         su_args = self.waiting_su.pop(qubit.addr, None)
@@ -182,7 +235,7 @@ class ForwarderSwapProc:
             return
 
         new_epr_name = msg["new_epr"]
-        new_epr = None if new_epr_name is None else self.remote_swapped_eprs.pop(new_epr_name)
+        new_epr = None if new_epr_name is None else self.remote_swapped.pop(new_epr_name)
 
         epr_name = msg["epr"]
         qubit_pair = self.memory.read(epr_name)
@@ -190,7 +243,7 @@ class ForwarderSwapProc:
             qubit, _ = qubit_pair
             if qubit.state is QubitState.ENTANGLED0:
                 if new_epr is not None:
-                    self.remote_swapped_eprs[cast(str, new_epr_name)] = new_epr
+                    self.remote_swapped[cast(str, new_epr_name)] = new_epr
                 self.waiting_su[qubit.addr] = (msg, fib_entry)
                 return
             self.parallel_swappings.pop(epr_name, None)
@@ -303,7 +356,7 @@ class ForwarderSwapProc:
             self.mux.su_parallel_succeeded(merged_epr, new_epr, other_epr)
 
             # Inform the "destination" of the swap result and new "partner".
-            self._deposit_remote_swapped_epr(destination, merged_epr)
+            self._deposit_remote_swapped(destination, merged_epr)
 
         su_msg: SwapUpdateMsg = {
             "cmd": "SWAP_UPDATE",

--- a/mqns/network/protocol/event.py
+++ b/mqns/network/protocol/event.py
@@ -97,7 +97,7 @@ class QubitEntangledEvent(Event):
         self.node = node
         self.neighbor = neighbor
         self.qubit = qubit
-        assert self.qubit.state == QubitState.ENTANGLED0
+        assert self.qubit.state is QubitState.ENTANGLED0, f"unexpected state {qubit.state}"
 
     @override
     def invoke(self) -> None:
@@ -128,7 +128,7 @@ class QubitDecoheredEvent(Event):
     @override
     def invoke(self) -> None:
         if self.memory.handle_decohere_qubit(self.qubit, self.epr):
-            assert self.qubit.state == QubitState.RELEASE
+            assert self.qubit.state is QubitState.RELEASE, f"unexpected state {self.qubit.state}"
             self.memory.node.handle(self)
 
 
@@ -149,9 +149,9 @@ class QubitReleasedEvent(Event):
         super().__init__(t, name)
         self.node = node
         self.qubit = qubit
-        assert self.qubit.state == QubitState.RELEASE
+        assert self.qubit.state is QubitState.RELEASE, f"unexpected state {self.qubit.state}"
 
     @override
     def invoke(self) -> None:
-        assert self.qubit.state == QubitState.RELEASE
+        assert self.qubit.state is QubitState.RELEASE, f"unexpected state {self.qubit.state}"
         self.node.handle(self)

--- a/mqns/network/protocol/link_layer.py
+++ b/mqns/network/protocol/link_layer.py
@@ -243,7 +243,6 @@ class LinkLayer(Application[QNode]):
             init_fidelity=self.init_fidelity,
             t0=self.simulator.tc,
             store_decays=(self.memory.time_decay, neighbor.memory.time_decay),
-            bsa_error=None,
         )
 
         epr_tpl, t_notify_a, t_notify_b = qchannel.link_arch.make_epr(

--- a/mqns/network/protocol/link_layer.py
+++ b/mqns/network/protocol/link_layer.py
@@ -287,7 +287,7 @@ class LinkLayer(Application[QNode]):
         qubits = list(self.memory.find(lambda *_: True, qchannel=qchannel))
         log.debug(f"{self.node}: {qchannel.name} has assigned qubits: {qubits}")
         for qb, data in qubits:
-            if qb.path_id != path_id or qb.state != QubitState.RAW:
+            if qb.path_id != path_id or qb.state is not QubitState.RAW:
                 continue
             assert qb.active is None
             assert data is None, f"{self.node}: qubit {qb} has data {data}"

--- a/tests/entity/test_link_arch.py
+++ b/tests/entity/test_link_arch.py
@@ -19,12 +19,14 @@ class FakeQuantumChannel:
     alpha: float
     delay: DelayModel
     transfer_error: ErrorModel
+    bsa_error: ErrorModel
 
-    def __init__(self, length: float, *, alpha=0.2, delay=-1.0, transfer_error_rate=0.0):
+    def __init__(self, length: float, *, alpha=0.2, delay=-1.0, transfer_error_rate=0.0, bsa_error_prob=0.0):
         self.length = length
         self.alpha = alpha
         self.delay = ConstantDelayModel(delay if delay >= 0 else length / default_light_speed[0])
         self.transfer_error = DepolarErrorModel().set(rate=transfer_error_rate, length=0)
+        self.bsa_error = DepolarErrorModel().set(p_error=bsa_error_prob)
 
 
 @pytest.mark.parametrize(
@@ -102,7 +104,6 @@ def test_perfect_error(LA: type[LinkArch], E: type[Entanglement]):
         epr_type=E,
         t0=t_cohere,
         store_decays=(time_decay_nop, time_decay_nop),
-        bsa_error={"p_error": 0},
     )
 
     epr, _, _ = make_epr(link_arch, t_cohere)
@@ -130,6 +131,7 @@ def test_realistic_error(LA: type[LinkArch], w_or_probv: float | tuple[float, fl
     ch = FakeQuantumChannel(
         50.0,  # km
         transfer_error_rate=0.001,  # 0.001 for typical fiber, 0.0051 for noisy fiber
+        bsa_error_prob=0.01,  # 0.5~2.0% detector jitter and beam-splitter asymmetry
     )
     t_cohere = Time.from_sec(0.100, accuracy=ACCURACY)  # coherence of an NV-center or Ion-Trap
     store_decay = parse_time_decay(None, t_cohere)
@@ -143,7 +145,6 @@ def test_realistic_error(LA: type[LinkArch], w_or_probv: float | tuple[float, fl
         epr_type=MixedStateEntanglement if isinstance(w_or_probv, tuple) else WernerStateEntanglement,
         t0=Time(0, accuracy=t_cohere.accuracy),
         store_decays=(store_decay, store_decay),
-        bsa_error={"p_error": 0.01},  # 0.5~2.0% detector jitter and beam-splitter asymmetry
     )
 
     epr, d_notify_a, d_notify_b = make_epr(link_arch, t_cohere)

--- a/tests/entity/test_memory.py
+++ b/tests/entity/test_memory.py
@@ -111,7 +111,7 @@ def test_decoherence_event_removes_qubit():
 
     res = mem.read("epr3")
     assert res is None
-    assert qubit.state == QubitState.RELEASE
+    assert qubit.state is QubitState.RELEASE, f"unexpected state {qubit.state}"
 
 
 def test_memory_clear_and_deallocate():

--- a/tests/fw/fw_common.py
+++ b/tests/fw/fw_common.py
@@ -49,8 +49,7 @@ class BuildNetworkArgs(TypedDict, total=False):
     qchannel_args: QuantumChannelInitKwargs
     cchannel_args: ClassicChannelInitKwargs
     ctrl: RoutingController  # replacing controller application
-    fw: ForwarderInitKwargs  # forwarder parameters
-    ps: float  # probability of successful swap, defaults to 0.5
+    fw: ForwarderInitKwargs  # forwarder parameters (`p_swap` defaults to 0.5)
     end_time: float  # simulation end time, defaults to 10.0 seconds
     timing: TimingMode  # network timing mode, defaults to ASYNC
     epr_type: type[Entanglement]  # entanglement type, defaults to werner state
@@ -68,7 +67,7 @@ def _make_topo_args(d: BuildNetworkArgs, *, memory_capacity_factor: int) -> Topo
         nodes_apps.append(QubitReleaseLoggerApp())
 
     fw_args = copy.copy(d.get("fw")) or {}
-    fw_args.setdefault("ps", d.get("ps", 0.5))
+    fw_args.setdefault("p_swap", 0.6)
     match d.get("mode", "P"):
         case "P":
             nodes_apps.append(ProactiveForwarder(**fw_args))

--- a/tests/fw/fw_common.py
+++ b/tests/fw/fw_common.py
@@ -1,21 +1,36 @@
+import copy
 import uuid
-from typing import Literal, TypedDict, Unpack
+from typing import Literal, TypedDict, Unpack, override
 
 from mqns.entity.cchannel import ClassicChannelInitKwargs
 from mqns.entity.memory import QubitState
 from mqns.entity.node import Application, Controller, QNode
 from mqns.entity.qchannel import LinkArchAlways, LinkArchDimBk, QuantumChannelInitKwargs
 from mqns.models.epr import Entanglement, WernerStateEntanglement
-from mqns.network.fw import Forwarder, MuxScheme, RoutingController, RoutingPath
+from mqns.network.fw import Forwarder, ForwarderInitKwargs, RoutingController, RoutingPath
 from mqns.network.network import QuantumNetwork, TimingMode, TimingModeAsync
 from mqns.network.proactive import ProactiveForwarder, ProactiveRoutingController
-from mqns.network.protocol.event import QubitEntangledEvent
+from mqns.network.protocol.event import QubitEntangledEvent, QubitReleasedEvent
 from mqns.network.protocol.link_layer import LinkLayer
 from mqns.network.reactive import ReactiveForwarder, ReactiveRoutingController
 from mqns.network.route import RouteAlgorithm, YenRouteAlgorithm
 from mqns.network.topology import ClassicTopology, GridTopology, LinearTopology, Topology, TopologyInitKwargs, TreeTopology
-from mqns.simulator import Simulator, func_to_event
+from mqns.simulator import Event, Simulator, Time, func_to_event
 from mqns.utils import log
+
+
+class QubitReleaseLoggerApp(Application):
+    def __init__(self):
+        super().__init__()
+        self.history: list[tuple[int, Time]] = []
+
+    @override
+    def handle(self, event: Event) -> bool | None:
+        if type(event) is QubitReleasedEvent:
+            self.history.append((event.qubit.addr, event.t))
+            log.debug(f"{self.node}: RELEASE {event.qubit}")
+        return False
+
 
 dflt_qchannel_args = QuantumChannelInitKwargs(
     length=100,  # delay is 0.0005 seconds
@@ -34,8 +49,8 @@ class BuildNetworkArgs(TypedDict, total=False):
     qchannel_args: QuantumChannelInitKwargs
     cchannel_args: ClassicChannelInitKwargs
     ctrl: RoutingController  # replacing controller application
+    fw: ForwarderInitKwargs  # forwarder parameters
     ps: float  # probability of successful swap, defaults to 0.5
-    mux: MuxScheme  # multiplexing scheme, defaults to buffer-space
     end_time: float  # simulation end time, defaults to 10.0 seconds
     timing: TimingMode  # network timing mode, defaults to ASYNC
     epr_type: type[Entanglement]  # entanglement type, defaults to werner state
@@ -49,12 +64,16 @@ def _make_topo_args(d: BuildNetworkArgs, *, memory_capacity_factor: int) -> Topo
     nodes_apps: list[Application[QNode]] = []
     if d.get("has_link_layer", False):
         nodes_apps.append(LinkLayer(init_fidelity=d.get("init_fidelity", 0.99)))
+    else:
+        nodes_apps.append(QubitReleaseLoggerApp())
 
+    fw_args = copy.copy(d.get("fw")) or {}
+    fw_args.setdefault("ps", d.get("ps", 0.5))
     match d.get("mode", "P"):
         case "P":
-            nodes_apps.append(ProactiveForwarder(ps=d.get("ps", 0.5), mux=d.get("mux")))
+            nodes_apps.append(ProactiveForwarder(**fw_args))
         case "R":
-            nodes_apps.append(ReactiveForwarder(ps=d.get("ps", 0.5), mux=d.get("mux")))
+            nodes_apps.append(ReactiveForwarder(**fw_args))
 
     return TopologyInitKwargs(
         nodes_apps=nodes_apps,

--- a/tests/fw/test_p_integ.py
+++ b/tests/fw/test_p_integ.py
@@ -26,8 +26,9 @@ from .fw_common import build_linear_network, build_rect_network, install_path, p
 )
 def test_4_swap(epr_type: type[Entanglement], timing_mode: str, swap: SwapSequenceInput):
     """Test swapping in 4-node topology."""
+    end_time = 10.0 if swap == "asap" else 3.0
     timing = TimingModeAsync() if timing_mode == "ASYNC" else TimingModeSync(t_ext=0.006, t_int=0.004)
-    net, simulator = build_linear_network(4, end_time=3.0, timing=timing, epr_type=epr_type, has_link_layer=True)
+    net, simulator = build_linear_network(4, end_time=end_time, timing=timing, epr_type=epr_type, has_link_layer=True)
     f1 = net.get_node("n1").get_app(ProactiveForwarder)
     f2 = net.get_node("n2").get_app(ProactiveForwarder)
     f3 = net.get_node("n3").get_app(ProactiveForwarder)

--- a/tests/fw/test_p_integ.py
+++ b/tests/fw/test_p_integ.py
@@ -26,9 +26,8 @@ from .fw_common import build_linear_network, build_rect_network, install_path, p
 )
 def test_4_swap(epr_type: type[Entanglement], timing_mode: str, swap: SwapSequenceInput):
     """Test swapping in 4-node topology."""
-    end_time = 10.0 if swap == "asap" else 3.0
     timing = TimingModeAsync() if timing_mode == "ASYNC" else TimingModeSync(t_ext=0.006, t_int=0.004)
-    net, simulator = build_linear_network(4, end_time=end_time, timing=timing, epr_type=epr_type, has_link_layer=True)
+    net, simulator = build_linear_network(4, end_time=3.0, timing=timing, epr_type=epr_type, has_link_layer=True)
     f1 = net.get_node("n1").get_app(ProactiveForwarder)
     f2 = net.get_node("n2").get_app(ProactiveForwarder)
     f3 = net.get_node("n3").get_app(ProactiveForwarder)

--- a/tests/fw/test_p_purif.py
+++ b/tests/fw/test_p_purif.py
@@ -51,7 +51,7 @@ def force_purify_outcome(monkeypatch: pytest.MonkeyPatch, *success: bool):
 def test_link_rounds(monkeypatch: pytest.MonkeyPatch, n_rounds: int, purif_success: list[int], n_purif: list[int]):
     """Test multi-round purification on a single link with various purification outcomes."""
     n_etg = 2**n_rounds
-    net, simulator = build_linear_network(2, ps=0.0, qchannel_capacity=n_etg)
+    net, simulator = build_linear_network(2, qchannel_capacity=n_etg, fw={"p_swap": 0.0})
     f1 = net.get_node("n1").get_app(ProactiveForwarder)
     f2 = net.get_node("n2").get_app(ProactiveForwarder)
 
@@ -70,7 +70,7 @@ def test_link_rounds(monkeypatch: pytest.MonkeyPatch, n_rounds: int, purif_succe
 
 def test_4_l2r(monkeypatch: pytest.MonkeyPatch):
     """Test multi-segment purification on 4-node topology with l2r swapping order."""
-    net, simulator = build_linear_network(4, ps=1.0, qchannel_capacity=8)
+    net, simulator = build_linear_network(4, qchannel_capacity=8, fw={"p_swap": 1.0})
     f1 = net.get_node("n1").get_app(ProactiveForwarder)
     f2 = net.get_node("n2").get_app(ProactiveForwarder)
     f3 = net.get_node("n3").get_app(ProactiveForwarder)

--- a/tests/fw/test_p_swap.py
+++ b/tests/fw/test_p_swap.py
@@ -37,7 +37,7 @@ from .fw_common import (
 
 def test_3_disabled():
     """Test swap disabled mode."""
-    net, simulator = build_linear_network(3, ps=1.0)
+    net, simulator = build_linear_network(3, fw={"p_swap": 1.0})
     f1 = net.get_node("n1").get_app(ProactiveForwarder)
     f2 = net.get_node("n2").get_app(ProactiveForwarder)
     f3 = net.get_node("n3").get_app(ProactiveForwarder)
@@ -96,7 +96,7 @@ def test_3_disabled():
 def test_4_sync(t_ext: float, expected: tuple[int, int, int, int]):
     """Test TimingModeSync in 4-node topology."""
     timing = TimingModeSync(t_ext=t_ext, t_int=0.010000 - t_ext)
-    net, simulator = build_linear_network(4, ps=1.0, timing=timing)
+    net, simulator = build_linear_network(4, fw={"p_swap": 1.0}, timing=timing)
     f1 = net.get_node("n1").get_app(ProactiveForwarder)
     f2 = net.get_node("n2").get_app(ProactiveForwarder)
     f3 = net.get_node("n3").get_app(ProactiveForwarder)
@@ -125,7 +125,7 @@ def test_4_sync(t_ext: float, expected: tuple[int, int, int, int]):
 )
 def test_4_asap(etg_ms: tuple[int, int, int], n_swapped_p: int):
     """Test SWAP-ASAP in 4-node topology with various entanglement arrival orders."""
-    net, simulator = build_linear_network(4, ps=1.0)
+    net, simulator = build_linear_network(4, fw={"p_swap": 1.0})
     f1 = net.get_node("n1").get_app(ProactiveForwarder)
     f2 = net.get_node("n2").get_app(ProactiveForwarder)
     f3 = net.get_node("n3").get_app(ProactiveForwarder)
@@ -204,7 +204,7 @@ def test_4_delayed(ps3: float, delay3: float, n_swap2: int, n_consumed: int, t_r
         4,
         epr_type=MixedStateEntanglement,
         fw={
-            "ps": 1.0,
+            "p_swap": 1.0,
             "swap_delay": 0.050,
             "swap_error": "DEPOLAR:0.3",
         },
@@ -276,7 +276,7 @@ def test_5_asap(
     n_consumed: int,
 ):
     """Test SWAP-ASAP in 5-node topology with various entanglement arrival orders."""
-    net, simulator = build_linear_network(5, ps=1.0)
+    net, simulator = build_linear_network(5, fw={"p_swap": 1.0})
     f1 = net.get_node("n1").get_app(ProactiveForwarder)
     f2 = net.get_node("n2").get_app(ProactiveForwarder)
     f3 = net.get_node("n3").get_app(ProactiveForwarder)
@@ -312,7 +312,7 @@ def test_5_asap(
 )
 def test_5_sequential(swap: list[int], etg_ms: tuple[int, int, int, int]):
     """Test sequential swap orders with various entanglement arrival orders."""
-    net, simulator = build_linear_network(5, ps=1.0)
+    net, simulator = build_linear_network(5, fw={"p_swap": 1.0})
     f1 = net.get_node("n1").get_app(ProactiveForwarder)
     f2 = net.get_node("n2").get_app(ProactiveForwarder)
     f3 = net.get_node("n3").get_app(ProactiveForwarder)
@@ -346,7 +346,7 @@ def test_5_sequential(swap: list[int], etg_ms: tuple[int, int, int, int]):
 )
 def test_rect_multipath(has_etg: tuple[int, int, int, int], n_swapped: tuple[int, int], n_consumed: int):
     """Test swapping in rectangular topology with a multi-path request."""
-    net, simulator = build_rect_network(ps=1.0)
+    net, simulator = build_rect_network(fw={"p_swap": 1.0})
     f1 = net.get_node("n1").get_app(ProactiveForwarder)
     f2 = net.get_node("n2").get_app(ProactiveForwarder)
     f3 = net.get_node("n3").get_app(ProactiveForwarder)
@@ -405,7 +405,7 @@ def test_tree2_dynepr(t_edge_etg: float, selected_path: tuple[int, int], n_consu
             chosen = (rp0.path_id, rp1.path_id)[selected_path[1]]
         return chosen
 
-    net, simulator = build_tree_network(fw={"ps": 1.0, "mux": MuxSchemeDynamicEpr(select_path=select_path)})
+    net, simulator = build_tree_network(fw={"p_swap": 1.0, "mux": MuxSchemeDynamicEpr(select_path=select_path)})
     f1, f2, f3, f4, f5, f6, f7 = (node.get_app(ProactiveForwarder) for node in net.nodes)
 
     # n4-n2-n1-n3-n6
@@ -502,7 +502,7 @@ def test_tree2_statistical(
         return chosen
 
     net, simulator = build_tree_network(
-        fw={"ps": 1.0, "mux": MuxSchemeStatistical(select_swap_qubit=select_qubit, select_path=select_path)}
+        fw={"p_swap": 1.0, "mux": MuxSchemeStatistical(select_swap_qubit=select_qubit, select_path=select_path)}
     )
     f1, f2, f3, f4, f5, f6, f7 = (node.get_app(ProactiveForwarder) for node in net.nodes)
 
@@ -545,7 +545,7 @@ def test_tree2_statistical(
 )
 def test_3_waittime(etg_sec: tuple[float, float], n_cutoff: tuple[int, int]):
     """Test CutoffSchemeWaitTime in 3-node topology."""
-    net, simulator = build_linear_network(3, ps=1.0, end_time=1.010)
+    net, simulator = build_linear_network(3, fw={"p_swap": 1.0}, end_time=1.010)
     f1 = net.get_node("n1").get_app(ProactiveForwarder)
     f2 = net.get_node("n2").get_app(ProactiveForwarder)
     f3 = net.get_node("n3").get_app(ProactiveForwarder)

--- a/tests/fw/test_p_swap.py
+++ b/tests/fw/test_p_swap.py
@@ -6,7 +6,10 @@ import itertools
 
 import pytest
 
-from mqns.models.epr import Entanglement
+from mqns.entity.timer import Timer
+from mqns.models.delay import ConstantDelayModel
+from mqns.models.epr import Entanglement, MixedStateEntanglement
+from mqns.models.error import PerfectErrorModel
 from mqns.network.fw import (
     Fib,
     Forwarder,
@@ -22,6 +25,7 @@ from mqns.network.proactive import ProactiveForwarder
 from mqns.simulator import func_to_event
 
 from .fw_common import (
+    QubitReleaseLoggerApp,
     build_linear_network,
     build_rect_network,
     build_tree_network,
@@ -139,6 +143,110 @@ def test_4_asap(etg_ms: tuple[int, int, int], n_swapped_p: int):
     assert f1.cnt.n_consumed == 1 == f4.cnt.n_consumed
     assert f2.cnt.n_swapped_s == 1 == f3.cnt.n_swapped_s
     assert f2.cnt.n_swapped_p == n_swapped_p == f3.cnt.n_swapped_p
+
+
+@pytest.mark.parametrize(
+    ("ps3", "delay3", "n_swap2", "n_consumed", "t_release"),
+    [
+        # 1. t=1.0110, n2-n3 arrives, both n2 and n3 start swapping.
+        # 2. t=1.0110, n3 completes swapping with success and sends n2-n4 heralding to n2 & n4.
+        # 3. t=1.0115, n2 & n4 receive n2-n4 heralding.
+        # 4. t=1.0610, n2 completes swapping with success and sends n1-n4 heralding to n1 & n4.
+        # 5. t=1.0615, n1 receives n1-n4 heralding and consumes EPR.
+        # 6. t=1.0620, n4 receives n1-n4 heralding and consumes EPR.
+        (1.0, 0.0000, 1, 1, (1.0615, 1.0620)),
+        # 1. t=1.0110, n2-n3 arrives, both n2 and n3 start swapping.
+        # 2. t=1.0110, n3 completes swapping with failure and sends failure heralding to n2 & n4.
+        # 3. t=1.0115, n2 & n4 receive failure heralding , both release qubits.
+        # 4. t=1.0610, n2 aborts swapping and sends failure heralding to n1 only.
+        # 5. t=1.0615, n1 receives failure heralding and releases qubit.
+        (0.0, 0.0000, 0, 0, (1.0615, 1.0115)),
+        # 1. t=1.0110, n2-n3 arrives, both n2 and n3 start swapping.
+        # 2. t=1.0609, n3 completes swapping with success and sends n2-n4 heralding to n2 & n4.
+        # 3. t=1.0610, n2 completes swapping with success and sends n1-n3 heralding to n1 & n3.
+        # 4. t=1.0614, n2 receives n2-n4 heralding and sends n1-n4 heralding to n1 only.
+        # 5. t=1.0615, n3 receives n1-n3 heralding and sends n1-n4 heralding to n4 only.
+        # 6. t=1.0619, n1 receives n1-n4 heralding and consumes EPR.
+        # 7. t=1.0620, n4 receives n1-n4 heralding and consumes EPR.
+        # XXX n_swap2==2 because step4 stitching is currently counted as another swap.
+        (1.0, 0.0499, 2, 1, (1.0619, 1.0620)),
+        # 1. t=1.0110, n2-n3 arrives, both n2 and n3 start swapping.
+        # 2. t=1.0609, n3 completes swapping with failure and sends failure heralding to n2 & n4.
+        # 3. t=1.0610, n2 completes swapping with success and sends n1-n3 heralding to n1 & n3.
+        # 4. t=1.0614, n4 receives failure heralding and releases qubit.
+        # 5. t=1.0614, n2 receives failure heralding and sends failure heralding to n1 only.
+        # 6. t=1.0615, n3 receives n1-n3 heralding, but could not stitch because n3-n4 is released.
+        # 7. t=1.0619, n1 receives failure heralding and releases qubit.
+        (0.0, 0.0499, 1, 0, (1.0619, 1.0614)),
+        # 1. t=1.0110, n2-n3 arrives, both n2 and n3 start swapping.
+        # 2. t=1.0610, n2 completes swapping with success and sends n1-n3 heralding to n1 & n3.
+        # 3. t=1.0611, n3 completes swapping with success and sends n2-n4 heralding to n2 & n4.
+        # 4. t=1.0615, n3 receives n1-n3 heralding and sends n1-n4 heralding to n4 only.
+        # 5. t=1.0616, n2 receives n2-n4 heralding and sends n1-n4 heralding to n1 only.
+        # 6. t=1.0620, n4 receives n1-n4 heralding and consumes EPR.
+        # 7. t=1.0621, n1 receives n1-n4 heralding and consumes EPR.
+        # XXX n_swap2==2 because step5 stitching is currently counted as another swap.
+        (1.0, 0.0501, 2, 1, (1.0621, 1.0620)),
+        # 1. t=1.0110, n2-n3 arrives, both n2 and n3 start swapping.
+        # 2. t=1.0610, n2 completes swapping with success and sends n1-n3 heralding to n1 & n3.
+        # 3. t=1.0611, n3 completes swapping with failure and sends failure heralding to n2 & n4.
+        # 4. t=1.0615, n3 receives n1-n3 heralding and sends n1-n4 heralding to n4 only.
+        # 5. t=1.0616, n4 receives failure heralding and releases qubit.
+        # 6. t=1.0616, n2 receives failure heralding and sends failure heralding to n1 only.
+        # 7. t=1.0620, n4 receives n1-n4 heralding but finds the qubit already released in step5.
+        # 8. t=1.0621, n1 receives failure heralding and releases qubit.
+        (0.0, 0.0501, 1, 0, (1.0621, 1.0616)),
+    ],
+)
+def test_4_delayed(ps3: float, delay3: float, n_swap2: int, n_consumed: int, t_release: tuple[float, float]):
+    """Test swap delay model and error model in 4-node topology."""
+    net, simulator = build_linear_network(
+        4,
+        epr_type=MixedStateEntanglement,
+        fw={
+            "ps": 1.0,
+            "swap_delay": 0.050,
+            "swap_error": "DEPOLAR:0.3",
+        },
+    )
+    f1 = net.get_node("n1").get_app(ProactiveForwarder)
+    f2 = net.get_node("n2").get_app(ProactiveForwarder)
+    f3 = net.get_node("n3").get_app(ProactiveForwarder)
+    f4 = net.get_node("n4").get_app(ProactiveForwarder)
+
+    f3.swap.ps = ps3
+    f3.swap.delay = ConstantDelayModel(delay3)
+    f3.swap.error = PerfectErrorModel()
+
+    f2_n_swapped_values: list[int] = []
+
+    def save_counter():
+        f2_n_swapped_values.append(f2.cnt.n_swapped)
+
+    timer = Timer("save_counters", start_time=1.018, end_time=1.088, step_time=0.010, trigger_func=save_counter)
+    timer.install(simulator)
+
+    install_path(net, RoutingPathSingle("n1", "n4", swap=[1, 0, 0, 1]))
+    provide_entanglements(
+        (1.000, f1, f2),
+        (1.000, f3, f4),
+        (1.010, f2, f3),
+        fidelity=1,
+    )
+    simulator.run()
+    print_fw_counters(net)
+
+    assert f2_n_swapped_values == [0, 0, 0, 0, 0, n_swap2, n_swap2, n_swap2]
+    assert f1.cnt.n_consumed == n_consumed
+    if n_consumed > 0:
+        # XXX https://github.com/usnistgov/mqns/issues/92#issuecomment-4056069219
+        # Currently, two ends are receiving distinct EPR objects.
+        # Until this is fixed, verify that BSA error model is applied to at least one of them.
+        assert 0.5 < min(f1.cnt.consumed_avg_fidelity, f4.cnt.consumed_avg_fidelity) <= 0.75
+
+    t_release1, t_release4 = t_release
+    assert f1.node.get_app(QubitReleaseLoggerApp).history == [(0, simulator.time(sec=t_release1))]
+    assert f4.node.get_app(QubitReleaseLoggerApp).history == [(0, simulator.time(sec=t_release4))]
 
 
 @pytest.mark.parametrize(
@@ -297,7 +405,7 @@ def test_tree2_dynepr(t_edge_etg: float, selected_path: tuple[int, int], n_consu
             chosen = (rp0.path_id, rp1.path_id)[selected_path[1]]
         return chosen
 
-    net, simulator = build_tree_network(ps=1.0, mux=MuxSchemeDynamicEpr(select_path=select_path))
+    net, simulator = build_tree_network(fw={"ps": 1.0, "mux": MuxSchemeDynamicEpr(select_path=select_path)})
     f1, f2, f3, f4, f5, f6, f7 = (node.get_app(ProactiveForwarder) for node in net.nodes)
 
     # n4-n2-n1-n3-n6
@@ -394,7 +502,7 @@ def test_tree2_statistical(
         return chosen
 
     net, simulator = build_tree_network(
-        ps=1.0, mux=MuxSchemeStatistical(select_swap_qubit=select_qubit, select_path=select_path)
+        fw={"ps": 1.0, "mux": MuxSchemeStatistical(select_swap_qubit=select_qubit, select_path=select_path)}
     )
     f1, f2, f3, f4, f5, f6, f7 = (node.get_app(ProactiveForwarder) for node in net.nodes)
 

--- a/tests/fw/test_r_swap.py
+++ b/tests/fw/test_r_swap.py
@@ -37,7 +37,7 @@ def test_tree2_one():
     net, simulator = build_tree_network(
         2,
         mode="R",
-        ps=1.0,
+        fw={"p_swap": 1.0},
         end_time=0.010,
         timing=TimingModeSync(t_ext=0.006, t_rtg=0.001, t_int=0.003),
         ctrl=ctrl,
@@ -74,7 +74,7 @@ def test_tree2_two():
         2,
         mode="R",
         qchannel_capacity=2,
-        ps=1.0,
+        fw={"p_swap": 1.0},
         end_time=0.010,
         timing=TimingModeSync(t_ext=0.006, t_rtg=0.001, t_int=0.003),
         ctrl=ctrl,
@@ -162,7 +162,7 @@ def test_3_minimal(req_active: tuple[float, float], etg12: list[float], etg23: l
         3,
         qchannel_capacity=2,
         mode="R",
-        ps=1.0,
+        fw={"p_swap": 1.0},
         end_time=0.020,
         timing=TimingModeSync(t_ext=0.006, t_rtg=0.001, t_int=0.003),
     )

--- a/tests/models/test_mixed_state.py
+++ b/tests/models/test_mixed_state.py
@@ -44,9 +44,10 @@ def test_swap():
     e1 = MixedStateEntanglement(fidelity=0.95, fidelity_time=now, decohere_time=decohere)
     e2 = MixedStateEntanglement(fidelity=0.95, fidelity_time=now, decohere_time=decohere)
     e1.read, e2.read = True, True
-    e3 = MixedStateEntanglement.swap(e1, e2, now=now)
-    assert e3 is not None
-    assert e3.fidelity == pytest.approx(0.903333, abs=1e-6)
+
+    ne, local_success = MixedStateEntanglement.swap(e1, e2, now=now)
+    assert local_success is True
+    assert ne.fidelity == pytest.approx(0.903333, abs=1e-6)
 
 
 def test_purify_success(monkeypatch: pytest.MonkeyPatch):

--- a/tests/models/test_werner_state.py
+++ b/tests/models/test_werner_state.py
@@ -32,9 +32,9 @@ def test_swap_success(monkeypatch: pytest.MonkeyPatch):
     e2 = WernerStateEntanglement(fidelity=0.8, fidelity_time=now, decohere_time=micros(4000))
 
     monkeypatch.setattr(rng, "random", lambda: 0.1)
-    ne = Entanglement.swap(e1, e2, now=now)
+    ne, local_success = Entanglement.swap(e1, e2, now=now)
 
-    assert ne is not None
+    assert local_success is True
     assert ne.fidelity < min(e1.fidelity, e2.fidelity)  # swapping reduces fidelity
     assert ne.fidelity_time == now
     assert ne.decohere_time == micros(3000)
@@ -54,7 +54,7 @@ def test_swap_fidelity():
     )
 
     ne1t = micros(2500)
-    ne1 = Entanglement.swap(e1, e2, now=ne1t)
+    ne1, _ = Entanglement.swap(e1, e2, now=ne1t)
     assert e1.w == pytest.approx(0.983711102, abs=1e-6)
     assert e2.w == pytest.approx(0.985680493, abs=1e-6)
     assert ne1 is not None
@@ -62,7 +62,7 @@ def test_swap_fidelity():
     assert ne1.fidelity == pytest.approx(0.977218633, abs=1e-6)
 
     ne2t = micros(3500)
-    ne2 = Entanglement.swap(ne1, e3, now=ne2t)
+    ne2, _ = Entanglement.swap(ne1, e3, now=ne2t)
     assert ne1.w == pytest.approx(0.967687533, abs=1e-6)
     assert e3.w == pytest.approx(0.985680493, abs=1e-6)
     assert ne2 is not None
@@ -77,9 +77,9 @@ def test_swap_failure(monkeypatch: pytest.MonkeyPatch):
     e2 = WernerStateEntanglement(fidelity=0.8, fidelity_time=now, decohere_time=decohere)
 
     monkeypatch.setattr(rng, "random", lambda: 0.99)
-    ne = Entanglement.swap(e1, e2, now=now, ps=0.5)
-
-    assert ne is None
+    ne, local_success = Entanglement.swap(e1, e2, now=now, ps=0.5)
+    assert local_success is False
+    assert ne.is_decohered
 
 
 def test_swap_decohered_inputs(monkeypatch: pytest.MonkeyPatch):
@@ -89,9 +89,8 @@ def test_swap_decohered_inputs(monkeypatch: pytest.MonkeyPatch):
     e2 = WernerStateEntanglement(fidelity=0.8, fidelity_time=now, decohere_time=decohere)
     e1.is_decohered = True
 
-    monkeypatch.setattr(rng, "random", lambda: 0.1)
-    ne = Entanglement.swap(e1, e2, now=now)
-    assert ne is not None
+    ne, local_success = Entanglement.swap(e1, e2, now=now)
+    assert local_success is True
     assert ne.is_decohered
 
 

--- a/tests/models/test_werner_state.py
+++ b/tests/models/test_werner_state.py
@@ -80,18 +80,19 @@ def test_swap_failure(monkeypatch: pytest.MonkeyPatch):
     ne = Entanglement.swap(e1, e2, now=now, ps=0.5)
 
     assert ne is None
-    assert e1.is_decohered
-    assert e2.is_decohered
 
 
-def test_swap_decohered_inputs():
+def test_swap_decohered_inputs(monkeypatch: pytest.MonkeyPatch):
     now = micros(0)
     decohere = now + 1.0
     e1 = WernerStateEntanglement(fidelity=0.9, fidelity_time=now, decohere_time=decohere)
     e2 = WernerStateEntanglement(fidelity=0.8, fidelity_time=now, decohere_time=decohere)
     e1.is_decohered = True
 
-    assert Entanglement.swap(e1, e2, now=now) is None
+    monkeypatch.setattr(rng, "random", lambda: 0.1)
+    ne = Entanglement.swap(e1, e2, now=now)
+    assert ne is not None
+    assert ne.is_decohered
 
 
 def test_purify_success(monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
refs #92

* Introduce `swap_delay` parameter to model Bell-state analyzer delay when the forwarder performs a swap.
* Introduce `swap_error` parameter to model Bell-state analyzer error/noise when the forwarder performs a swap.
* Expose the above parameters in `NetworkBuilder` API.
* Also expose photonic Bell-state analyzer error/noise `bsa_error` parameter in `NetworkBuilder` API.
* Avoid faster-than-light information leak in `Entanglement.is_decohered` for swapping related operations.
