### PR TITLE
reactive,etc: 3_nodes_thruput enhancement and deterministic simulation

### DIFF
--- a/examples/3_nodes_thruput.py
+++ b/examples/3_nodes_thruput.py
@@ -3,9 +3,9 @@ Simulate 3-node linear topology and report end-to-end throughput.
 
 This script sets up and executes simulations using:
 
-* A generated topology based with varying qubit coherence time,
-* A quantum network with Dijkstra-based routing algorithm, and asynchronous timing mode,
-* A seeded random number generator.
+* a generated topology based with varying qubit coherence time
+* a quantum network with Dijkstra-based routing algorithm
+* a seeded random number generator
 
 After simulation, it reports the number of successful entanglement generations per second.
 The statistics can be saved and plotted.
@@ -35,20 +35,48 @@ class Args(Tap):
     workers: int = 1  # number of workers for parallel execution
     runs: int = 100  # number of trials per parameter set
     sim_duration: float = 3  # simulation duration in seconds
-    mode: Literal["PCA", "RCS"] = "PCA"
+    mode: Literal["PCA", "PCS", "RCS"] = "PCA"
     sync_timing: list[float]
     L: tuple[float, float] = (32, 18)  # qchannel lengths (km)
-    t_cohere: list[float] = [0.002, 0.005, 0.01, 0.015, 0.02, 0.025, 0.05, 0.1]  # memory coherence time (s)
-    qchannel_capacity: int = 1  # qchannel capacity
+    M: list[int] = [1]
+    t_cohere: list[float] = [0.002, 0.005, 0.01, 0.015, 0.02, 0.025, 0.05, 0.1]  # memory coherence times (sec)
     epr_type: EprTypeLiteral  # network-wide EPR type
     link_arch: LinkArchLiteral  # link architecture
     json: str = ""  # save results as JSON file
-    csv: str = ""  # save results as CSV file
+    csv: str = ""  # save summary as CSV file
     plt: str = ""  # save plot as image file
 
     @override
     def configure(self) -> None:
         tap_configure(self)
+
+        self.add_argument("--L", metavar=("L_SR", "L_RD"))
+        self.add_argument("--M", help="(int | 4*int, default: 1) number of qubits per channel per direction")
+
+    @override
+    def process_args(self) -> None:
+        if len(self.M) not in (1, 4):
+            raise ValueError("--M must have either 1 or 4 elements")
+        if min(self.M) < 1:
+            raise ValueError("--M must be positive")
+
+    def qchannel_capacity(self) -> int | list[tuple[int, int]]:
+        """
+        Derive ``NetworkBuilder.topo_linear(channel_capacity=)`` from ``--M``.
+
+        If ``--M`` has one integer, it is used as channel capacity on both S-R and R-D.
+
+        If ``--M`` has four integers, they are used as:
+
+        1. number of qubits on S assigned to S-R channel
+        2. number of qubits on R assigned to S-R channel
+        3. number of qubits on R assigned to R-D channel
+        4. number of qubits on D assigned to R-D channel
+        """
+        if len(self.M) == 1:
+            return self.M[0]
+        mSr, mRl, mRr, mDl = self.M
+        return [(mSr, mRl), (mRr, mDl)]
 
 
 SEED_BASE = 100
@@ -69,16 +97,18 @@ def run_simulation(seed: int, args: Args, t_cohere: float) -> Stats:
         nodes=("S", "R", "D"),
         t_cohere=t_cohere,
         channel_length=args.L,
-        channel_capacity=args.qchannel_capacity,
+        channel_capacity=args.qchannel_capacity(),
         link_arch=args.link_arch,
     )
 
+    total_duration = args.sim_duration
     match args.mode:
         case "PCA":
-            total_duration = args.sim_duration + CTRL_DELAY
+            total_duration += CTRL_DELAY
             b.proactive_centralized()
+        case "PCS":
+            b.proactive_centralized(timing=args.sync_timing)
         case "RCS":
-            total_duration = args.sim_duration
             b.reactive_centralized(timing=args.sync_timing)
 
     b.request("S-D")
@@ -93,7 +123,7 @@ def run_simulation(seed: int, args: Args, t_cohere: float) -> Stats:
     stats = Stats(
         t_cohere=t_cohere,
         throughput_eps=fw_s_cnt.n_consumed / args.sim_duration,
-        mean_fidelity=float(fw_s_cnt.consumed_avg_fidelity),
+        mean_fidelity=fw_s_cnt.consumed_avg_fidelity,
         expired_ratio=ll_cnt.decoh_ratio,
         expired_per_e2e=ll_cnt.n_decoh / fw_s_cnt.n_consumed if fw_s_cnt.n_consumed > 0 else 0,
     )

--- a/examples/multi_request_single_path.py
+++ b/examples/multi_request_single_path.py
@@ -151,7 +151,10 @@ def plot(results: dict[str, list[list[PathStats]]], *, save_plt: str):
 
 # Simulation constants
 STRATEGIES: dict[str, MuxScheme] = {
-    "Statistical Mux.": MuxSchemeStatistical(),
+    # XXX https://github.com/usnistgov/mqns/pull/134#issuecomment-4362659122
+    # This is set to coordinated_decisions=True to workaround bugs in ASAP swap.
+    # It should be changed back to coordinated_decisions=False for more realistic solution.
+    "Statistical Mux.": MuxSchemeStatistical(coordinated_decisions=True),
     "Random Alloc.": MuxSchemeDynamicEpr(),
     "Swap-weighted Alloc.": MuxSchemeDynamicEpr(select_path=MuxSchemeDynamicEpr.SelectPath_swap_weighted),
 }

--- a/mqns/models/epr/entanglement.py
+++ b/mqns/models/epr/entanglement.py
@@ -26,7 +26,6 @@
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import hashlib
-import uuid
 from abc import abstractmethod
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Self, TypedDict, Unpack, cast
@@ -44,6 +43,12 @@ from mqns.utils import rng
 
 if TYPE_CHECKING:
     from mqns.entity.node import QNode
+
+
+_AUTOID = 0
+"""
+Automatically assigned ``Entanglement.name`` numeric portion.
+"""
 
 
 class EntanglementInitKwargs(TypedDict, total=False):
@@ -99,7 +104,11 @@ class Entanglement(QuantumModel):
             store_decays: Memory time-based decay functions at src and dst.
         """
         name = kwargs.get("name")
-        self.name = uuid.uuid4().hex if name is None else name
+        if name is None:
+            global _AUTOID
+            name = f"etg_{_AUTOID:028x}"
+            _AUTOID += 1
+        self.name = name
         """Descriptive name."""
 
         self.decohere_time = kwargs.get("decohere_time", Time.SENTINEL)
@@ -194,7 +203,7 @@ class Entanglement(QuantumModel):
                 orig_eprs.append(epr)
 
         orig_names = "-".join((e.name for e in orig_eprs))
-        name = hashlib.sha256(orig_names.encode()).hexdigest()[:32]  # same length as `uuid.uuid4().hex`
+        name = hashlib.sha256(orig_names.encode()).hexdigest()[:32]  # same length as default name
         ne = cast(
             E,
             type(epr0)._make_swapped(

--- a/mqns/network/protocol/link_layer.py
+++ b/mqns/network/protocol/link_layer.py
@@ -17,7 +17,7 @@
 
 import uuid
 from collections import deque
-from collections.abc import Sequence
+from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Literal, TypedDict, cast, override
 
@@ -54,7 +54,7 @@ class ReservationRequest:
 @json_encodable
 class LinkLayerCounters:
     @staticmethod
-    def aggregate(nodes: Sequence[QNode]) -> "LinkLayerCounters":
+    def aggregate(nodes: Iterable[QNode]) -> "LinkLayerCounters":
         """
         Aggregate ``LinkLayerCounters`` from a network.
 

--- a/mqns/network/protocol/link_layer.py
+++ b/mqns/network/protocol/link_layer.py
@@ -15,7 +15,6 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import uuid
 from collections import deque
 from collections.abc import Iterable
 from dataclasses import dataclass
@@ -34,6 +33,11 @@ from mqns.network.protocol.event import (
     QubitReleasedEvent,
 )
 from mqns.utils import json_encodable, log, rng
+
+_AUTOID = 0
+"""
+Automatically assigned ``ReservationRequest.key`` numeric portion.
+"""
 
 
 class ReserveMsg(TypedDict):
@@ -316,9 +320,11 @@ class LinkLayer(Application[QNode]):
               Key format: ``<node1>_<node2>_[<path_id>]_<local_qubit_addr>``
             - The reservation is communicated via a classical message using the ``RESERVE_QUBIT`` command.
         """
-
-        key = uuid.uuid4().hex
+        global _AUTOID
+        key = f"llk_{_AUTOID:028x}"
+        _AUTOID += 1
         assert key not in self.pending_init_reservation
+
         qubit.state, qubit.active = QubitState.ACTIVE, key
         self.pending_init_reservation[key] = (qchannel, next_hop, qubit)
         log.debug(f"{self.node}: start reservation key={key} dst={next_hop} addr={qubit.addr} path={qubit.path_id}")

--- a/mqns/network/protocol/link_layer.py
+++ b/mqns/network/protocol/link_layer.py
@@ -188,16 +188,24 @@ class LinkLayer(Application[QNode]):
 
         1. Run all active channels from reservation step.
 
+        Upon exiting EXTERNAL phase:
+
+        1. Clear incomplete reservations.
+        2. Clear unsatisfied reservation requests.
+
         Upon exiting INTERNAL phase:
 
         1. Clear existing memory qubits.
         """
         match event.action:
-            case TimingPhase.INTERNAL, False:
-                self.memory.clear()
             case TimingPhase.EXTERNAL, True:
                 for (qchannel, path_id), (neighbor, _) in self.active_channels.items():
                     self.run_active_channel(qchannel, path_id, neighbor)
+            case TimingPhase.EXTERNAL, False:
+                self.pending_init_reservation.clear()
+                self.fifo_reservation_req.clear()
+            case TimingPhase.INTERNAL, False:
+                self.memory.clear()
 
     def RecvClassicPacketHandler(self, event: RecvClassicPacket) -> bool:
         msg = event.packet.get()
@@ -340,10 +348,16 @@ class LinkLayer(Application[QNode]):
         2. A ``RESERVE_QUBIT_OK`` response is sent back to confirm the reservation.
         3. If no available qubit is found, the request is enqueued for future retry (FIFO).
         """
+        key = msg["key"]
+
+        if not self.node.timing.is_external():
+            log.debug(f"{self.node}: ignore reservation request key={key} reason=not-external-phase")
+            return
+
         from_node = cchannel.find_peer(self.node)
         assert type(from_node) is QNode
         qchannel = self.node.get_qchannel(from_node)
-        req = ReservationRequest(msg["key"], msg["path_id"], cchannel, from_node, qchannel)
+        req = ReservationRequest(key, msg["path_id"], cchannel, from_node, qchannel)
         if not self.try_accept_reservation(req):
             self.fifo_reservation_req.append(req)
 
@@ -385,6 +399,10 @@ class LinkLayer(Application[QNode]):
         1. Trigger the entanglement generation process using the reserved memory qubit.
         """
         key = msg["key"]
+        if not self.node.timing.is_external():
+            log.debug(f"{self.node}: ignore reservation response key={key} reason=not-external-phase")
+            return
+
         (qchannel, next_hop, qubit) = self.pending_init_reservation.pop(key)
         assert qubit.active == key
         qubit.state = QubitState.RESERVED

--- a/mqns/network/reactive/controller.py
+++ b/mqns/network/reactive/controller.py
@@ -15,7 +15,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from collections import defaultdict
+from collections import defaultdict, deque
 from itertools import pairwise
 from typing import cast, override
 
@@ -71,7 +71,7 @@ class ReactiveRoutingController(ClassicCommandDispatcherMixin, RoutingController
         self.add_handler(self.handle_classic_command, RecvClassicPacket)
         self.add_handler(self.handle_sync_phase, TimingPhaseEvent)
 
-        self._tls = defaultdict[tuple[str, str], set[str]](set)
+        self._tls = defaultdict[tuple[str, str], deque[str]](deque)
         """
         Topology link state.
 
@@ -110,7 +110,7 @@ class ReactiveRoutingController(ClassicCommandDispatcherMixin, RoutingController
         for entry in msg["ls"]:
             n0, n1 = entry["node"], entry["neighbor"]
             if n0 < n1:
-                self._tls[(n0, n1)].add(entry["qubit"])
+                self._tls[(n0, n1)].append(entry["qubit"])
 
         return True
 
@@ -149,7 +149,7 @@ class ReactiveRoutingController(ClassicCommandDispatcherMixin, RoutingController
         Attempt to match a computed route with available entanglements.
         The entanglements are removed from ``self._tls`` only if every link along the path has an entanglement.
         """
-        link_etgs: list[set[str]] = []
+        link_etgs: list[deque[str]] = []
 
         for n0, n1 in pairwise(route):
             etgs = self._tls.get((n0, n1) if n0 < n1 else (n1, n0))
@@ -157,4 +157,4 @@ class ReactiveRoutingController(ClassicCommandDispatcherMixin, RoutingController
                 return None
             link_etgs.append(etgs)
 
-        return [etgs.pop() for etgs in link_etgs]
+        return [etgs.popleft() for etgs in link_etgs]


### PR DESCRIPTION
* In `3_nodes_thruput.py` example, introduce `--mode=PCS` flag for Proactive-Centralized-Sync-timing mode (deferred from https://github.com/usnistgov/mqns/pull/130#discussion_r3126348124).
* In `3_nodes_thruput.py` example, generalize `--channel_capacity` as `--M` to allow asymmetric channels.
* Make reactive simulation deterministic, by replacing `uuid4` with auto-incremented counter in `Entanglement.key` and `ReservationRequest.key` field, and replacing `set` with `deque` in `ReactiveRoutingController`.
* In `LinkLayer`, ensure the reservation is only processed in EXTERNAL phase and prevent carrying over a reservation to another slot.
* In `multi_request_single_path.py` example, set `coordinated_decisions=True` to workaround ASAP swapping bug.
