### PR TITLE
refactor NetworkBuilder and improve fidelity accuracy

### DIFF
--- a/examples/3_nodes_purif.py
+++ b/examples/3_nodes_purif.py
@@ -3,7 +3,7 @@ import pandas as pd
 from tap import Tap
 
 from mqns.network.builder import CTRL_DELAY, NetworkBuilder
-from mqns.network.proactive import ProactiveForwarder
+from mqns.network.fw import ForwarderConsumeCounters
 from mqns.simulator import Simulator
 from mqns.utils import log, rng
 
@@ -45,8 +45,8 @@ def run_simulation(t_cohere: float, seed: int):
     s.run()
 
     #### get stats
-    fw_s = net.get_node("S").get_app(ProactiveForwarder)
-    return fw_s.cnt.n_consumed / sim_duration, fw_s.cnt.consumed_avg_fidelity
+    consume_cnt = ForwarderConsumeCounters.of_path(net, "S", "D")
+    return consume_cnt.get_rate(sim_duration), consume_cnt.consumed_avg_fidelity
 
 
 results = {"T_cohere": [], "Mean Rate": [], "Std Rate": [], "Mean F": [], "Std F": []}

--- a/examples/3_nodes_purif.py
+++ b/examples/3_nodes_purif.py
@@ -30,10 +30,10 @@ def run_simulation(t_cohere: float, seed: int):
     net = (
         NetworkBuilder()
         .topo_linear(
-            nodes=("S", "R", "D"),
+            nodes="SRD",
             t_cohere=t_cohere,
-            channel_length=[32, 18],
-            channel_capacity=2,
+            channels=[32, 18],
+            ch_capacity=2,
             init_fidelity=0.7,
         )
         .proactive_centralized()

--- a/examples/3_nodes_thruput.py
+++ b/examples/3_nodes_thruput.py
@@ -32,7 +32,7 @@ import pandas as pd
 from tap import Tap
 
 from mqns.network.builder import CTRL_DELAY, ChannelParam, EprTypeLiteral, LinkArchLiteral, NetworkBuilder, tap_configure
-from mqns.network.fw import Forwarder
+from mqns.network.fw import ForwarderConsumeCounters
 from mqns.network.protocol.link_layer import LinkLayerCounters
 from mqns.simulator import Simulator
 from mqns.utils import log, rng
@@ -133,14 +133,14 @@ def run_simulation(seed: int, args: Args, t_cohere: float) -> Stats:
     s = Simulator(0, total_duration, accuracy=1000000, install_to=(log, net))
     s.run()
 
-    fw_s_cnt = net.get_node("S").get_app(Forwarder).cnt
+    consume_cnt = ForwarderConsumeCounters.of_path(net, "S", "D")
     ll_cnt = LinkLayerCounters.aggregate(net.nodes)
     stats = Stats(
         t_cohere=t_cohere,
-        throughput_eps=fw_s_cnt.n_consumed / args.sim_duration,
-        mean_fidelity=fw_s_cnt.consumed_avg_fidelity,
+        throughput_eps=consume_cnt.get_rate(args.sim_duration),
+        mean_fidelity=consume_cnt.consumed_avg_fidelity,
         expired_ratio=ll_cnt.decoh_ratio,
-        expired_per_e2e=ll_cnt.n_decoh / fw_s_cnt.n_consumed if fw_s_cnt.n_consumed > 0 else 0,
+        expired_per_e2e=consume_cnt.get_per_consumed(ll_cnt.n_decoh),
     )
     return stats
 

--- a/examples/3_nodes_thruput.py
+++ b/examples/3_nodes_thruput.py
@@ -31,7 +31,7 @@ import numpy as np
 import pandas as pd
 from tap import Tap
 
-from mqns.network.builder import CTRL_DELAY, EprTypeLiteral, LinkArchLiteral, NetworkBuilder, tap_configure
+from mqns.network.builder import CTRL_DELAY, ChannelParam, EprTypeLiteral, LinkArchLiteral, NetworkBuilder, tap_configure
 from mqns.network.fw import Forwarder
 from mqns.network.protocol.link_layer import LinkLayerCounters
 from mqns.simulator import Simulator
@@ -71,9 +71,9 @@ class Args(Tap):
         if min(self.M) < 1:
             raise ValueError("--M must be positive")
 
-    def qchannel_capacity(self) -> int | list[tuple[int, int]]:
+    def linear_channels(self) -> tuple[ChannelParam, ChannelParam]:
         """
-        Derive ``NetworkBuilder.topo_linear(channel_capacity=)`` from ``--M``.
+        Derive ``NetworkBuilder.topo_linear(channels=)`` from ``--L`` and ``--M``.
 
         If ``--M`` has one integer, it is used as channel capacity on both S-R and R-D.
 
@@ -84,10 +84,15 @@ class Args(Tap):
         3. number of qubits on R assigned to R-D channel
         4. number of qubits on D assigned to R-D channel
         """
+        lSR, lRD = self.L
         if len(self.M) == 1:
-            return self.M[0]
-        mSr, mRl, mRr, mDl = self.M
-        return [(mSr, mRl), (mRr, mDl)]
+            mSr = mRl = mRr = mDl = self.M[0]
+        else:
+            mSr, mRl, mRr, mDl = self.M
+        return (
+            ChannelParam(ch_length=lSR, ch_capacity=(mSr, mRl)),
+            ChannelParam(ch_length=lRD, ch_capacity=(mRr, mDl)),
+        )
 
 
 SEED_BASE = 100
@@ -105,10 +110,9 @@ def run_simulation(seed: int, args: Args, t_cohere: float) -> Stats:
     rng.reseed(seed)
 
     b = NetworkBuilder().topo_linear(
-        nodes=("S", "R", "D"),
+        nodes="SRD",
         t_cohere=t_cohere,
-        channel_length=args.L,
-        channel_capacity=args.qchannel_capacity(),
+        channels=args.linear_channels(),
         link_arch=args.link_arch,
     )
 

--- a/examples/3_nodes_wait.py
+++ b/examples/3_nodes_wait.py
@@ -110,7 +110,7 @@ def run_simulation(seed: int, args: Args, t_cohere: float, t_wait: float):
         .request(
             "S-D",
             swap=[1, 0, 1],
-            swap_cutoff=[0, t_wait, 0],
+            swap_cutoff=[t_wait, t_wait],
         )
         .make_network()
     )

--- a/examples/3_nodes_wait.py
+++ b/examples/3_nodes_wait.py
@@ -47,7 +47,7 @@ from mqns.entity.base_channel import default_light_speed
 from mqns.models.error import TimeDecayInput
 from mqns.models.error.input import ErrorModelInputBasic, ErrorModelInputLength
 from mqns.network.builder import CTRL_DELAY, EprTypeLiteral, LinkArchLiteral, NetworkBuilder, tap_configure
-from mqns.network.fw import CutoffSchemeWaitTime
+from mqns.network.fw import CutoffSchemeWaitTime, ForwarderConsumeCounters
 from mqns.network.proactive import ProactiveForwarder
 from mqns.simulator import Simulator
 from mqns.utils import json_default, log, rng
@@ -115,8 +115,7 @@ def run_simulation(seed: int, args: Args, t_cohere: float, t_wait: float):
         .make_network()
     )
 
-    fwS = net.get_node("S").get_app(ProactiveForwarder)
-    fwS.cnt.enable_collect_all()
+    ForwarderConsumeCounters.enable_collect_all_on_path(net, "S", "D")
     fwR = net.get_node("R").get_app(ProactiveForwarder)
     waitR = CutoffSchemeWaitTime.of(fwR)
     waitR.cnt.enable_collect_all()
@@ -125,11 +124,12 @@ def run_simulation(seed: int, args: Args, t_cohere: float, t_wait: float):
     s.run()
     log.install(None)
 
-    rate = fwS.cnt.n_consumed / args.sim_duration
+    consume_cnt = ForwarderConsumeCounters.of_path(net, "S", "D")
+    rate = consume_cnt.get_rate(args.sim_duration)
     discard = fwR.cnt.n_cutoff[0] / args.sim_duration
-    assert fwS.cnt.consumed_fidelity_values is not None
+    assert consume_cnt.consumed_fidelity_values is not None
     assert waitR.cnt.wait_values is not None
-    return [rate], [discard], fwS.cnt.consumed_fidelity_values, waitR.cnt.wait_values
+    return [rate], [discard], consume_cnt.consumed_fidelity_values, waitR.cnt.wait_values
 
 
 class Stats(TypedDict):

--- a/examples/3_nodes_wait.py
+++ b/examples/3_nodes_wait.py
@@ -94,14 +94,14 @@ def run_simulation(seed: int, args: Args, t_cohere: float, t_wait: float):
             epr_type=args.epr_type,
         )
         .topo_linear(
-            nodes=("S", "R", "D"),
+            nodes="SRD",
             t_cohere=t_cohere,
             memory_decay=args.memory_decay,
-            channel_length=args.L,
+            channels=args.L,
+            init_fidelity=None if args.link_arch_sim else 0.99,
             fiber_error=args.fiber_error,
             bsa_error=args.bsa_error,
             link_arch=args.link_arch,
-            init_fidelity=None if args.link_arch_sim else 0.99,
         )
         .proactive_centralized(
             swap_delay=args.swap_delay,

--- a/examples/asymmetric_channel_3_nodes.py
+++ b/examples/asymmetric_channel_3_nodes.py
@@ -21,7 +21,7 @@ from tap import Tap
 
 from mqns.entity.qchannel import LinkArch, LinkArchDimBk, LinkArchSim, LinkArchSr
 from mqns.network.builder import CTRL_DELAY, ChannelParam, NetworkBuilder
-from mqns.network.proactive import ProactiveForwarder
+from mqns.network.fw import ForwarderConsumeCounters
 from mqns.simulator import Simulator
 from mqns.utils import log, rng
 
@@ -72,10 +72,8 @@ def run_simulation(
     s.run()
 
     #### get stats
-    fw_s = net.get_node("S").get_app(ProactiveForwarder)
-    e2e_rate = fw_s.cnt.n_consumed / sim_duration
-    mean_fidelity = fw_s.cnt.consumed_avg_fidelity
-    return e2e_rate, mean_fidelity
+    consume_cnt = ForwarderConsumeCounters.of_path(net, "S", "D")
+    return consume_cnt.get_rate(sim_duration), consume_cnt.consumed_avg_fidelity
 
 
 def run_row(

--- a/examples/asymmetric_channel_3_nodes.py
+++ b/examples/asymmetric_channel_3_nodes.py
@@ -20,7 +20,7 @@ import numpy as np
 from tap import Tap
 
 from mqns.entity.qchannel import LinkArch, LinkArchDimBk, LinkArchSim, LinkArchSr
-from mqns.network.builder import CTRL_DELAY, NetworkBuilder
+from mqns.network.builder import CTRL_DELAY, ChannelParam, NetworkBuilder
 from mqns.network.proactive import ProactiveForwarder
 from mqns.simulator import Simulator
 from mqns.utils import log, rng
@@ -56,10 +56,11 @@ def run_simulation(
     net = (
         NetworkBuilder()
         .topo_linear(
-            nodes=("S", "R", "D"),
-            channel_length=ch_lengths,
-            channel_capacity=ch_capacities,
-            link_arch=link_architectures,
+            nodes="SRD",
+            channels=[
+                ChannelParam(ch_length=l, ch_capacity=m, link_arch=la)
+                for l, m, la in zip(ch_lengths, ch_capacities, link_architectures, strict=True)
+            ],
             t_cohere=t_cohere,
         )
         .proactive_centralized()

--- a/examples/asymmetric_channel_memory.py
+++ b/examples/asymmetric_channel_memory.py
@@ -20,7 +20,7 @@ impact the end-to-end entanglement rate and qubit decoherence ratios.
 from tap import Tap
 
 from mqns.network.builder import CTRL_DELAY, NetworkBuilder
-from mqns.network.proactive import ProactiveForwarder
+from mqns.network.fw import ForwarderConsumeCounters
 from mqns.network.protocol.link_layer import LinkLayerCounters
 from mqns.simulator import Simulator
 from mqns.utils import log, rng
@@ -54,9 +54,9 @@ def run_simulation(seed: int, args: Args):
     s.run()
 
     #### get stats
-    decoh_ratio = LinkLayerCounters.aggregate(net.nodes).decoh_ratio
-    e2e_rate = net.get_node("S").get_app(ProactiveForwarder).cnt.n_consumed / args.sim_duration
-    return e2e_rate, decoh_ratio
+    consume_cnt = ForwarderConsumeCounters.of_path(net, "S", "D")
+    ll_cnt = LinkLayerCounters.aggregate(net.nodes)
+    return consume_cnt.get_rate(args.sim_duration), ll_cnt.decoh_ratio
 
 
 if __name__ == "__main__":

--- a/examples/asymmetric_channel_memory.py
+++ b/examples/asymmetric_channel_memory.py
@@ -42,8 +42,7 @@ def run_simulation(seed: int, args: Args):
         NetworkBuilder()
         .topo_linear(
             nodes=4,
-            channel_length=[32, 18, 10],
-            channel_capacity=[(4, 3), (1, 2), (2, 4)],
+            channels=[(32, (4, 3)), (18, (1, 2)), (10, (2, 4))],
             t_cohere=0.01,
         )
         .proactive_centralized()

--- a/examples/extctrl/src/lib.rs
+++ b/examples/extctrl/src/lib.rs
@@ -38,7 +38,7 @@ pub struct PathInstructions {
     pub req_id: u32,
     pub route: Vec<String>,
     pub swap: Vec<i32>,
-    pub swap_cutoff: Vec<i32>,
+    pub swap_cutoff: Option<Vec<i32>>,
     pub m_v: Option<Vec<MultiplexingVectorElem>>,
     pub purif: HashMap<String, String>,
 }

--- a/examples/extctrl/src/main.rs
+++ b/examples/extctrl/src/main.rs
@@ -160,7 +160,7 @@ fn make_path(req_id: u32, nodes: &str, opt: PathOpt) -> PathInstructions {
         req_id,
         route,
         swap: opt.to_swap(),
-        swap_cutoff: vec![-1; len],
+        swap_cutoff: None,
         m_v: Some(vec![MultiplexingVectorElem::Count(1, 1); len - 1]),
         purif: HashMap::new(),
     }

--- a/examples/linear_attempts.py
+++ b/examples/linear_attempts.py
@@ -82,8 +82,8 @@ def run_simulation(seed: int, sim_duration: float, L: list[float], M: int, link_
         NetworkBuilder()
         .topo_linear(
             nodes=len(L) + 1,
-            channel_length=L,
-            channel_capacity=M,
+            channels=L,
+            ch_capacity=M,
             link_arch=link_arch,
             t_cohere=0.1,
         )

--- a/examples/multi_request_single_path.py
+++ b/examples/multi_request_single_path.py
@@ -25,8 +25,7 @@ import numpy as np
 from tap import Tap
 
 from mqns.network.builder import CTRL_DELAY, NetworkBuilder
-from mqns.network.fw import MuxScheme, MuxSchemeDynamicEpr, MuxSchemeStatistical
-from mqns.network.proactive import ProactiveForwarder
+from mqns.network.fw import ForwarderConsumeCounters, MuxScheme, MuxSchemeDynamicEpr, MuxSchemeStatistical
 from mqns.simulator import Simulator
 from mqns.utils import log, rng
 
@@ -81,13 +80,12 @@ def run_simulation(seed: int, args: Args, mux: MuxScheme, t_cohere: float):
     s.run()
 
     #### get stats: e2e_rate and mean_fidelity
-    fw_s1 = net.get_node("S1").get_app(ProactiveForwarder)
-    fw_s2 = net.get_node("S2").get_app(ProactiveForwarder)
     # [(path 1), (path 2), ...]
-    return [
-        (fw_s1.cnt.n_consumed / args.sim_duration, fw_s1.cnt.consumed_avg_fidelity),
-        (fw_s2.cnt.n_consumed / args.sim_duration, fw_s2.cnt.consumed_avg_fidelity),
+    consume_cnts = [
+        ForwarderConsumeCounters.of_path(net, "S1", "D1"),
+        ForwarderConsumeCounters.of_path(net, "S2", "D2"),
     ]
+    return [(c.get_rate(args.sim_duration), c.consumed_avg_fidelity) for c in consume_cnts]
 
 
 class PathStats(NamedTuple):

--- a/examples/multiplexing.py
+++ b/examples/multiplexing.py
@@ -7,6 +7,7 @@ from tap import Tap
 
 from mqns.network.builder import CTRL_DELAY, NetworkBuilder
 from mqns.network.fw import (
+    ForwarderConsumeCounters,
     MultiplexingVector,
     MuxScheme,
     MuxSchemeBufferSpace,
@@ -200,9 +201,8 @@ def run_simulation(seed: int, args: Args, mux: MuxScheme, active_flows: list[Flo
 
     # Collect per-source stats in fixed order [AK, BL, CI, DH, GM]
     def _get_rate_fid(flow: FlowDef):
-        node = net.get_node(flow.route[0])
-        fw = node.get_app(ProactiveForwarder)
-        return (fw.cnt.n_consumed / args.sim_duration, fw.cnt.consumed_avg_fidelity)
+        consume_cnt = ForwarderConsumeCounters.of_path(net, flow.route[0], flow.route[-1])
+        return consume_cnt.get_rate(args.sim_duration), consume_cnt.consumed_avg_fidelity
 
     stats: list[tuple[float, float]] = []  # [(AK), (BL), (CI), (DH), (GM)] # disabled flows have zero stats
     for flow in FLOWS:

--- a/examples/s2uc.py
+++ b/examples/s2uc.py
@@ -1,0 +1,164 @@
+"""
+This script simulates a linear topology with ``CutoffSchemeWaitTime``.
+The controller sets wait-time budgets so that the end-to-end EPRs are delivered with a certain minimal fidelity.
+"""
+
+import csv
+import itertools
+import json
+from dataclasses import dataclass
+from multiprocessing import Pool, freeze_support
+from typing import TypedDict, override
+
+import numpy as np
+from tap import Tap
+
+from mqns.entity.qchannel import LinkArchDimDual
+from mqns.models.epr import MixedStateEntanglement
+from mqns.network.builder import CTRL_DELAY, NetworkBuilder, tap_configure
+from mqns.network.proactive import ProactiveForwarder
+from mqns.simulator import Simulator
+from mqns.utils import log, rng
+
+log.set_default_level("CRITICAL")
+
+
+class Args(Tap):
+    workers: int = 1  # number of workers for parallel execution
+    runs: int = 10  # number of trials per parameter set
+    sim_duration: float = 1.0  # simulation duration in seconds
+    json: str = ""  # save stats as JSON file
+    csv: str = ""  # save stats summary as CSV file
+
+    @override
+    def configure(self) -> None:
+        tap_configure(self)
+
+
+SIMULATOR_ACCURACY = 1000000
+SEED_BASE = 100
+
+
+@dataclass
+class RowInput:
+    f_req: float
+    """Required fidelity."""
+    w: tuple[float, float]
+    """Wait-time budgets."""
+
+
+ROW_INPUTS: list[RowInput] = [
+    RowInput(0.75, (0.031731, 0.023798)),
+    RowInput(0.7823, (0.023991, 0.017993)),
+    RowInput(0.8146, (0.017056, 0.012792)),
+    RowInput(0.8469, (0.010775, 0.008081)),
+    RowInput(0.8791, (0.005053, 0.003789)),
+    RowInput(0.8904, (0.003155, 0.002367)),
+    RowInput(0.9001, (0.001569, 0.001177)),
+    RowInput(0.9098, (1.9e-05, 1.4e-05)),
+]
+
+
+class Stats(TypedDict):
+    count: int
+    """Rate -- number of entanglements consumed."""
+    fid: list[float]
+    """Fidelity -- individual fidelity values."""
+
+
+class Row(TypedDict):
+    f_req: float
+    """Required fidelity."""
+    details: list[Stats]
+    """Per-run statistics."""
+
+
+def convert_fidelity(raw_fidelity: float, x_ratio: float, y_ratio: float, z_ratio: float):
+    p_error = 1 - raw_fidelity
+    return raw_fidelity, p_error * z_ratio, p_error * x_ratio, p_error * y_ratio
+
+
+def run_simulation(seed: int, args: Args, ri: RowInput) -> Stats:
+    rng.reseed(seed)
+
+    net = (
+        NetworkBuilder(
+            epr_type=MixedStateEntanglement,
+        )
+        .topo_linear(
+            nodes=("S", "R", "D"),
+            channel_length=(32, 18),
+            fiber_alpha=0.2,
+            link_arch=LinkArchDimDual,
+            t_cohere=1 / 10,  # TODO change coherence rate of S to 5 Hz
+            init_fidelity=convert_fidelity(0.9677, 0.1547, 0.1547, 0.6907),
+            # TODO two links should have different init_fidelity
+            eta_d=0.58,
+            eta_s=0.99,
+            frequency=80e6,
+        )
+        .proactive_centralized(
+            p_swap=0.5,
+            swap_delay=340e-6,
+            swap_error=None,  # TODO memory decoherence should continue during swap
+            # TODO set LinkArch local processing time tau_0=10e-6
+        )
+        .request(
+            "S-D",
+            swap_cutoff=ri.w,
+        )
+        .make_network()
+    )
+
+    fwS = net.get_node("S").get_app(ProactiveForwarder)
+    fwD = net.get_node("D").get_app(ProactiveForwarder)
+
+    fwS.cnt.enable_collect_all()
+
+    s = Simulator(0, args.sim_duration + CTRL_DELAY, accuracy=SIMULATOR_ACCURACY, install_to=(log, net))
+    s.run()
+
+    # XXX off-by-one is possible if the simulation terminates when the final message is in flight
+    assert fwS.cnt.n_consumed == fwD.cnt.n_consumed
+    assert abs(fwS.cnt.consumed_sum_fidelity - fwD.cnt.consumed_sum_fidelity) < 1e-3
+    assert fwS.cnt.consumed_fidelity_values is not None
+    return Stats(
+        count=fwS.cnt.n_consumed,
+        fid=fwS.cnt.consumed_fidelity_values,
+    )
+
+
+def run_row(args: Args, ri: RowInput) -> Row:
+    details: list[Stats] = []
+    for i in range(args.runs):
+        details.append(run_simulation(SEED_BASE + i, args, ri))
+    return Row(f_req=ri.f_req, details=details)
+
+
+def main(args: Args) -> list[Row]:
+    with Pool(processes=args.workers) as pool:
+        rows = pool.starmap(run_row, itertools.product([args], ROW_INPUTS))
+
+    if args.json:
+        with open(args.json, "w") as file:
+            json.dump(rows, file)
+
+    if args.csv:
+        with open(args.csv, "w", newline="") as file:
+            w = csv.writer(file)
+            w.writerow(["f_req", "rate_mean", "rate_std", "f_mean", "f_std"])
+            for row in rows:
+                rates = np.fromiter((s["count"] for s in row["details"]), dtype=float) / args.sim_duration
+                fids = np.fromiter((f for s in row["details"] for f in s["fid"]), dtype=float)
+                if len(fids) == 0:
+                    fids = np.array([0])
+                w.writerow([row["f_req"], rates.mean(), rates.std(), fids.mean(), fids.std()])
+
+    return rows
+
+
+if __name__ == "__main__":
+    freeze_support()
+    args = Args().parse_args()
+    main(args)
+    # TODO plotting

--- a/examples/s2uc.py
+++ b/examples/s2uc.py
@@ -86,8 +86,8 @@ def run_simulation(seed: int, args: Args, ri: RowInput) -> Stats:
             epr_type=MixedStateEntanglement,
         )
         .topo_linear(
-            nodes=("S", "R", "D"),
-            channel_length=(32, 18),
+            nodes="SRD",
+            channels=(32, 18),
             fiber_alpha=0.2,
             link_arch=LinkArchDimDual,
             t_cohere=1 / 10,  # TODO change coherence rate of S to 5 Hz

--- a/examples/s2uc.py
+++ b/examples/s2uc.py
@@ -15,7 +15,7 @@ from tap import Tap
 
 from mqns.entity.qchannel import LinkArchDimDual
 from mqns.models.epr import MixedStateEntanglement
-from mqns.network.builder import CTRL_DELAY, NetworkBuilder, tap_configure
+from mqns.network.builder import CTRL_DELAY, ChannelParam, NetworkBuilder, NodeDef, tap_configure
 from mqns.network.proactive import ProactiveForwarder
 from mqns.simulator import Simulator
 from mqns.utils import log, rng
@@ -86,22 +86,27 @@ def run_simulation(seed: int, args: Args, ri: RowInput) -> Stats:
             epr_type=MixedStateEntanglement,
         )
         .topo_linear(
-            nodes="SRD",
-            channels=(32, 18),
+            nodes=[
+                NodeDef("S", t_cohere=1 / 5),
+                "R",
+                "D",
+            ],
+            t_cohere=1 / 10,
+            channels=[
+                ChannelParam(ch_length=32, init_fidelity=convert_fidelity(0.9474, 0.1427, 0.1427, 0.7147)),
+                ChannelParam(ch_length=18, init_fidelity=convert_fidelity(0.9677, 0.1547, 0.1547, 0.6907)),
+            ],
             fiber_alpha=0.2,
             link_arch=LinkArchDimDual,
-            t_cohere=1 / 10,  # TODO change coherence rate of S to 5 Hz
-            init_fidelity=convert_fidelity(0.9677, 0.1547, 0.1547, 0.6907),
-            # TODO two links should have different init_fidelity
             eta_d=0.58,
             eta_s=0.99,
             frequency=80e6,
+            tau_0=10e-6,
         )
         .proactive_centralized(
             p_swap=0.5,
             swap_delay=340e-6,
             swap_error=None,  # TODO memory decoherence should continue during swap
-            # TODO set LinkArch local processing time tau_0=10e-6
         )
         .request(
             "S-D",

--- a/examples/s2uc.py
+++ b/examples/s2uc.py
@@ -16,7 +16,7 @@ from tap import Tap
 from mqns.entity.qchannel import LinkArchDimDual
 from mqns.models.epr import MixedStateEntanglement
 from mqns.network.builder import CTRL_DELAY, ChannelParam, NetworkBuilder, NodeDef, tap_configure
-from mqns.network.proactive import ProactiveForwarder
+from mqns.network.fw import ForwarderConsumeCounters
 from mqns.simulator import Simulator
 from mqns.utils import log, rng
 
@@ -115,21 +115,16 @@ def run_simulation(seed: int, args: Args, ri: RowInput) -> Stats:
         .make_network()
     )
 
-    fwS = net.get_node("S").get_app(ProactiveForwarder)
-    fwD = net.get_node("D").get_app(ProactiveForwarder)
-
-    fwS.cnt.enable_collect_all()
+    ForwarderConsumeCounters.enable_collect_all_on_path(net, "S", "D")
 
     s = Simulator(0, args.sim_duration + CTRL_DELAY, accuracy=SIMULATOR_ACCURACY, install_to=(log, net))
     s.run()
 
-    # XXX off-by-one is possible if the simulation terminates when the final message is in flight
-    assert fwS.cnt.n_consumed == fwD.cnt.n_consumed
-    assert abs(fwS.cnt.consumed_sum_fidelity - fwD.cnt.consumed_sum_fidelity) < 1e-3
-    assert fwS.cnt.consumed_fidelity_values is not None
+    consume_cnt = ForwarderConsumeCounters.of_path(net, "S", "D")
+    assert consume_cnt.consumed_fidelity_values is not None
     return Stats(
-        count=fwS.cnt.n_consumed,
-        fid=fwS.cnt.consumed_fidelity_values,
+        count=consume_cnt.n_consumed,
+        fid=consume_cnt.consumed_fidelity_values,
     )
 
 

--- a/examples/scalability_randomtopo/srt_detail/defs.py
+++ b/examples/scalability_randomtopo/srt_detail/defs.py
@@ -100,13 +100,12 @@ def build_network(args: RunArgs) -> QuantumNetwork:
     topo = RandomTopology(
         nodes_number=args.nodes,
         lines_number=args.edges,
-        qchannel_args={"length": 30, "alpha": fiber_alpha},
+        qchannel_args={"length": 30, "alpha": fiber_alpha, "init_fidelity": init_fidelity},
         cchannel_args={"length": 30},
         memory_args={"capacity": nqubits, "t_cohere": t_cohere},
         nodes_apps=[
             LinkLayer(
                 attempt_rate=entg_attempt_rate,
-                init_fidelity=init_fidelity,
                 eta_d=eta_d,
                 eta_s=eta_s,
                 frequency=frequency,

--- a/examples/scalability_randomtopo/srt_mqns.py
+++ b/examples/scalability_randomtopo/srt_mqns.py
@@ -2,7 +2,7 @@ import json
 import os.path
 
 from mqns.entity.node import QNode
-from mqns.network.fw import QubitAllocationType, RoutingPathSingle
+from mqns.network.fw import ForwarderConsumeCounters, QubitAllocationType, RoutingPathSingle
 from mqns.network.network import Request
 from mqns.network.proactive import ProactiveForwarder, ProactiveRoutingController
 from mqns.network.protocol.link_layer import LinkLayer
@@ -37,8 +37,8 @@ def run_simulation(args: RunArgs) -> RunResult:
 
     # Collect results.
     def gather_request_stats(req: Request) -> RequestStats:
-        fw = req.src.get_app(ProactiveForwarder)
-        return fw.cnt.n_consumed / sim_duration, fw.cnt.consumed_avg_fidelity
+        consume_cnt = ForwarderConsumeCounters.of_path(net, req.src.name, req.dst.name)
+        return consume_cnt.get_rate(sim_duration), consume_cnt.consumed_avg_fidelity
 
     def gather_node_stats(node: QNode):
         fw = node.get_app(ProactiveForwarder)

--- a/examples/single_request_multipath.py
+++ b/examples/single_request_multipath.py
@@ -17,7 +17,7 @@ alter the total end-to-end entanglement generation rate and overall qubit decohe
 from tap import Tap
 
 from mqns.network.builder import CTRL_DELAY, NetworkBuilder
-from mqns.network.proactive import ProactiveForwarder
+from mqns.network.fw import ForwarderConsumeCounters
 from mqns.network.protocol.link_layer import LinkLayerCounters
 from mqns.network.route import YenRouteAlgorithm
 from mqns.simulator import Simulator
@@ -72,8 +72,8 @@ def run_simulation(seed: int, args: Args):
 
     #### get stats
     decoh_ratio = LinkLayerCounters.aggregate(net.nodes).decoh_ratio
-    e2e_rate = net.get_node("S").get_app(ProactiveForwarder).cnt.n_consumed / args.sim_duration
-    return e2e_rate, decoh_ratio
+    consume_cnt = ForwarderConsumeCounters.of_path(net, "S", "D")
+    return consume_cnt.get_rate(args.sim_duration), decoh_ratio
 
 
 if __name__ == "__main__":

--- a/examples/swapping_policies_6_nodes.py
+++ b/examples/swapping_policies_6_nodes.py
@@ -29,9 +29,7 @@ import numpy as np
 from tap import Tap
 
 from mqns.network.builder import CTRL_DELAY, NetworkBuilder
-from mqns.network.fw import SwapPolicy
-from mqns.network.proactive import ProactiveForwarder
-from mqns.network.protocol.link_layer import LinkLayerCounters
+from mqns.network.fw import ForwarderConsumeCounters, SwapPolicy
 from mqns.simulator import Simulator
 from mqns.utils import log, rng
 
@@ -74,11 +72,8 @@ def run_simulation(
     s.run()
 
     #### get stats
-    decoh_ratio = LinkLayerCounters.aggregate(net.nodes).decoh_ratio
-    fw_s = net.get_node("S").get_app(ProactiveForwarder)
-    e2e_rate = fw_s.cnt.n_consumed / sim_duration
-    mean_fidelity = fw_s.cnt.consumed_avg_fidelity
-    return e2e_rate, decoh_ratio, mean_fidelity
+    consume_cnt = ForwarderConsumeCounters.of_path(net, "S", "D")
+    return consume_cnt.get_rate(sim_duration)
 
 
 type Results = dict[str, dict[SwapPolicy, dict[float, tuple[float, float]]]]
@@ -171,7 +166,7 @@ if __name__ == "__main__":
 
                     ch_capacities = mem_allocs
 
-                    rate, *_ = run_simulation(
+                    rate = run_simulation(
                         ch_capacities=ch_capacities,
                         t_cohere=t_cohere,
                         swapping_order=swapping_config,

--- a/examples/swapping_policies_6_nodes.py
+++ b/examples/swapping_policies_6_nodes.py
@@ -63,8 +63,7 @@ def run_simulation(
             nodes=N_NODES,
             mem_capacity=TOTAL_QUBITS,
             t_cohere=t_cohere,
-            channel_length=CHANNEL_LENGTHS,
-            channel_capacity=ch_capacities,
+            channels=list(zip(CHANNEL_LENGTHS, ch_capacities, strict=True)),
         )
         .proactive_centralized()
         .request("S-D", swap=swapping_order)

--- a/examples/template_linear.py
+++ b/examples/template_linear.py
@@ -22,8 +22,7 @@ from tap import Tap
 
 from mqns.entity.qchannel import LinkArchDimBk, LinkArchSim, LinkArchSr
 from mqns.network.builder import CTRL_DELAY, NetworkBuilder
-from mqns.network.fw import SwapSequenceInput
-from mqns.network.proactive import ProactiveForwarder
+from mqns.network.fw import ForwarderConsumeCounters, SwapSequenceInput
 from mqns.network.protocol.link_layer import LinkLayerCounters
 from mqns.simulator import Simulator
 from mqns.utils import log, rng
@@ -185,19 +184,18 @@ def run_simulation(
     # ── Extract metrics ───────────────────────────────────────────────────────
     out: dict[str, float] = {}
 
-    fw_s = net.get_node("S").get_app(ProactiveForwarder)
-    e2e_count = fw_s.cnt.n_consumed
+    consume_cnt = ForwarderConsumeCounters.of_path(net, "S", "D")
 
     if "throughput" in MEASURES:
-        out["throughput_eps"] = e2e_count / SIM_DURATION
+        out["throughput_eps"] = consume_cnt.get_rate(SIM_DURATION)
 
     if "mean_fidelity" in MEASURES:
-        out["mean_fidelity"] = float(fw_s.cnt.consumed_avg_fidelity)
+        out["mean_fidelity"] = consume_cnt.consumed_avg_fidelity
 
     if "expired_ratio" in MEASURES:
         ll_cnt = LinkLayerCounters.aggregate(net.nodes)
         out["expired_ratio"] = float(ll_cnt.decoh_ratio)
-        out["expired_per_e2e_safe"] = float(ll_cnt.n_decoh / e2e_count) if e2e_count > 0 else 0.0
+        out["expired_per_e2e_safe"] = consume_cnt.get_per_consumed(ll_cnt.n_decoh)
 
     return out
 

--- a/examples/template_linear.py
+++ b/examples/template_linear.py
@@ -64,37 +64,31 @@ DEFAULT_RUNS = 10  #  Can be changed via --runs flag
 #   - list[str]: explicit names (must include "S" and "D")
 NODES: int | list[str] = 4
 
-# channel_length:
-#   - float: uniform length for every link
-#   - list[float]: per-link lengths (must have n_links = len(nodes)-1 values)
-CHANNEL_LENGTH: float | list[float] = [32.0, 18.0, 10.0]
+# channel_length (must have n_links = len(nodes)-1 values)
+CHANNEL_LENGTH: list[float] = [32.0, 18.0, 10.0]
 
-# channel_capacity:
-#   - int: uniform capacity for every link (left == right == capacity)
-#   - list[int]: per-link capacity (left == right for each link)
-#   - list[tuple[int,int]]: per-link (left,right) endpoint allocation
+# Channel capacity used when SWEEP = False
 #
-# NetworkBuilder interprets (left,right) as:
-#   - capacity1 = allocation at node i
-#   - capacity2 = allocation at node i+1
-CHANNEL_CAPACITY: int | list[int] | list[tuple[int, int]] = 3
+# Note: NetworkBuilder allows specifying distinct channel capacities for each link.
+# To use this feature, pass a list of ChannelParam objects into channels= argument.
+CHANNEL_CAPACITY: int = 3
 
 # mem_capacity:
-#   - None: derived from channel_capacity (recommended for allocation-consistent setups)
-#   - int: uniform #qubits per node
-#   - list[int]: per-node #qubits
-MEM_CAPACITY: int | list[int] | None = None
+#   - -1: derived from channel_capacity (recommended for allocation-consistent setups)
+#   - positive integer: uniform #qubits per node
+MEM_CAPACITY: int = -1
 
 # Memory coherence time (seconds) used when SWEEP = False
 T_COHERE = 0.01
 
-# link_arch:
-#   - pass a LinkArch instance (broadcast to all links)
-#   - pass list[LinkArch] (per-link)
+# Link Architecture:
+#   - LinkArchDimBk: Detection-in-Midpoint with single-rail encoding using Barrett-Kok protocol
+#   - LinkArchSim: Source-in-Midpoint with dual-rail polarization encoding
+#   - LinkArchSr: Sender-Receiver with dual-rail polarization encoding
 #
-# If you want custom architectures, uncomment and edit:
-# LINK_ARCH = [LinkArchSr(), LinkArchSim(), ...]
-LINK_ARCH = [LinkArchDimBk(), LinkArchDimBk(), LinkArchDimBk()]
+# Note: NetworkBuilder allows specifying distinct link architectures for each link.
+# To use this feature, pass a list of ChannelParam objects into channels= argument.
+LINK_ARCH = LinkArchDimBk
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -133,7 +127,7 @@ SWEEP = True
 # Supported sweep variables:
 t_cohere_values = [0.005, 0.01, 0.02]  # seconds
 swap_values: list[SwapSequenceInput] = ["l2r", "r2l", "asap"]  # see SWAP
-channel_capacity_values = [CHANNEL_CAPACITY]  # include alternative allocations if desired
+channel_capacity_values = [2, 3]  # include alternative allocations if desired
 
 
 # What to measure:
@@ -149,8 +143,7 @@ def run_simulation(
     seed: int,
     t_cohere: float,
     swap: SwapSequenceInput,
-    channel_capacity: int | list[int] | list[tuple[int, int]],
-    channel_length: float | list[float] = CHANNEL_LENGTH,
+    channel_capacity: int,
     nodes: int | list[str] = NODES,
 ) -> dict[str, float]:
     """
@@ -169,10 +162,9 @@ def run_simulation(
             nodes=nodes,
             mem_capacity=MEM_CAPACITY,
             t_cohere=t_cohere,
-            channel_length=channel_length,
-            channel_capacity=channel_capacity,
+            channels=CHANNEL_LENGTH,
+            ch_capacity=channel_capacity,
             fiber_alpha=FIBER_ALPHA,
-            link_arch=LINK_ARCH,
             entg_attempt_rate=ENTG_ATTEMPT_RATE,
             init_fidelity=INIT_FIDELITY,
             eta_d=ETA_D,
@@ -215,7 +207,7 @@ def run_row(
     n_runs: int,
     t_cohere: float,
     swap: SwapSequenceInput,
-    channel_capacity: int | list[int] | list[tuple[int, int]],
+    channel_capacity: int,
 ) -> dict[str, Any]:
     """
     Run n_runs trials for one parameter point and return mean/std + raw lists.

--- a/examples/template_routing.py
+++ b/examples/template_routing.py
@@ -49,6 +49,7 @@ from tap import Tap
 
 from mqns.network.builder import CTRL_DELAY, NetworkBuilder
 from mqns.network.fw import (
+    ForwarderConsumeCounters,
     MultiplexingVector,
     MuxScheme,
     MuxSchemeBufferSpace,
@@ -61,7 +62,6 @@ from mqns.network.fw import (
 )
 from mqns.network.network import QuantumNetwork
 from mqns.network.network.timing import TimingModeSync
-from mqns.network.proactive import ProactiveForwarder
 from mqns.network.route import DijkstraRouteAlgorithm, YenRouteAlgorithm
 from mqns.simulator import Simulator
 from mqns.utils import log, rng
@@ -297,13 +297,11 @@ def run_one(t_cohere: float, seed: int) -> dict[str, tuple[float, float]]:
     sim = Simulator(0, SIM_DURATION + CTRL_DELAY, accuracy=1_000_000, install_to=(log, net))
     sim.run()
 
-    # Collect stats at selected sources (one per “request” in this tutorial pattern)
+    # Collect stats for selected requests
     out: dict[str, tuple[float, float]] = {}
-    for src, label in zip(SC.measured_sources, SC.measured_labels):
-        fw = net.get_node(src).get_app(ProactiveForwarder)
-        rate = fw.cnt.n_consumed / SIM_DURATION
-        fid = fw.cnt.consumed_avg_fidelity
-        out[label] = (rate, fid)
+    for rp, label in zip(SC.install_paths, SC.measured_labels, strict=True):
+        consume_cnt = ForwarderConsumeCounters.of_path(net, rp.src, rp.dst)
+        out[label] = consume_cnt.get_rate(SIM_DURATION), consume_cnt.consumed_avg_fidelity
 
     return out
 

--- a/examples/vora_evaluation.py
+++ b/examples/vora_evaluation.py
@@ -51,9 +51,9 @@ import pandas as pd
 from tap import Tap
 
 from mqns.network.builder import CTRL_DELAY, NetworkBuilder
-from mqns.network.fw import SwapPolicy, SwapSequence, SwapSequenceInput
+from mqns.network.fw import ForwarderConsumeCounters, SwapPolicy, SwapSequence, SwapSequenceInput
 from mqns.network.network import QuantumNetwork
-from mqns.network.proactive import ProactiveForwarder, compute_vora_swap_sequence
+from mqns.network.proactive import compute_vora_swap_sequence
 from mqns.network.protocol.link_layer import LinkLayerCounters
 from mqns.simulator import Simulator
 from mqns.utils import log, rng
@@ -193,9 +193,9 @@ def run_simulation(p: ParameterSet, seed: int) -> tuple[float, float]:
     s.run()
 
     #### get stats
-    total_decohered = LinkLayerCounters.aggregate(net.nodes).n_decoh
-    e2e_count = net.get_node("S").get_app(ProactiveForwarder).cnt.n_consumed
-    return e2e_count / p.sim_duration, total_decohered / e2e_count if e2e_count > 0 else 0
+    consume_cnt = ForwarderConsumeCounters.of_path(net, "S", "D")
+    ll_cnt = LinkLayerCounters.aggregate(net.nodes)
+    return consume_cnt.get_rate(p.sim_duration), consume_cnt.get_per_consumed(ll_cnt.n_decoh)
 
 
 def run_row(p: ParameterSet, num_routers: int, dist_prop: str, swap_conf: str) -> dict:

--- a/examples/vora_evaluation.py
+++ b/examples/vora_evaluation.py
@@ -121,8 +121,8 @@ class ParameterSet:
             .topo_linear(
                 nodes=2 + self.number_of_routers,
                 t_cohere=self.t_cohere,
-                channel_length=distances,
-                channel_capacity=self.qchannel_capacity,
+                channels=distances,
+                ch_capacity=self.qchannel_capacity,
             )
             .proactive_centralized()
             .request("S-D", swap=swap)

--- a/mqns/entity/memory/memory.py
+++ b/mqns/entity/memory/memory.py
@@ -337,7 +337,6 @@ class QuantumMemory(Entity):
         *,
         must: Literal[True] = True,
         has: type[M],
-        set_fidelity=False,
         remove: bool | QuantumModel = False,
     ) -> tuple[MemoryQubit, M]:
         """
@@ -347,7 +346,6 @@ class QuantumMemory(Entity):
             key: Qubit address or reservation key.
             must: True (implied).
             has: Expected type of stored data.
-            set_fidelity: Whether to update fidelity, XXX current formula is inaccurate for EPRs.
             remove: Whether to remove the data.
                     If specified as QuantumModel, remove only if stored data is the same object.
 
@@ -365,7 +363,6 @@ class QuantumMemory(Entity):
         *,
         must=False,
         has: type[M] | None = None,
-        set_fidelity=False,
         remove: bool | QuantumModel = False,
     ):
         if type(key) is int:
@@ -380,9 +377,6 @@ class QuantumMemory(Entity):
 
         if has and type(data) is not has:
             raise ValueError(f"{self}: data at {qubit.addr} is not {has}")
-
-        if set_fidelity and isinstance(data, Entanglement) and not data.read:
-            data.apply_store_decays(self.simulator.tc)
 
         if remove in (True, data):
             qubit.events.discard(MemoryDecohereEvent)

--- a/mqns/entity/qchannel/link_arch.py
+++ b/mqns/entity/qchannel/link_arch.py
@@ -25,12 +25,14 @@ class ChannelParameters(Protocol):
     Fiber propagation delay in seconds, also used as one-way classical message delay.
     This must reflect a constant delay.
     """
+    init_fidelity: float | Sequence[float] | None
+    """Initial fidelity value for entanglements delivered by this channel."""
     transfer_error: ErrorModel
     """
     Fiber transfer error model.
     This is only used if ``init_fidelity`` is omitted or negative.
 
-    If the LinkArch subclass needs to apply transfer error at a different length,
+    If the ``LinkArch`` subclass needs to apply transfer error at a different length,
     it will clone the instance and adjust the length while preserving the decoherence rate.
     """
     bsa_error: ErrorModel
@@ -53,18 +55,6 @@ class LinkArchParameters(TypedDict):
     """Local operation delay in seconds."""
     epr_type: type[Entanglement]
     """EPR type, either ``WernerStateEntanglement`` or ``MixedStateEntanglement``."""
-    init_fidelity: NotRequired[float | Sequence[float] | None]
-    """
-    Initial fidelity value.
-
-    If set as float, every entanglement has a Werner state with the specified fidelity.
-    If set as four floats, every entanglement has a Bell-diagonal state with the specified I,Z,X,Y values.
-    In these cases, the specified fidelity must be tuned to the EPR creation time,
-    which is generally when the first photon is emitted or absorbed by a memory.
-
-    If omitted or ``None``, a mini simulation is performed to determine the proper fidelity values,
-    by applying error models to the memories, fibers, etc.
-    """
     t0: NotRequired[Time]
     """
     Time reference for mini simulation; only the accuracy is used.
@@ -172,7 +162,7 @@ class LinkArchBase(ABC, LinkArch):
             tau_0=kwargs["tau_0"],
         )
 
-        if (init_fidelity := kwargs.get("init_fidelity")) is None:
+        if (init_fidelity := ch.init_fidelity) is None:
             self._make_epr: MakeEprFunc = self._prepare_make_epr(kwargs, ch, tau_l)
         elif isinstance(init_fidelity, Sequence):
             assert kwargs["epr_type"] is MixedStateEntanglement

--- a/mqns/entity/qchannel/link_arch.py
+++ b/mqns/entity/qchannel/link_arch.py
@@ -1,9 +1,10 @@
 import copy
 from abc import ABC, abstractmethod
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from typing import NotRequired, Protocol, TypedDict, Unpack, override
 
 from mqns.entity.node import QNode
+from mqns.models.core.bell_diagonal import make_bell_diagonal_probv
 from mqns.models.delay import DelayModel
 from mqns.models.epr import Entanglement, EntanglementInitKwargs, MixedStateEntanglement, WernerStateEntanglement
 from mqns.models.error import ErrorModel, TimeDecayFunc, time_decay_nop
@@ -52,11 +53,14 @@ class LinkArchParameters(TypedDict):
     """Local operation delay in seconds."""
     epr_type: type[Entanglement]
     """EPR type, either ``WernerStateEntanglement`` or ``MixedStateEntanglement``."""
-    init_fidelity: NotRequired[float | None]
+    init_fidelity: NotRequired[float | Sequence[float] | None]
     """
     Initial fidelity value.
 
-    If set, every entanglement has a Werner state with the specified fidelity.
+    If set as float, every entanglement has a Werner state with the specified fidelity.
+    If set as four floats, every entanglement has a Bell-diagonal state with the specified I,Z,X,Y values.
+    In these cases, the specified fidelity must be tuned to the EPR creation time,
+    which is generally when the first photon is emitted or absorbed by a memory.
 
     If omitted or ``None``, a mini simulation is performed to determine the proper fidelity values,
     by applying error models to the memories, fibers, etc.
@@ -170,6 +174,17 @@ class LinkArchBase(ABC, LinkArch):
 
         if (init_fidelity := kwargs.get("init_fidelity")) is None:
             self._make_epr: MakeEprFunc = self._prepare_make_epr(kwargs, ch, tau_l)
+        elif isinstance(init_fidelity, Sequence):
+            assert kwargs["epr_type"] is MixedStateEntanglement
+            assert len(init_fidelity) == 4
+            probv = make_bell_diagonal_probv(*init_fidelity)
+
+            def _make_epr_with_probv(a: EntanglementInitKwargs) -> Entanglement:
+                epr = MixedStateEntanglement(**a)
+                epr.set_probv(probv, normalize=False)
+                return epr
+
+            self._make_epr = _make_epr_with_probv
         else:
             epr_type = kwargs["epr_type"]
             assert 0 <= init_fidelity <= 1

--- a/mqns/entity/qchannel/qchannel.py
+++ b/mqns/entity/qchannel/qchannel.py
@@ -26,6 +26,7 @@
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import copy
+from collections.abc import Sequence
 from typing import Unpack, final, override
 
 from mqns.entity.base_channel import BaseChannel, BaseChannelInitKwargs, calc_transmission_prob
@@ -52,6 +53,18 @@ class QuantumChannelInitKwargs(BaseChannelInitKwargs, total=False):
     In ``LinkArch``, this parameter determines the success probability,
     but does not affect the decoherence / quality of the state given the photon arrived.
     """
+    init_fidelity: float | Sequence[float] | None
+    """
+    Initial fidelity value for entanglements delivered by this channel.
+
+    If set as float, every entanglement has a Werner state with the specified fidelity.
+    If set as four floats, every entanglement has a Bell-diagonal state with the specified I,Z,X,Y values.
+    In these cases, the specified fidelity must be tuned to the EPR creation time,
+    which is generally when the first photon is emitted or absorbed by a memory.
+
+    If omitted or ``None``, ``LinkArch`` performs a mini simulation to determine the proper fidelity values,
+    by applying error models to the memories, fibers, etc.
+    """
     transfer_error: ErrorModelInputLength
     """
     Transfer error model for loss of quantum information.
@@ -75,6 +88,8 @@ class QuantumChannel(BaseChannel[QNode]):
     In entanglement routing experiments, MQNS does not use the ``send()`` method to transmit photonic qubits.
     Instead, the ``LinkLayer`` application calculates entanglement arrival times and fidelity from channel parameters
     such as ``length`` and ``link_arch``, and directly schedules entanglement arrivals.
+
+    This class implements the protocol ``mqns.entity.qchannel.ChannelParameters``.
     """
 
     def __init__(self, name: str, **kwargs: Unpack[QuantumChannelInitKwargs]):
@@ -85,23 +100,13 @@ class QuantumChannel(BaseChannel[QNode]):
         """Link architecture model (separate instance per channel)."""
 
         self.alpha = kwargs.get("alpha", 0.0)
-        """Fiber attenuation loss in dB/km."""
         assert self.alpha >= 0
         if self.drop_rate == 0 and self.length > 0 and self.alpha > 0:
             self.drop_rate = 1 - calc_transmission_prob(self.length, self.alpha)
 
+        self.init_fidelity = kwargs.get("init_fidelity")
         self.transfer_error = parse_error(kwargs.get("transfer_error"), DepolarErrorModel, self.length)
-        """
-        Transfer error model.
-
-        It reflects loss of quantum information when a qubit/EPR is sent through the fiber.
-        It does not reflect loss of photons.
-        """
-
         self.bsa_error = parse_error(kwargs.get("bsa_error"), DepolarErrorModel, -1)
-        """
-        Bell-state analyzer or absorptive memory capture (depending on link architecture) error model.
-        """
 
     @override
     def handle(self, event: Event):

--- a/mqns/models/epr/entanglement.py
+++ b/mqns/models/epr/entanglement.py
@@ -72,13 +72,6 @@ class Entanglement(QuantumModel):
     It must not be used to guide decision prior to measurement.
     """
 
-    read: bool = False
-    """
-    Whether the entanglement has been read from the memory by either node.
-
-    Note: This is a legacy attribute, planned for removal.
-    """
-
     ch_index: int = -1
     """
     Index of elementary entanglement in a path, smaller indices are on the left side.
@@ -165,12 +158,11 @@ class Entanglement(QuantumModel):
         """
         t = now - self.fidelity_time
         assert self.consumed_sides == 0b00
-        if self.read or t.time_slot == 0:
+        if t.time_slot == 0:
             return
         for se in self.store_decays:
             se(self, t)
         self.fidelity_time = now
-        self.read = True
 
     def consume_with_store_decay_side(self, now: Time, *, side: int) -> bool:
         """
@@ -190,7 +182,6 @@ class Entanglement(QuantumModel):
         assert (self.consumed_sides & side_bit) == 0b00
         self.store_decays[side](self, now - self.fidelity_time)
         self.consumed_sides |= side_bit
-        self.read = True
         return self.consumed_sides == 0b11
 
     @staticmethod

--- a/mqns/models/epr/entanglement.py
+++ b/mqns/models/epr/entanglement.py
@@ -180,7 +180,8 @@ class Entanglement(QuantumModel):
         Args:
             epr0: Left entanglement.
             epr1: Right entanglement.
-            now: Current timestamp.
+            now: Timestamp to stop accumulating errors on ``epr0`` and ``epr1``,
+                and start accumulating errors on new entanglement.
             ps: Probability of successful swapping.
             error: BSA error model.
 
@@ -190,7 +191,7 @@ class Entanglement(QuantumModel):
         """
 
         assert type(epr0) is type(epr1)
-        assert epr0.dst == epr1.src  # it's okay for src and dst to be None
+        assert epr0.dst is epr1.src  # it's okay for src and dst to be None
 
         orig_eprs: list[E] = []
         for epr in (epr0, epr1):
@@ -220,10 +221,9 @@ class Entanglement(QuantumModel):
 
         local_failure = ps < 1.0 and rng.random() >= ps
         ne.is_decohered = epr0.is_decohered or epr1.is_decohered or local_failure
-        if ne.is_decohered:
-            epr0.is_decohered = epr1.is_decohered = True
-        else:
+        if not ne.is_decohered:
             ne.apply_error(error)
+        epr0.is_decohered = epr1.is_decohered = True
         return ne, not local_failure
 
     @staticmethod

--- a/mqns/models/epr/entanglement.py
+++ b/mqns/models/epr/entanglement.py
@@ -88,6 +88,12 @@ class Entanglement(QuantumModel):
     """Elementary entanglements that swapped into this entanglement."""
     affectionated_path_id: int = -1
     """Path ID chosen by MuxSchemeDynamicEpr or MuxSchemeStatistical(coordinated_decisions=True)."""
+    consumed_sides: int = 0b00
+    """
+    Whether the entanglement has been consumed via ``consume_with_store_decay_side()`` on each side, as bitmap:
+    * 0b01: Left side.
+    * 0b10: Right side.
+    """
 
     def __init__(self, **kwargs: Unpack[EntanglementInitKwargs]):
         """
@@ -158,12 +164,34 @@ class Entanglement(QuantumModel):
             now: Current time point.
         """
         t = now - self.fidelity_time
+        assert self.consumed_sides == 0b00
         if self.read or t.time_slot == 0:
             return
         for se in self.store_decays:
             se(self, t)
         self.fidelity_time = now
         self.read = True
+
+    def consume_with_store_decay_side(self, now: Time, *, side: int) -> bool:
+        """
+        Apply memory time-based decays for one qubit in this EPR, when it is ready for consumption.
+
+        Args:
+            now: Current time point.
+            side: 0 for left side, 1 for right side.
+
+        Returns: Whether both qubits are consumed.
+
+        This differs from ``apply_store_decays()`` in that:
+        * ``fidelity_time`` is not updated, so that the other side can update from the same origin time.
+        * ``consumed_sides`` indicates which side(s) have performed this update.
+        """
+        side_bit = 1 << side
+        assert (self.consumed_sides & side_bit) == 0b00
+        self.store_decays[side](self, now - self.fidelity_time)
+        self.consumed_sides |= side_bit
+        self.read = True
+        return self.consumed_sides == 0b11
 
     @staticmethod
     def swap[E: Entanglement](

--- a/mqns/models/epr/mixed.py
+++ b/mqns/models/epr/mixed.py
@@ -19,6 +19,8 @@ from mqns.models.core.state import (
 from mqns.models.epr.entanglement import Entanglement, EntanglementInitKwargs
 from mqns.utils import rng
 
+_probv_1 = make_bell_diagonal_probv(1, 0, 0, 0)
+
 
 @final
 class MixedStateEntanglement(Entanglement):
@@ -58,7 +60,7 @@ class MixedStateEntanglement(Entanglement):
         *,
         probv: BellDiagonalProbV | None = None,
         fidelity: float | None = None,
-        i=1.0,
+        i: float | None = None,
         z=0.0,
         x=0.0,
         y=0.0,
@@ -67,11 +69,12 @@ class MixedStateEntanglement(Entanglement):
         super().__init__(**kwargs)
         if probv is not None:
             self.set_probv(probv)
-        elif fidelity is None:
+        elif i is not None:
             self.set_probv(make_bell_diagonal_probv(i, z, x, y), normalize=False)
-            """Probability vector: I,Z,X,Y."""
-        else:
+        elif fidelity is not None:
             self.fidelity = fidelity
+        else:
+            self.set_probv(_probv_1, normalize=False)
 
     @property
     @override

--- a/mqns/network/builder.py
+++ b/mqns/network/builder.py
@@ -156,6 +156,11 @@ class ChannelArgs(TypedDict, total=False):
     Fiber loss in dB/km, defaults to ``0.2``.
     This determines success probability.
     """
+    init_fidelity: float | Sequence[float] | None
+    """
+    Fidelity of generated entangled pairs, defaults to ``0.99``.
+    If ``None``, determine with error models in link architecture.
+    """
     fiber_error: ErrorModelInputLength
     """
     Fiber error model, defaults to depolarizing with ``0.01`` error probability.
@@ -191,11 +196,6 @@ class TopoCommonArgs(NodeArgs, ChannelArgs):
     # Conceptually these should belong to either NodeArgs or ChannelArgs,
     # but implementation limitation made them non-configurable.
     # If use case arises, these could be refactored to be per-node or per-channel.
-    init_fidelity: NotRequired[float | Sequence[float] | None]
-    """
-    Fidelity of generated entangled pairs, defaults to ``0.99``.
-    If ``None``, determine with error models in link architecture.
-    """
     entg_attempt_rate: NotRequired[float]
     """Maximum entanglement attempts per second, defaults to ``50_000_000`` but currently ineffective."""
     eta_d: NotRequired[float]
@@ -204,6 +204,8 @@ class TopoCommonArgs(NodeArgs, ChannelArgs):
     """Source efficiency, defaults to ``0.95``."""
     frequency: NotRequired[float]
     """Entanglement source frequency, defaults to ``1_000_000``."""
+    tau_0: NotRequired[float]
+    """Local operation delay in seconds for emitting and absorbing photon, defaults to ``0.0``."""
 
 
 class AppsCommonArgs(TypedDict, total=False):
@@ -332,6 +334,7 @@ class NetworkBuilder:
                     "length": d.get("ch_length", 1.0) if length is None else length,
                     "link_arch": la,
                     "alpha": d.get("fiber_alpha", 0.2),
+                    "init_fidelity": d.get("init_fidelity", 0.99),
                     "transfer_error": d.get("fiber_error", "DEPOLAR:0.01"),
                     "bsa_error": d.get("bsa_error", "PERFECT"),
                 },
@@ -463,10 +466,10 @@ class NetworkBuilder:
         self.qnode_apps.append(
             LinkLayer(
                 attempt_rate=self.d.get("entg_attempt_rate", 50e6),
-                init_fidelity=self.d.get("init_fidelity", 0.99),
                 eta_d=self.d.get("eta_d", 0.95),
                 eta_s=self.d.get("eta_s", 0.95),
                 frequency=self.d.get("frequency", 1e6),
+                tau_0=self.d.get("tau_0", 0.0),
             )
         )
 

--- a/mqns/network/builder.py
+++ b/mqns/network/builder.py
@@ -125,7 +125,7 @@ class TopoCommonArgs(TypedDict, total=False):
     """Memory time decay function, defaults to dephasing in ``t_cohere``."""
     entg_attempt_rate: float
     """Maximum entanglement attempts per second, defaults to ``50_000_000`` but currently ineffective."""
-    init_fidelity: float | None
+    init_fidelity: float | Sequence[float] | None
     """
     Fidelity of generated entangled pairs, defaults to ``0.99``.
     If ``None``, determine with error models in link architecture.

--- a/mqns/network/builder.py
+++ b/mqns/network/builder.py
@@ -1,9 +1,11 @@
 import functools
-from collections.abc import Mapping, Sequence
-from typing import Literal, Self, TypedDict, Unpack, cast, overload
+import itertools
+from collections.abc import Sequence
+from typing import Literal, NotRequired, Self, TypedDict, Unpack, cast, overload
 
 from tap import Tap
 
+from mqns.entity.memory import QuantumMemoryInitKwargs
 from mqns.entity.node import Application, QNode
 from mqns.entity.qchannel import (
     LinkArch,
@@ -118,23 +120,89 @@ so that the QNodes can perform entanglement forwarding for the full intended dur
 """
 
 
-class TopoCommonArgs(TypedDict, total=False):
+class NodeArgs(TypedDict, total=False):
+    mem_capacity: int
+    """Memory capacity, defaults to ``-1`` for deriving from channel capacities."""
     t_cohere: float
     """Memory coherence time in seconds, defaults to ``0.02``."""
     memory_decay: TimeDecayInput
     """Memory time decay function, defaults to dephasing in ``t_cohere``."""
-    entg_attempt_rate: float
-    """Maximum entanglement attempts per second, defaults to ``50_000_000`` but currently ineffective."""
-    init_fidelity: float | Sequence[float] | None
+
+
+class NodeDef:
+    """Node definition."""
+
+    def __init__(self, name: str, **kwargs: Unpack[NodeArgs]):
+        self.name = name
+        self.d = kwargs
+
+
+class ChannelArgs(TypedDict, total=False):
+    ch_length: float
+    """
+    Channel length in kilometer, defaults to ``1.0``.
+    """
+    ch_capacity: int | tuple[int, int]
+    """
+    Channel capacity, defaults to ``1``.
+    An integer applies to both sides; a tuple applies to ``(left,right)`` sides.
+    """
+    link_arch: LinkArchDef
+    """
+    Link architecture, defaults to ``LinkArchDimBkSeq``.
+    """
+    fiber_alpha: float
+    """
+    Fiber loss in dB/km, defaults to ``0.2``.
+    This determines success probability.
+    """
+    fiber_error: ErrorModelInputLength
+    """
+    Fiber error model, defaults to depolarizing with ``0.01`` error probability.
+    This determines qualify of entangled state.
+    """
+    bsa_error: ErrorModelInputBasic
+    """
+    Photonic Bell-state analyzer or absorptive memory capture error model, defaults to perfect.
+    This determines qualify of entangled state.
+    """
+
+
+class ChannelParam:
+    """Channel parameters."""
+
+    def __init__(self, **kwargs: Unpack[ChannelArgs]):
+        self.d = kwargs
+
+
+class ChannelDef(ChannelParam):
+    """Channel definition."""
+
+    def __init__(self, np: NodePair, /, **kwargs: Unpack[ChannelArgs]):
+        super().__init__(**kwargs)
+        self.np = np
+
+
+class TopoCommonArgs(NodeArgs, ChannelArgs):
+    """
+    Combination of ``NodeArgs`` and ``ChannelArgs``, with additional parameters.
+    """
+
+    # Conceptually these should belong to either NodeArgs or ChannelArgs,
+    # but implementation limitation made them non-configurable.
+    # If use case arises, these could be refactored to be per-node or per-channel.
+    init_fidelity: NotRequired[float | Sequence[float] | None]
     """
     Fidelity of generated entangled pairs, defaults to ``0.99``.
     If ``None``, determine with error models in link architecture.
     """
-    eta_d: float
+    entg_attempt_rate: NotRequired[float]
+    """Maximum entanglement attempts per second, defaults to ``50_000_000`` but currently ineffective."""
+    eta_d: NotRequired[float]
     """Detector efficiency, defaults to ``0.95``."""
-    eta_s: float
+    eta_s: NotRequired[float]
     """Source efficiency, defaults to ``0.95``."""
-    frequency: float
+    frequency: NotRequired[float]
     """Entanglement source frequency, defaults to ``1_000_000``."""
 
 
@@ -155,14 +223,6 @@ class AppsForwarderArgs(AppsCommonArgs, ForwarderInitKwargs):
     """
 
 
-def _broadcast[T](name: str, input: T | Sequence[T], n: int) -> Sequence[T]:
-    if isinstance(input, Sequence) and not isinstance(input, (str, bytes, bytearray, memoryview)):
-        if len(input) != n:
-            raise ValueError(f"{name} must have {n} items")
-        return input
-    return [cast(T, input)] * n
-
-
 def _split_node_pair(np: NodePair) -> tuple[str, str]:
     if isinstance(np, str):
         tokens = np.split("-")
@@ -170,15 +230,6 @@ def _split_node_pair(np: NodePair) -> tuple[str, str]:
             raise ValueError(f"expect two node names in '{np}'")
         return cast(tuple[str, str], tuple(tokens))
     return np
-
-
-def _split_channel_capacity(item: int | tuple[int, int]) -> tuple[int, int]:
-    return (item, item) if isinstance(item, int) else item
-
-
-def _convert_link_arch(la: LinkArchDef) -> LinkArch:
-    la = LINK_ARCH_MAP.get(cast(LinkArchLiteral, la), cast(LinkArch | type[LinkArch], la))
-    return la() if callable(la) else la
 
 
 class NetworkBuilder:
@@ -211,6 +262,8 @@ class NetworkBuilder:
         self.epr_type = epr_type if isinstance(epr_type, type) else EPR_TYPE_MAP[epr_type]
 
         self.qnodes: list[TopoQNode] = []
+        self.qnode_by_name: dict[str, TopoQNode] = {}
+        self.extensible_memory_by_name: dict[str, QuantumMemoryInitKwargs] = {}
         self.qnode_apps: list[Application] = []
         self.qchannels: list[TopoQChannel] = []
         self.controller_apps: list[Application] = []
@@ -218,35 +271,57 @@ class NetworkBuilder:
         self.qubit_allocation = QubitAllocationType.DISABLED
         self.requests: list[tuple[str, str]] = []
 
-    def _parse_topo_args(self, d: TopoCommonArgs) -> None:
-        self.t_cohere = d.get("t_cohere", 0.02)
-        self.memory_decay = d.get("memory_decay")
-        self.entg_attempt_rate = d.get("entg_attempt_rate", 50e6)
-        self.init_fidelity = d.get("init_fidelity", 0.99)
-        self.eta_d = d.get("eta_d", 0.95)
-        self.eta_s = d.get("eta_s", 0.95)
-        self.frequency = d.get("frequency", 1e6)
+    def _save_topo_args(self, d: TopoCommonArgs) -> None:
+        self.d = d
 
-    def _add_qnode(self, name: str, mem_cap: int) -> TopoQNode:
+    def _add_qnode(self, name: str, d: NodeArgs | None = None) -> TopoQNode:
+        if old_node := self.qnode_by_name.get(name):
+            return old_node
+
+        d = (self.d | d) if d else self.d
+        mem_capacity = d.get("mem_capacity", -1)
         node: TopoQNode = {
             "name": name,
-            "memory": {"capacity": mem_cap},
+            "memory": {
+                "capacity": max(0, mem_capacity),
+                "t_cohere": d.get("t_cohere", 0.02),
+                "time_decay": d.get("memory_decay"),
+            },
         }
         self.qnodes.append(node)
+
+        self.qnode_by_name[name] = node
+        if mem_capacity < 0:
+            self.extensible_memory_by_name[name] = node["memory"]
         return node
+
+    def _inc_memory(self, name: str, n: int) -> None:
+        if memory := self.extensible_memory_by_name.get(name):
+            assert "capacity" in memory
+            memory["capacity"] += n
 
     def _add_qchannel(
         self,
         node1: str,
         node2: str,
-        cap1: int,
-        cap2: int,
-        length: float,
-        fiber_alpha: float,
-        fiber_error: ErrorModelInputLength,
-        bsa_error: ErrorModelInputBasic,
-        la: LinkArchDef,
+        d: ChannelArgs | None,
+        length: float | None = None,
+        capacity: int | tuple[int, int] | None = None,
     ):
+        d = (self.d | d) if d else self.d
+
+        caps: int | tuple[int, int] = capacity or d.get("ch_capacity", 1)
+        cap1, cap2 = (caps, caps) if isinstance(caps, int) else caps
+
+        la = d.get("link_arch", LinkArchDimBkSeq)
+        la = LINK_ARCH_MAP.get(cast(LinkArchLiteral, la), cast(LinkArch | type[LinkArch], la))
+        la = la() if callable(la) else la
+
+        self._add_qnode(node1)
+        self._add_qnode(node2)
+        self._inc_memory(node1, cap1)
+        self._inc_memory(node2, cap2)
+
         self.qchannels.append(
             {
                 "node1": node1,
@@ -254,11 +329,11 @@ class NetworkBuilder:
                 "capacity1": cap1,
                 "capacity2": cap2,
                 "parameters": {
-                    "length": length,
-                    "link_arch": _convert_link_arch(la),
-                    "alpha": fiber_alpha,
-                    "transfer_error": fiber_error,
-                    "bsa_error": bsa_error,
+                    "length": d.get("ch_length", 1.0) if length is None else length,
+                    "link_arch": la,
+                    "alpha": d.get("fiber_alpha", 0.2),
+                    "transfer_error": d.get("fiber_error", "DEPOLAR:0.01"),
+                    "bsa_error": d.get("bsa_error", "PERFECT"),
                 },
             }
         )
@@ -266,116 +341,67 @@ class NetworkBuilder:
     def topo(
         self,
         *,
-        mem_capacity: int | Mapping[str, int] | None = None,
-        channels: Sequence[tuple[NodePair, float] | tuple[NodePair, float, int | tuple[int, int]]],
-        channel_capacity: int = 1,
-        fiber_alpha: float = 0.2,
-        fiber_error: ErrorModelInputLength = "DEPOLAR:0.01",
-        bsa_error: ErrorModelInputBasic = "PERFECT",
-        link_arch: LinkArchDef | Sequence[LinkArchDef] = LinkArchDimBkSeq,
+        channels: Sequence[ChannelDef | tuple[NodePair, float] | tuple[NodePair, float, int | tuple[int, int]]],
+        nodes: Sequence[NodeDef] = [],
         **kwargs: Unpack[TopoCommonArgs],
     ) -> Self:
         """
         Build a general topology.
 
         Args:
-            mem_capacity: Number of memory qubits per node.
-                If specified as number, it is applied to all nodes.
-                If specified as dict, it maps from node name to node memory capacity.
-                If ``None`` or for unspecified nodes, it is derived from channels.
             channels: List of channels.
-                First tuple item is channel end points; nodes are automatically created.
-                Second tuple item is channel length in kilometer.
-                Third tuple item is channel capacity, defaults to ``channel_capacity``;
-                for each qchannel, an integer applies to both sides, a tuple applies to (left,right) sides.
-            channel_capacity: Qubit allocation per qchannel, if not specified in ``channels``.
-            fiber_alpha: Fiber loss in dB/km, determines success probability.
-            fiber_error: Fiber error model, determines qualify of entangled state.
-            bsa_error: Photonic Bell-state analyzer or absorptive memory capture error model,
-                       determines qualify of entangled state.
-            link_arch: Link architecture per qchannel.
-                If specified as list, it must have same length as ``channel_length``.
-                If specified as instance/type/string, it is broadcast to all qchannels.
+                Each element is either a ``ChannelDef`` or a tuple.
+                If specified as tuple:
+                * First tuple item is channel end points.
+                * Second tuple item is channel length in kilometer.
+                * Third tuple item is channel capacity, if it differs from ``kwargs.ch_capacity``.
+            nodes: Node parameter overrides (optional).
+                It is unnecessary to list a node unless its parameter differs from ``kwargs``.
+            kwargs: Default node and channel parameters.
+                To override a node's parameters, pass ``NodeDef`` to ``nodes``.
+                To override a channel's parameters, pass ``ChannelDef`` to ``channels``.
         """
-        self._parse_topo_args(kwargs)
+        self._save_topo_args(kwargs)
 
-        n_links = len(channels)
-        link_arch = _broadcast("link_arch", link_arch, n_links)
-        node_by_name: dict[str, TopoQNode | Literal[True]] = {}
+        for node in nodes:
+            self._add_qnode(node.name, node.d)
 
-        def ensure_node(name: str, ch_cap: int):
-            node = node_by_name.get(name)
-            if node is True:  # node created with mem_capacity
-                return
-
-            if node is not None:  # need to increase mem_capacity
-                assert "memory" in node
-                assert "capacity" in node["memory"]
-                node["memory"]["capacity"] += ch_cap
-                return
-
-            # need to create new node
-            if mem_capacity is None:
-                mem_cap, defined_mem_cap = ch_cap, False
-            elif isinstance(mem_capacity, int):
-                mem_cap, defined_mem_cap = mem_capacity, True
-            elif name in mem_capacity:
-                mem_cap, defined_mem_cap = mem_capacity[name], True
+        for ch in channels:
+            capacity = None
+            if isinstance(ch, ChannelDef):
+                np = ch.np
+                d = ch.d
+                length = None
             else:
-                mem_cap, defined_mem_cap = ch_cap, False
-
-            node = self._add_qnode(name, mem_cap)
-            node_by_name[name] = True if defined_mem_cap else node
-
-        for (np, length, *opt_cap), la in zip(channels, link_arch, strict=True):
-            node1, node2 = _split_node_pair(np)
-            cap1, cap2 = _split_channel_capacity(opt_cap[0] if len(opt_cap) > 0 else channel_capacity)
-            ensure_node(node1, cap1)
-            ensure_node(node2, cap2)
-            self._add_qchannel(node1, node2, cap1, cap2, length, fiber_alpha, fiber_error, bsa_error, la)
+                np, length, *opt_capacity = ch
+                if opt_capacity:
+                    (capacity,) = opt_capacity
+                d = None
+            self._add_qchannel(*_split_node_pair(np), d, length, capacity)
 
         return self
 
     def topo_linear(
         self,
         *,
-        nodes: int | Sequence[str],
-        mem_capacity: int | Sequence[int] | None = None,
-        channel_length: float | Sequence[float],
-        channel_capacity: int | Sequence[int | tuple[int, int]] = 1,
-        fiber_alpha: float = 0.2,
-        fiber_error: ErrorModelInputLength = "DEPOLAR:0.01",
-        bsa_error: ErrorModelInputBasic = "PERFECT",
-        link_arch: LinkArchDef | Sequence[LinkArchDef] = LinkArchDimBkSeq,
+        nodes: int | Sequence[NodeDef | str],
+        channels: Sequence[ChannelParam | float | tuple[float, int | tuple[int, int]]] | None = None,
         **kwargs: Unpack[TopoCommonArgs],
     ) -> Self:
         """
         Build a linear topology consisting of zero or more repeaters.
 
         Args:
-            nodes: Number of nodes or list of node names, minimum is 2.
+            nodes: Number of nodes or list of node definitions / names, minimum is 2 nodes.
                 If specified as number, the nodes are named ``S R1 R2 .. Rn D``.
                 If specified as list, each node name must be unique.
-            mem_capacity: Number of memory qubits per node.
-                If specified as list, it must have same length as ``nodes``.
-                If specified as number, it is broadcast to all nodes.
-                If ``None``, it is derived from ``channel_capacity``.
-            channel_length: Lengths of qchannels between adjacent nodes in kilometer.
-                If specified as list, it must have length ``len(nodes)-1``.
-                If specified as number, all qchannels have uniform length.
-            channel_capacity: Qubit allocation per qchannel.
-                If specified as list, it must have same length as ``channel_length``.
-                If specified as number, it is broadcast to all qchannels.
-                For each qchannel, an integer applies to both sides, a tuple applies to (left,right) sides.
-            fiber_alpha: Fiber loss in dB/km, determines success probability.
-            fiber_error: Fiber error model, determines qualify of entangled state.
-            bsa_error: Photonic Bell-state analyzer or absorptive memory capture error model,
-                       determines qualify of entangled state.
-            link_arch: Link architecture per qchannel.
-                If specified as list, it must have same length as ``channel_length``.
-                If specified as instance/type/string, it is broadcast to all qchannels.
+            channels: Channel parameter overrides (optional).
+                This is necessary only if some channel's parameter differs from ``kwargs``.
+            kwargs: Default node and channel parameters.
+                To override a node's parameters, pass ``NodeDef`` to ``nodes``.
+                To override a channel's parameters, pass ``ChannelDef`` to ``channels``.
         """
-        self._parse_topo_args(kwargs)
+        self._save_topo_args(kwargs)
 
         if isinstance(nodes, int):
             if nodes < 2:
@@ -388,27 +414,30 @@ class NetworkBuilder:
         if n_nodes < 2:
             raise ValueError("at least two nodes")
         n_links = n_nodes - 1
-
-        channel_length = _broadcast("channel_length", channel_length, n_links)
-        channel_capacity = _broadcast("channel_capacity", channel_capacity, n_links)
-        link_arch = _broadcast("link_arch", link_arch, n_links)
-
-        if mem_capacity is None:
-            mem_capacity = [0]
-            for caps in channel_capacity:
-                capL, capR = _split_channel_capacity(caps)
-                mem_capacity[-1] += capL
-                mem_capacity.append(capR)
+        if channels is None:
+            chs = [None] * n_links
+        elif len(channels) == n_links:
+            chs = channels
         else:
-            mem_capacity = _broadcast("mem_capacity", mem_capacity, n_nodes)
+            raise ValueError("incorrect number of channels")
 
-        for name, mem_capacity in zip(nodes, mem_capacity, strict=True):
-            self._add_qnode(name, mem_capacity)
+        node_names: list[str] = []
+        for node in nodes:
+            if isinstance(node, NodeDef):
+                self._add_qnode(node.name, node.d)
+                node_names.append(node.name)
+            else:
+                self._add_qnode(node)
+                node_names.append(node)
 
-        for i, (length, caps, la) in enumerate(zip(channel_length, channel_capacity, link_arch, strict=True)):
-            node1, node2 = nodes[i], nodes[i + 1]
-            cap1, cap2 = _split_channel_capacity(caps)
-            self._add_qchannel(node1, node2, cap1, cap2, length, fiber_alpha, fiber_error, bsa_error, la)
+        for np, ch in zip(itertools.pairwise(node_names), chs, strict=True):
+            if isinstance(ch, ChannelParam):
+                self._add_qchannel(*np, ch.d)
+            elif isinstance(ch, tuple):
+                length, capacity = ch
+                self._add_qchannel(*np, None, length, capacity)
+            else:
+                self._add_qchannel(*np, None, ch)
 
         return self
 
@@ -425,18 +454,19 @@ class NetworkBuilder:
         elif timing is None:
             self.timing = TimingModeAsync()
         else:
+            t_cohere = self.d.get("t_cohere", 0.02)
             if len(timing) == 0:
-                timing = (self.t_cohere / 2 - 2 * CTRL_DELAY, 4 * CTRL_DELAY, self.t_cohere / 2 - 2 * CTRL_DELAY)
+                timing = (t_cohere / 2 - 2 * CTRL_DELAY, 4 * CTRL_DELAY, t_cohere / 2 - 2 * CTRL_DELAY)
             self.timing = TimingModeSync(durations=timing)
 
     def _add_link_layer(self):
         self.qnode_apps.append(
             LinkLayer(
-                attempt_rate=self.entg_attempt_rate,
-                init_fidelity=self.init_fidelity,
-                eta_d=self.eta_d,
-                eta_s=self.eta_s,
-                frequency=self.frequency,
+                attempt_rate=self.d.get("entg_attempt_rate", 50e6),
+                init_fidelity=self.d.get("init_fidelity", 0.99),
+                eta_d=self.d.get("eta_d", 0.95),
+                eta_s=self.d.get("eta_s", 0.95),
+                frequency=self.d.get("frequency", 1e6),
             )
         )
 
@@ -586,10 +616,6 @@ class NetworkBuilder:
         return CustomTopology(
             topo,
             nodes_apps=self.qnode_apps,
-            memory_args={
-                "t_cohere": self.t_cohere,
-                "time_decay": self.memory_decay,
-            },
         )
 
     def make_network(

--- a/mqns/network/fw/__init__.py
+++ b/mqns/network/fw/__init__.py
@@ -1,7 +1,7 @@
 from mqns.network.fw.controller import RoutingController
 from mqns.network.fw.cutoff import CutoffScheme, CutoffSchemeWaitTime, CutoffSchemeWaitTimeCounters
 from mqns.network.fw.fib import Fib, FibEntry
-from mqns.network.fw.forwarder import Forwarder, ForwarderCounters, ForwarderInitKwargs
+from mqns.network.fw.forwarder import Forwarder, ForwarderConsumeCounters, ForwarderCounters, ForwarderInitKwargs
 from mqns.network.fw.fw_classic import fw_control_cmd_handler, fw_signaling_cmd_handler
 from mqns.network.fw.message import MultiplexingVector, SwapSequence
 from mqns.network.fw.mux import MuxScheme
@@ -31,6 +31,7 @@ __all__ = [
     "Fib",
     "FibEntry",
     "Forwarder",
+    "ForwarderConsumeCounters",
     "ForwarderCounters",
     "ForwarderInitKwargs",
     "fw_control_cmd_handler",

--- a/mqns/network/fw/cutoff.py
+++ b/mqns/network/fw/cutoff.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, final, override
 
-from mqns.entity.memory import MemoryQubit
+from mqns.entity.memory import MemoryQubit, PathDirection
 from mqns.entity.node import QNode
 from mqns.network.fw.fib import FibEntry
 from mqns.network.fw.message import CutoffDiscardMsg
@@ -16,7 +16,7 @@ class CutoffScheme(ABC):
     """
     EPR age cut-off scheme.
 
-    This determines how PathInstructions.swap_cutoff is interpreted.
+    This determines how ``PathInstructions.swap_cutoff`` is interpreted.
     """
 
     fw: "Forwarder"
@@ -97,7 +97,7 @@ class CutoffScheme(ABC):
         fw.release_qubit(qubit)
 
     @abstractmethod
-    def before_store_eligible(self, mq: MemoryQubit, fib_entry: FibEntry | None) -> None:
+    def before_store_eligible(self, mq: MemoryQubit, dir: PathDirection, fib_entry: FibEntry | None) -> None:
         """
         Handle an ELIGIBLE qubit stored for future swapping.
         """
@@ -160,14 +160,19 @@ class CutoffSchemeWaitTime(CutoffScheme):
     Note that ``swap_delay`` does not count against the wait budget.
     """
 
+    _DIR_OFFSET = {
+        PathDirection.L: -2,
+        PathDirection.R: -1,
+    }
+
     def __init__(self, name="wait-time"):
         super().__init__(name)
 
         self.cnt = CutoffSchemeWaitTimeCounters()
 
     @override
-    def before_store_eligible(self, mq: MemoryQubit, fib_entry: FibEntry | None) -> None:
-        if not fib_entry or (wait_budget := fib_entry.swap_cutoff[fib_entry.own_idx]) is None:
+    def before_store_eligible(self, mq: MemoryQubit, dir: PathDirection, fib_entry: FibEntry | None) -> None:
+        if not fib_entry or (wait_budget := fib_entry.swap_cutoff[2 * fib_entry.own_idx + self._DIR_OFFSET[dir]]) is None:
             return
 
         now = self.simulator.tc

--- a/mqns/network/fw/forwarder.py
+++ b/mqns/network/fw/forwarder.py
@@ -17,7 +17,7 @@
 
 import copy
 from abc import abstractmethod
-from typing import TypedDict, Unpack, override
+from typing import Literal, TypedDict, Unpack, override
 
 import numpy as np
 
@@ -52,11 +52,13 @@ from mqns.utils import json_encodable, log
 
 class ForwarderInitKwargs(TypedDict, total=False):
     p_swap: float
-    """Probability of successful entanglement swapping, default is 1.0."""
+    """Probability of successful entanglement swapping, default is ``1.0``."""
     swap_delay: DelayInput
     """Swapping delay model, default is zero."""
     swap_error: ErrorModelInputBasic
     """Swapping error model, default is perfect."""
+    swap_error_at: Literal["s", "f"]
+    """Swapping error applied at start or finish time, default is ``s``."""
     cutoff: CutoffScheme | None
     """EPR age cut-off scheme, default is wait-time."""
     mux: MuxScheme | None
@@ -182,6 +184,7 @@ class Forwarder(ForwarderClassicMixin, Application[QNode]):
             ps=kwargs.get("p_swap", 1.0),
             delay=parse_delay(kwargs.get("swap_delay", 0)),
             error=parse_error(kwargs.get("swap_error"), PerfectErrorModel, -1),
+            error_at_finish=kwargs.get("swap_error_at", "s") == "f",
         )
 
         self.waiting_etg: list[QubitEntangledEvent] = []

--- a/mqns/network/fw/forwarder.py
+++ b/mqns/network/fw/forwarder.py
@@ -44,7 +44,7 @@ from mqns.network.fw.message import (
 from mqns.network.fw.mux import MuxScheme
 from mqns.network.fw.mux_buffer_space import MuxSchemeBufferSpace
 from mqns.network.fw.select import SelectPurifQubit, call_select_purif_qubit
-from mqns.network.network import TimingPhase, TimingPhaseEvent
+from mqns.network.network import QuantumNetwork, TimingPhase, TimingPhaseEvent
 from mqns.network.protocol.event import QubitEntangledEvent, QubitReleasedEvent
 from mqns.simulator import Time, event_handler
 from mqns.utils import json_encodable, log
@@ -68,10 +68,104 @@ class ForwarderInitKwargs(TypedDict, total=False):
 
 
 @json_encodable
-class ForwarderCounters:
+class ForwarderConsumeCounters:
+    """
+    Consumption counters of ``Forwarder``.
+
+    Each entangled pair is delivered and consumed by two forwarders, possibly at different times due to
+    heralding timing. However, only the forwarder that measures the second qubit logs the consumption,
+    because the final end-to-end fidelity can only be calculate when memory error models on both sides are applied.
+    """
+
+    n_consumed = 0
+    """How many entanglements were consumed (either end-to-end or in swap-disabled mode)."""
+    consumed_sum_fidelity = 0.0
+    """
+    Sum of fidelity of consumed entanglements.
+    """
+    consumed_fidelity_values: list[float] | None = None
+    """
+    Fidelity values of consumed entanglements, None disables collection.
+    """
+
+    @staticmethod
+    def of_path(net: QuantumNetwork, src: str, dst: str) -> "ForwarderConsumeCounters":
+        """
+        Obtain consumption counters of a path.
+
+        Args:
+            net: Quantum network.
+            src: Left end node, which must belong to exactly one path.
+            dst: Right end node, which must belong to exactly one path.
+        """
+        a = net.get_node(src).get_app(Forwarder).cnt
+        b = net.get_node(dst).get_app(Forwarder).cnt
+
+        g = ForwarderConsumeCounters()
+        g.n_consumed = a.n_consumed + b.n_consumed
+        g.consumed_sum_fidelity = a.consumed_sum_fidelity + b.consumed_sum_fidelity
+        if a.consumed_fidelity_values is b.consumed_fidelity_values:
+            g.consumed_fidelity_values = a.consumed_fidelity_values
+        return g
+
+    @staticmethod
+    def enable_collect_all_on_path(net: QuantumNetwork, src: str, dst: str) -> None:
+        """
+        Enable collecting all values for histogram generation.
+
+        Args:
+            net: Quantum network.
+            src: Left end node, which must belong to exactly one path.
+            dst: Right end node, which must belong to exactly one path.
+        """
+        a = net.get_node(src).get_app(Forwarder).cnt
+        b = net.get_node(dst).get_app(Forwarder).cnt
+
+        assert a.consumed_fidelity_values is None
+        assert b.consumed_fidelity_values is None
+        a.consumed_fidelity_values = b.consumed_fidelity_values = []
+
+    def increment_n_consumed(self, fidelity: float) -> None:
+        self.n_consumed += 1
+        self.consumed_sum_fidelity += fidelity
+        if self.consumed_fidelity_values is not None:
+            self.consumed_fidelity_values.append(fidelity)
+
+    @property
+    def consumed_avg_fidelity(self) -> float:
+        """Average fidelity of consumed entanglements."""
+        if self.consumed_fidelity_values is not None and len(self.consumed_fidelity_values) == self.n_consumed > 0:
+            return np.mean(self.consumed_fidelity_values).item()
+        return self.get_per_consumed(self.consumed_sum_fidelity)
+
+    def get_rate(self, duration: float) -> float:
+        """
+        Calculate entanglement rate.
+
+        Args:
+            duration: How many seconds did the path remain active.
+
+        Returns: Entanglement rate in entanglements per second.
+        """
+        return self.n_consumed / duration
+
+    def get_per_consumed(self, x: float) -> float:
+        """
+        Divide a value by ``n_consumed``, but return zero if ``n_consumed`` is zero.
+        """
+        return x / self.n_consumed if self.n_consumed > 0 else 0.0
+
+    def __repr__(self) -> str:
+        return f"consumed={self.n_consumed} (F={self.consumed_avg_fidelity})"
+
+
+@json_encodable
+class ForwarderCounters(ForwarderConsumeCounters):
     """Counters of ``Forwarder``."""
 
     def __init__(self):
+        super().__init__()
+
         self.n_entg = 0
         """How many elementary entanglements received from link layer."""
         self.n_purif: list[int] = []
@@ -99,12 +193,6 @@ class ForwarderCounters:
         * [0]: normal
         * [1]: previous-swap-failure
         """
-        self.n_consumed = 0
-        """How many entanglements were consumed (either end-to-end or in swap-disabled mode)."""
-        self.consumed_sum_fidelity = 0.0
-        """Sum of fidelity of consumed entanglement.s"""
-        self.consumed_fidelity_values: list[float] | None = None
-        """Fidelity values of consumed entanglements, None disables collection."""
         self.n_cutoff = [0, 0]
         """
         How many entanglements are discarded by CutoffScheme.
@@ -115,21 +203,10 @@ class ForwarderCounters:
         * [2r+1]: purif_cutoff[r] exceeded on partner forwarder
         """
 
-    def enable_collect_all(self) -> None:
-        """Enable collecting all values for histogram generation."""
-        assert self.n_consumed == 0
-        self.consumed_fidelity_values = []
-
     def increment_n_purif(self, i: int) -> None:
         if len(self.n_purif) <= i:
             self.n_purif += [0] * (i + 1 - len(self.n_purif))
         self.n_purif[i] += 1
-
-    def increment_n_consumed(self, fidelity: float) -> None:
-        self.n_consumed += 1
-        self.consumed_sum_fidelity += fidelity
-        if self.consumed_fidelity_values is not None:
-            self.consumed_fidelity_values.append(fidelity)
 
     def increment_n_cutoff(self, round: int, local: bool) -> None:
         minlen = 2 * (round + 1)
@@ -137,21 +214,12 @@ class ForwarderCounters:
             self.n_cutoff += [0] * (minlen - len(self.n_cutoff))
         self.n_cutoff[2 * round + (0 if local else 1)] += 1
 
-    @property
-    def consumed_avg_fidelity(self) -> float:
-        """Average fidelity of consumed entanglements."""
-        if self.n_consumed == 0:
-            return 0.0
-        if self.consumed_fidelity_values is None:
-            return self.consumed_sum_fidelity / self.n_consumed
-        return np.mean(self.consumed_fidelity_values).item()
-
     def __repr__(self) -> str:
         return (
             f"entg={self.n_entg} purif={self.n_purif} eligible={self.n_eligible} "
             f"swapped={self.n_swapped} swap-fail={self.n_swap_fail} "
             f"su-lower={self.n_su_lower} su-same={self.n_su_same} cutoff-discard={self.n_cutoff} "
-            f"consumed={self.n_consumed} (F={self.consumed_avg_fidelity})"
+            f"{ForwarderConsumeCounters.__repr__(self)}"
         )
 
 
@@ -523,9 +591,10 @@ class Forwarder(ForwarderClassicMixin, Application[QNode]):
         """
         Consume an entangled qubit.
         """
-        _, qm = self.memory.read(qubit.addr, has=self.epr_type, set_fidelity=True, remove=True)
-        log.debug(f"{self}: consume EPR: {qm}")
-        self.cnt.increment_n_consumed(qm.fidelity)
+        _, epr = self.memory.read(qubit.addr, has=self.epr_type, remove=True)
+        log.debug(f"{self}: consume EPR: {epr}")
+        if epr.consume_with_store_decay_side(self.simulator.tc, side=0 if epr.src is self.node else 1):
+            self.cnt.increment_n_consumed(epr.fidelity)
 
         self.release_qubit(qubit)
 

--- a/mqns/network/fw/forwarder.py
+++ b/mqns/network/fw/forwarder.py
@@ -46,7 +46,7 @@ from mqns.network.fw.mux_buffer_space import MuxSchemeBufferSpace
 from mqns.network.fw.select import SelectPurifQubit, call_select_purif_qubit
 from mqns.network.network import TimingPhase, TimingPhaseEvent
 from mqns.network.protocol.event import QubitEntangledEvent, QubitReleasedEvent
-from mqns.simulator import event_handler
+from mqns.simulator import Time, event_handler
 from mqns.utils import json_encodable, log
 
 
@@ -248,13 +248,17 @@ class Forwarder(ForwarderClassicMixin, Application[QNode]):
 
         # populate FIB
         route = instructions["route"]
+        if "swap_cutoff" in instructions:
+            swap_cutoff = [None if t < 0 else self.simulator.time(time_slot=t) for t in instructions["swap_cutoff"]]
+        else:
+            swap_cutoff: list[Time | None] = [None] * (2 * (len(route) - 2))
         fib_entry = FibEntry(
             path_id=path_id,
             req_id=instructions["req_id"],
             route=route,
             own_idx=route.index(self.node.name),
             swap=instructions["swap"],
-            swap_cutoff=[None if t < 0 else self.simulator.time(time_slot=t) for t in instructions["swap_cutoff"]],
+            swap_cutoff=swap_cutoff,
             purif=instructions["purif"],
         )
         self.fib.insert_or_replace(fib_entry)
@@ -501,7 +505,7 @@ class Forwarder(ForwarderClassicMixin, Application[QNode]):
             self.cutoff.before_swap(qubit, mq1, fib_entry)
             self.swap.start(qubit, mq1, fib_entry)
         else:
-            self.cutoff.before_store_eligible(qubit, fib_entry)
+            self.cutoff.before_store_eligible(qubit, PathDirection.L if epr.src is self.node else PathDirection.R, fib_entry)
 
     def can_consume(self, fib_entry: FibEntry | None, epr: Entanglement) -> bool:
         if fib_entry is None:

--- a/mqns/network/fw/fw_purif.py
+++ b/mqns/network/fw/fw_purif.py
@@ -49,8 +49,11 @@ class ForwarderPurifProc:
             partner: quantum node with which entanglements are shared.
         """
         # read qubits to set fidelity at this time
-        _, epr0 = self.memory.read(mq0.addr, has=self.epr_type, set_fidelity=True)
-        _, epr1 = self.memory.read(mq1.addr, has=self.epr_type, set_fidelity=True, remove=True)
+        now = self.simulator.tc
+        _, epr0 = self.memory.read(mq0.addr, has=self.epr_type)
+        _, epr1 = self.memory.read(mq1.addr, has=self.epr_type, remove=True)
+        epr0.apply_store_decays(now)
+        epr1.apply_store_decays(now)
 
         log.debug(
             f"{self}: request purif qubit {mq0.addr} (F={epr0.fidelity}) and "
@@ -92,8 +95,8 @@ class ForwarderPurifProc:
         """
         # mq0 is the "kept" memory whose fidelity would be increased if purification succeeds
         # mq1 is the "measured" memory that is consumed during purification
-        mq0, epr0 = self.memory.read(msg["key0"], has=self.epr_type, set_fidelity=True)
-        mq1, epr1 = self.memory.read(msg["key1"], has=self.epr_type, set_fidelity=True, remove=True)
+        mq0, epr0 = self.memory.read(msg["key0"], has=self.epr_type)
+        mq1, epr1 = self.memory.read(msg["key1"], has=self.epr_type, remove=True)
         # TODO: handle the exception case when an EPR is decohered and not found in memory
         p_key0 = _qubit_p_key(mq0)
         p_key1 = _qubit_p_key(mq1)

--- a/mqns/network/fw/fw_swap.py
+++ b/mqns/network/fw/fw_swap.py
@@ -337,7 +337,7 @@ class ForwarderSwapProc:
     memory: QuantumMemory
     mux: MuxScheme
 
-    def __init__(self, *, ps: float, delay: DelayModel, error: ErrorModel):
+    def __init__(self, *, ps: float, delay: DelayModel, error: ErrorModel, error_at_finish: bool):
         self.ps = ps
         """Probability of successful entanglement swapping."""
         assert 0.0 <= self.ps <= 1.0
@@ -345,6 +345,8 @@ class ForwarderSwapProc:
         """Swapping delay model."""
         self.error = error
         """Swapping error model."""
+        self.error_at_finish = error_at_finish
+        """Whether to apply memory errors at swap finish time instead of swap start time."""
 
         self.waiting_su: dict[str, tuple[SwapUpdateMsg, FibEntry]] = {}
         """
@@ -458,7 +460,9 @@ class ForwarderSwapProc:
         # Schedule swap completion event.
         now = self.simulator.tc
         finish_time = now + self.delay.calculate()
-        self.simulator.add_event(func_to_event(finish_time, self._s_finish, arms, fib_entry, now, task))
+        self.simulator.add_event(
+            func_to_event(finish_time, self._s_finish, arms, fib_entry, finish_time if self.error_at_finish else now, task)
+        )
 
         log.debug(f"{self}: SWAP_START {task} retrieved-from={task_from} saved-at={task_saved} finish-time={finish_time}")
 
@@ -516,7 +520,7 @@ class ForwarderSwapProc:
             task_saved.append(f"task_by_qubit[{arm.o_key}]")
         return task_saved
 
-    def _s_finish(self, arms: Sequence[SwapArm], fib_entry: FibEntry, swap_start: Time, task_via_event: SwapTask):
+    def _s_finish(self, arms: Sequence[SwapArm], fib_entry: FibEntry, error_t: Time, task_via_event: SwapTask):
         """
         Complete swapping between two memory qubits.
 
@@ -541,7 +545,7 @@ class ForwarderSwapProc:
             phy_eprs.append(phy)
 
         # Attempt physical swap.
-        new_epr, outcome_str, local_success = self._s_physical_swap(swap_start, phy_eprs)
+        new_epr, outcome_str, local_success = self._s_physical_swap(error_t, phy_eprs)
         log.debug(f"{self}: {outcome_str} rank={fib_entry.own_swap_rank} | {arms[0]} x {arms[1]} = {new_epr}")
 
         # Release consumed qubits.

--- a/mqns/network/fw/message.py
+++ b/mqns/network/fw/message.py
@@ -38,17 +38,17 @@ class PathInstructions(TypedDict):
     without attempting entanglement swapping.
     """
 
-    swap_cutoff: list[int]
+    swap_cutoff: NotRequired[list[int]]
     """
     Swap cutoff time -- maximum age at each swapping step.
 
-    This list shall have the same length as ``swap``.
-    The i-th element corresponds to the i-th node in the ``route`` list.
+    This list shall have two elements per intermediate node, i.e. `2*(len(route)-2)`.
+    The (2i)-th and (2i+1)-th element corresponds to left and right qchannel of the i-th intermediate node.
     Each element is a duration in time_slot unit (see ``Time`` class); ``-1`` means no restriction.
 
-    The semantics of "age" depend on the CutoffScheme passed to ProactiveForwarder.
-    Since the first and last nodes in ``route`` do not perform swapping, the first and last elements
-    in this list have no effect. Likewise, if swapping has been disabled, this list has no effect.
+    The semantics of "age" depend on the CutoffScheme passed to Forwarder.
+    If swapping has been disabled, this list has no effect.
+    If this list is omitted, it is equivalent to all ``-1`` i.e. no restriction on any node.
     """
 
     m_v: NotRequired[MultiplexingVector]
@@ -98,8 +98,8 @@ def validate_path_instructions(instructions: PathInstructions) -> None:
     if len(instructions["swap"]) != len(route):
         raise ValueError("swapping order does not match route length")
 
-    if "swap_cutoff" in instructions and len(instructions["swap_cutoff"]) != len(route):
-        raise ValueError("swap_cutoff does not match swapping order length")
+    if "swap_cutoff" in instructions and len(instructions["swap_cutoff"]) != 2 * (len(route) - 2):
+        raise ValueError("swap_cutoff does not match route length")
 
     if "m_v" in instructions and len(instructions["m_v"]) != len(route) - 1:
         raise ValueError("multiplexing vector does not match route length")

--- a/mqns/network/fw/routing.py
+++ b/mqns/network/fw/routing.py
@@ -122,7 +122,6 @@ class RoutingPath(ABC):
             "req_id": self.req_id,
             "route": route,
             "swap": swap,
-            "swap_cutoff": [-1] * len(swap),
             "purif": self.purif,
         }
         if self.swap_cutoff is not None:

--- a/mqns/network/fw/routing.py
+++ b/mqns/network/fw/routing.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from collections.abc import Iterator, Sequence
+from collections.abc import Iterator, Mapping, Sequence
 from enum import Enum, auto
 from itertools import pairwise
 from typing import TypedDict, Unpack, override
@@ -47,9 +47,9 @@ class RoutingPathInitArgs(TypedDict, total=False):
     """Path identifier for the first path, defaults to auto-assignment."""
     swap: SwapSequenceInput
     """Swap sequence or swap policy, defaults to ASAP."""
-    swap_cutoff: list[float] | None
+    swap_cutoff: Sequence[float] | None
     """Swap cut-off times in seconds."""
-    purif: dict[str, int] | None
+    purif: Mapping[str, int] | None
     """Purification scheme."""
 
 
@@ -84,7 +84,7 @@ class RoutingPath(ABC):
         """
         self.swap: SwapSequenceInput = kwargs.get("swap") or "asap"
         self.swap_cutoff = kwargs.get("swap_cutoff")
-        self.purif = kwargs.get("purif") or {}
+        self.purif = dict(kwargs.get("purif") or {})
 
     @abstractmethod
     def compute_paths(self, net: QuantumNetwork) -> Iterator[PathInstructions]:

--- a/mqns/network/protocol/link_layer.py
+++ b/mqns/network/protocol/link_layer.py
@@ -16,7 +16,7 @@
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from collections import deque
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Literal, TypedDict, cast, override
 
@@ -108,7 +108,6 @@ class LinkLayer(Application[QNode]):
         eta_d: float = 1.0,
         frequency: float = 80e6,
         tau_0: float = 0.0,
-        init_fidelity: float | Sequence[float] | None = 0.99,
     ):
         """
         Constructor.
@@ -119,7 +118,6 @@ class LinkLayer(Application[QNode]):
             eta_d: detector efficiency (default: 1.0).
             frequency: entanglement source frequency in Hz (default: 80e6).
             tau_0: local operation delay in seconds for emitting and absorbing photon (default: 0.0).
-            init_fidelity: fidelity of generated entangled pairs (default: 0.99).
 
         """
         super().__init__()
@@ -134,8 +132,6 @@ class LinkLayer(Application[QNode]):
         """Minimum time between two consecutive photon excitations/absorptions."""
         self.tau_0 = tau_0
         """Local operation delay in seconds."""
-        self.init_fidelity = init_fidelity
-        """Fidelity of generated entangled pairs."""
 
         self.active_channels: dict[tuple[QuantumChannel, int | None], tuple[QNode, int]] = {}
         """
@@ -248,7 +244,6 @@ class LinkLayer(Application[QNode]):
             reset_time=self.reset_time,
             tau_0=self.tau_0,
             epr_type=self.node.network.epr_type,
-            init_fidelity=self.init_fidelity,
             t0=self.simulator.tc,
             store_decays=(self.memory.time_decay, neighbor.memory.time_decay),
         )

--- a/mqns/network/protocol/link_layer.py
+++ b/mqns/network/protocol/link_layer.py
@@ -16,7 +16,7 @@
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from collections import deque
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from typing import Literal, TypedDict, cast, override
 
@@ -108,7 +108,7 @@ class LinkLayer(Application[QNode]):
         eta_d: float = 1.0,
         frequency: float = 80e6,
         tau_0: float = 0.0,
-        init_fidelity: float | None = 0.99,
+        init_fidelity: float | Sequence[float] | None = 0.99,
     ):
         """
         Constructor.

--- a/tests/entity/test_link_arch.py
+++ b/tests/entity/test_link_arch.py
@@ -86,6 +86,32 @@ def make_epr(link_arch: LinkArch, t_cohere: Time):
 
 
 @pytest.mark.parametrize(
+    ("E", "use_probv"),
+    [
+        (WernerStateEntanglement, False),
+        (MixedStateEntanglement, False),
+        (MixedStateEntanglement, True),
+    ],
+)
+def test_init_fidelity(E: type[Entanglement], use_probv: bool):
+    ch = FakeQuantumChannel(0)
+    t_cohere = Time.from_sec(1, accuracy=ACCURACY)
+    link_arch = LinkArchDimDual()
+    link_arch.set(
+        ch=ch, eta_s=1, eta_d=1, reset_time=0, tau_0=0, epr_type=E, init_fidelity=(70, 20, 5, 5) if use_probv else 0.7
+    )
+
+    epr, _, _ = make_epr(link_arch, t_cohere)
+    assert epr.fidelity_time == EPR_TIME
+    assert epr.fidelity == pytest.approx(0.7, abs=1e-6)
+    if type(epr) is MixedStateEntanglement:
+        if use_probv:
+            assert epr.probv[1] == pytest.approx(0.2, abs=1e-6)
+        else:
+            assert epr.probv[1] == pytest.approx(0.1, abs=1e-6)
+
+
+@pytest.mark.parametrize(
     ("LA", "E"),
     list(
         itertools.product(

--- a/tests/entity/test_link_arch.py
+++ b/tests/entity/test_link_arch.py
@@ -1,5 +1,5 @@
 import itertools
-from dataclasses import dataclass
+from collections.abc import Sequence
 
 import pytest
 
@@ -13,18 +13,28 @@ from mqns.models.error import DepolarErrorModel, ErrorModel, parse_time_decay, t
 from mqns.simulator import Simulator, Time
 
 
-@dataclass
 class FakeQuantumChannel:
     length: float
     alpha: float
     delay: DelayModel
+    init_fidelity: float | Sequence[float] | None
     transfer_error: ErrorModel
     bsa_error: ErrorModel
 
-    def __init__(self, length: float, *, alpha=0.2, delay=-1.0, transfer_error_rate=0.0, bsa_error_prob=0.0):
+    def __init__(
+        self,
+        length: float,
+        *,
+        alpha=0.2,
+        delay=-1.0,
+        init_fidelity: float | Sequence[float] | None = None,
+        transfer_error_rate=0.0,
+        bsa_error_prob=0.0,
+    ):
         self.length = length
         self.alpha = alpha
         self.delay = ConstantDelayModel(delay if delay >= 0 else length / default_light_speed[0])
+        self.init_fidelity = init_fidelity
         self.transfer_error = DepolarErrorModel().set(rate=transfer_error_rate, length=0)
         self.bsa_error = DepolarErrorModel().set(p_error=bsa_error_prob)
 
@@ -56,7 +66,6 @@ def test_delays(LA: type[LinkArch], multipliers: tuple[float, float, float, floa
         reset_time=0,
         tau_0=tau_0,
         epr_type=WernerStateEntanglement,
-        init_fidelity=1.0,
     )
 
     d1_epr_creation, d1_notify_a, d1_notify_b = link_arch.delays(1)
@@ -94,12 +103,10 @@ def make_epr(link_arch: LinkArch, t_cohere: Time):
     ],
 )
 def test_init_fidelity(E: type[Entanglement], use_probv: bool):
-    ch = FakeQuantumChannel(0)
+    ch = FakeQuantumChannel(0, init_fidelity=(70, 20, 5, 5) if use_probv else 0.7)
     t_cohere = Time.from_sec(1, accuracy=ACCURACY)
     link_arch = LinkArchDimDual()
-    link_arch.set(
-        ch=ch, eta_s=1, eta_d=1, reset_time=0, tau_0=0, epr_type=E, init_fidelity=(70, 20, 5, 5) if use_probv else 0.7
-    )
+    link_arch.set(ch=ch, eta_s=1, eta_d=1, reset_time=0, tau_0=0, epr_type=E)
 
     epr, _, _ = make_epr(link_arch, t_cohere)
     assert epr.fidelity_time == EPR_TIME

--- a/tests/fw/fw_common.py
+++ b/tests/fw/fw_common.py
@@ -12,7 +12,7 @@ from mqns.entity.memory import QubitState
 from mqns.entity.node import Application, Controller, Node, QNode
 from mqns.entity.qchannel import LinkArchAlways, LinkArchDimBk, QuantumChannelInitKwargs
 from mqns.models.epr import Entanglement, WernerStateEntanglement
-from mqns.network.fw import Forwarder, ForwarderInitKwargs, RoutingController, RoutingPath
+from mqns.network.fw import Forwarder, ForwarderConsumeCounters, ForwarderInitKwargs, RoutingController, RoutingPath
 from mqns.network.fw.fw_swap import ForwarderSwapProc
 from mqns.network.network import QuantumNetwork, TimingMode, TimingModeAsync, TimingPhase, TimingPhaseEvent
 from mqns.network.proactive import ProactiveForwarder, ProactiveRoutingController
@@ -286,6 +286,14 @@ def install_path(
         simulator.add_event(func_to_event(simulator.time(sec=t_uninstall), ctrl.uninstall_path, rp))
 
     return rp
+
+
+def check_path_counters(net: QuantumNetwork, rp: RoutingPath | None = None, *, n_consumed: int):
+    if rp is None:
+        cnt = ForwarderConsumeCounters.of_path(net, net.nodes[0].name, net.nodes[-1].name)
+    else:
+        cnt = ForwarderConsumeCounters.of_path(net, rp.src, rp.dst)
+    assert cnt.n_consumed == n_consumed
 
 
 _provide_entanglements_autoid = AutoIncrementIdentifier("Tpe_")

--- a/tests/fw/fw_common.py
+++ b/tests/fw/fw_common.py
@@ -66,6 +66,7 @@ class QubitReleaseReset(Application[QNode]):
 
 dflt_qchannel_args = QuantumChannelInitKwargs(
     length=100,  # delay is 0.0005 seconds
+    init_fidelity=1.0,
     link_arch=LinkArchAlways(LinkArchDimBk()),  # etg creation in 0.001 seconds and arrival in 0.002 seconds
 )
 
@@ -87,7 +88,6 @@ class BuildNetworkArgs(TypedDict, total=False):
     timing: TimingMode  # network timing mode, defaults to ASYNC
     epr_type: type[Entanglement]  # entanglement type, defaults to werner state
     has_link_layer: bool  # whether to include full LinkLayer application, defaults to False
-    init_fidelity: float  # initial fidelity, defaults to 0.99
 
 
 def _make_topo_args(d: BuildNetworkArgs, *, memory_capacity_factor: int) -> TopologyInitKwargs:
@@ -95,7 +95,7 @@ def _make_topo_args(d: BuildNetworkArgs, *, memory_capacity_factor: int) -> Topo
 
     nodes_apps: list[Application[QNode]] = []
     if d.get("has_link_layer", False):
-        nodes_apps.append(LinkLayer(init_fidelity=d.get("init_fidelity", 0.99)))
+        nodes_apps.append(LinkLayer())
     else:
         nodes_apps.append(QubitReleaseReset())
 
@@ -318,7 +318,6 @@ def provide_entanglements(
             reset_time=0,
             tau_0=0,
             epr_type=src.network.epr_type,
-            init_fidelity=1.0,
         )
         _, d_notify_a, d_notify_b = ch.link_arch.delays(1)
 

--- a/tests/fw/test_p_integ.py
+++ b/tests/fw/test_p_integ.py
@@ -8,7 +8,7 @@ import pytest
 
 from mqns.entity.timer import Timer
 from mqns.models.epr import Entanglement, MixedStateEntanglement, WernerStateEntanglement
-from mqns.network.fw import RoutingPathSingle, RoutingPathStatic, SwapSequenceInput
+from mqns.network.fw import ForwarderConsumeCounters, RoutingPathSingle, RoutingPathStatic, SwapSequenceInput
 from mqns.network.network import TimingModeAsync, TimingModeSync
 from mqns.network.proactive import ProactiveForwarder
 from mqns.network.protocol.link_layer import LinkLayer
@@ -32,7 +32,7 @@ def test_4_swap(epr_type: type[Entanglement], timing_mode: str, swap: SwapSequen
     net, simulator = build_linear_network(
         4, swap_table_leak_tol=256, end_time=3.0, timing=timing, epr_type=epr_type, has_link_layer=True
     )
-    fwA, fwB, fwC, fwD = (node.get_app(ProactiveForwarder) for node in net.nodes)
+    _, fwB, fwC, _ = (node.get_app(ProactiveForwarder) for node in net.nodes)
 
     install_path(net, RoutingPathSingle("A", "D", swap=swap))
     simulator.run()
@@ -43,9 +43,8 @@ def test_4_swap(epr_type: type[Entanglement], timing_mode: str, swap: SwapSequen
     # Hence, these numeric bounds are much smaller than usual values, but must be greater than the memory capacity.
     assert fwB.cnt.n_swapped >= 16
     assert fwC.cnt.n_swapped >= 16
-    assert fwA.cnt.n_consumed >= 16
-    assert fwD.cnt.n_consumed >= 16
-    assert -4 <= fwA.cnt.n_consumed - fwD.cnt.n_consumed <= 4
+    consume_cnt = ForwarderConsumeCounters.of_path(net, "A", "D")
+    assert consume_cnt.n_consumed >= 16
 
 
 def test_rect_uninstall_path():

--- a/tests/fw/test_p_purif.py
+++ b/tests/fw/test_p_purif.py
@@ -8,7 +8,14 @@ from mqns.network.fw import RoutingPathSingle
 from mqns.network.proactive import ProactiveForwarder
 from mqns.utils import rng
 
-from .fw_common import build_linear_network, check_fw_counters, install_path, print_fw_counters, provide_entanglements
+from .fw_common import (
+    build_linear_network,
+    check_fw_counters,
+    check_path_counters,
+    install_path,
+    print_fw_counters,
+    provide_entanglements,
+)
 
 
 def force_purify_outcome(monkeypatch: pytest.MonkeyPatch, *success: bool):
@@ -62,8 +69,8 @@ def test_link_rounds(monkeypatch: pytest.MonkeyPatch, n_rounds: int, purif_succe
         net,
         n_entg=(n_etg, n_etg),
         n_eligible=(n_eligible, n_eligible),
-        n_consumed=(n_eligible, n_eligible),
     )
+    check_path_counters(net, n_consumed=n_eligible)
 
 
 def test_4_l2r(monkeypatch: pytest.MonkeyPatch):
@@ -115,5 +122,5 @@ def test_4_l2r(monkeypatch: pytest.MonkeyPatch):
         # fwC: 2 with fwD, 2 with fwA
         # fwD: 1 with fwA
         n_eligible=(1, 4 + 4, 2 + 2, 1),
-        n_consumed=(1, 0, 0, 1),
     )
+    check_path_counters(net, n_consumed=1)

--- a/tests/fw/test_p_swap.py
+++ b/tests/fw/test_p_swap.py
@@ -140,7 +140,7 @@ def test_3_waittime(etg_sec: tuple[float, float], swap_delay: float, n_consumed:
     net, simulator = build_linear_network(3, t_cohere=0.004, fw={"p_swap": 1.0, "swap_delay": swap_delay}, end_time=1.010)
     fwA, fwB, fwC = (node.get_app(ProactiveForwarder) for node in net.nodes)
 
-    install_path(net, RoutingPathStatic("ABC", swap_cutoff=[0, 0.002, 0]))
+    install_path(net, RoutingPathStatic("ABC", swap_cutoff=[0.002, 0.002]))
     provide_entanglements(
         (etg_sec[0], fwA, fwB),
         (etg_sec[1], fwB, fwC),
@@ -526,7 +526,7 @@ def test_5_decohere(
     net, simulator = build_linear_network(5, t_cohere=0.010, fw={"p_swap": 1.0, "swap_delay": swap_delay}, end_time=2)
     fwA, fwB, fwC, fwD, fwE = (node.get_app(ProactiveForwarder) for node in net.nodes)
 
-    swap_cutoff = None if cutoff4 is None else [-1, -1, -1, cutoff4, -1]
+    swap_cutoff = None if cutoff4 is None else [-1, -1, -1, -1, cutoff4, cutoff4]
     install_path(net, RoutingPathStatic("ABCDE", swap_cutoff=swap_cutoff))
     provide_entanglements(
         (etg_ms, (fwA, fwB, fwC, fwD, fwE)),

--- a/tests/fw/test_p_swap.py
+++ b/tests/fw/test_p_swap.py
@@ -16,6 +16,7 @@ from mqns.models.error import PerfectErrorModel
 from mqns.network.fw import (
     Fib,
     Forwarder,
+    ForwarderConsumeCounters,
     MemoryEprTuple,
     MuxSchemeDynamicEpr,
     MuxSchemeStatistical,
@@ -34,6 +35,7 @@ from .fw_common import (
     build_tree_network,
     check_fw_counters,
     check_memory_released,
+    check_path_counters,
     collect_cpacket_counts,
     install_path,
     print_fw_counters,
@@ -62,9 +64,9 @@ def test_3_disabled():
     print_fw_counters(net)
     check_fw_counters(
         net,
-        n_consumed=(1, 2, 1),
         n_swapped=(0, 0, 0),
     )
+    assert fwA.cnt.n_consumed + fwB.cnt.n_consumed + fwC.cnt.n_consumed == 2
 
 
 @pytest.mark.parametrize(
@@ -101,9 +103,9 @@ def test_3_decohere(swap_delay: float, n_consumed: int):
     print_fw_counters(net)
     check_fw_counters(
         net,
-        n_consumed=(n_consumed, 0, n_consumed),
         n_su_lower=(1, 0, 1),
     )
+    check_path_counters(net, n_consumed=n_consumed)
 
 
 @pytest.mark.parametrize(
@@ -150,12 +152,12 @@ def test_3_waittime(etg_sec: tuple[float, float], swap_delay: float, n_consumed:
 
     check_fw_counters(
         net,
-        n_consumed=(n_consumed, 0, n_consumed),
         n_swapped=(0, n_consumed, 0),
     )
     assert fwA.cnt.n_cutoff == [0, n_cutoff[0]]
     assert fwB.cnt.n_cutoff == [sum(n_cutoff), 0]
     assert fwC.cnt.n_cutoff == [0, n_cutoff[1]]
+    check_path_counters(net, n_consumed=n_consumed)
 
 
 @pytest.mark.parametrize(
@@ -202,9 +204,9 @@ def test_4_sync(t_ext: float, expected: tuple[int, int, int, int]):
     print_fw_counters(net)
     check_fw_counters(
         net,
-        n_consumed=(expected[0], 0, 0, expected[3]),
         n_swapped=(0, expected[1], expected[2], 0),
     )
+    check_path_counters(net, n_consumed=min(expected[0], expected[3]))
 
 
 @pytest.mark.parametrize(
@@ -237,21 +239,21 @@ def test_4_asap(etg_ms: tuple[int, int, int], ps3: int):
     if ps3 == 1:
         check_fw_counters(
             net,
-            n_consumed=(1, 0, 0, 1),
             n_swapped=(0, 1, 1, 0),
             n_swap_fail=(0, 0, 0, 0),
             n_su_same=(0, 1, 1, 0),
             n_su_lower=(1, 0, 0, 1),
         )
+        check_path_counters(net, n_consumed=1)
     else:
         check_fw_counters(
             net,
-            n_consumed=(0, 0, 0, 0),
             n_swapped=(0, 1, 0, 0),
             n_swap_fail=(0, 0, 1, 0),
             n_su_same=(0, 1, (0, 1), 0),  # if B hears C's failure before its own swap, it does not herald C
             n_su_lower=(1, 0, 0, 1),
         )
+        check_path_counters(net, n_consumed=0)
     check_memory_released(net)
 
 
@@ -354,10 +356,10 @@ def test_4_delayed(
     print("cpacket_cnt", cpacket_cnt)
 
     assert fwB_n_swapped_values == [0, 0, 0, 0, 0, n_swap2, n_swap2, n_swap2]
-    assert fwA.cnt.n_consumed == n_consumed
+    consume_cnt = ForwarderConsumeCounters.of_path(net, "A", "D")
+    assert consume_cnt.n_consumed == n_consumed
     if n_consumed > 0:
-        assert 0.5 < fwA.cnt.consumed_avg_fidelity <= 0.75
-        assert fwA.cnt.consumed_avg_fidelity == pytest.approx(fwD.cnt.consumed_avg_fidelity)
+        assert 0.5 < consume_cnt.consumed_avg_fidelity <= 0.75
 
     assert list(fw.node.get_app(QubitReleaseReset).last_t for fw in (fwA, fwB, fwC, fwD)) == [
         simulator.time(sec=t) for t in t_release
@@ -407,9 +409,9 @@ def test_4_decohere(swap_delay: float, n_consumed: int):
     print_fw_counters(net)
     check_fw_counters(
         net,
-        n_consumed=(n_consumed, 0, 0, n_consumed),
         n_su_lower=(1, 0, 0, 1),
     )
+    check_path_counters(net, n_consumed=n_consumed)
     check_memory_released(net)
 
 
@@ -434,12 +436,12 @@ def test_5_asap(
     print_fw_counters(net)
     check_fw_counters(
         net,
-        n_consumed=(n_consumed, 0, 0, 0, n_consumed),
         n_swapped=(0, 1, n_consumed, 1, 0),
         n_swap_fail=(0, 0, 1 - n_consumed, 0, 0),
         n_su_same=(0, 1, (0, 1, 2), 1, 0),
         n_su_lower=(1, 0, 0, 0, 1),
     )
+    check_path_counters(net, n_consumed=n_consumed)
     check_memory_released(net)
 
 
@@ -472,12 +474,12 @@ def test_5_sequential(swap_sulower: tuple[Sequence[int], Sequence[int]], etg_ms:
     print_fw_counters(net)
     check_fw_counters(
         net,
-        n_consumed=(1, 0, 0, 0, 1),
         n_swapped=(0, 1, 1, 1, 0),
         n_swap_fail=(0, 0, 0, 0, 0),
         n_su_same=(0, 0, 0, 0, 0),
         n_su_lower=su_lower,
     )
+    check_path_counters(net, n_consumed=1)
 
 
 @pytest.mark.parametrize(
@@ -534,11 +536,11 @@ def test_5_decohere(
     )
     simulator.run()
     print_fw_counters(net)
-    check_fw_counters(
-        net,
-        n_consumed=(n_consumed, 0, 0, 0, n_consumed),
-        # n_su_lower=(1, 0, 0, 0, 1),
-    )
+    # check_fw_counters(
+    #     net,
+    #     n_su_lower=(1, 0, 0, 0, 1),
+    # )
+    check_path_counters(net, n_consumed=n_consumed)
     check_memory_released(net)
     assert list(node.get_app(QubitReleaseReset).last_t for node in net.nodes[: len(t_release)]) == [
         simulator.time(sec=t) for t in t_release
@@ -575,8 +577,7 @@ def test_rect_multipath(has_etg: tuple[int, int, int, int], n_swapped: tuple[int
     )
     simulator.run()
     print_fw_counters(net)
-
-    assert fwA.cnt.n_consumed == n_consumed == fwD.cnt.n_consumed
+    check_path_counters(net, n_consumed=n_consumed)
     assert (fwB.cnt.n_swapped, fwC.cnt.n_swapped) == n_swapped
 
 
@@ -634,8 +635,8 @@ def test_tree2_dynepr(t_edge_etg: float, selected_path: tuple[int, int], n_consu
     simulator.run()
     print_fw_counters(net)
 
-    assert fwD.cnt.n_consumed == n_consumed[0] == fwF.cnt.n_consumed
-    assert fwE.cnt.n_consumed == n_consumed[1] == fwG.cnt.n_consumed
+    check_path_counters(net, rp0, n_consumed=n_consumed[0])
+    check_path_counters(net, rp1, n_consumed=n_consumed[1])
 
 
 @pytest.mark.parametrize(
@@ -703,8 +704,8 @@ def test_tree2_statistical(
     )
     fwA, fwB, fwC, fwD, fwE, fwF, fwG = (node.get_app(ProactiveForwarder) for node in net.nodes)
 
-    install_path(net, RoutingPathStatic("DBACF", m_v=QubitAllocationType.DISABLED))
-    install_path(net, RoutingPathStatic("EBACG", m_v=QubitAllocationType.DISABLED))
+    rp0 = install_path(net, RoutingPathStatic("DBACF", m_v=QubitAllocationType.DISABLED))
+    rp1 = install_path(net, RoutingPathStatic("EBACG", m_v=QubitAllocationType.DISABLED))
 
     edges = ((fwD, fwB), (fwE, fwB), (fwB, fwA), (fwA, fwC), (fwC, fwF), (fwC, fwG))
     provide_entanglements(
@@ -717,8 +718,8 @@ def test_tree2_statistical(
         # For test cases without unused EPRs, swap conflict should release memory quickly.
         check_memory_released(net)
 
-    assert fwD.cnt.n_consumed == n_consumed[0] == fwF.cnt.n_consumed
-    assert fwE.cnt.n_consumed == n_consumed[1] == fwG.cnt.n_consumed
+    check_path_counters(net, rp0, n_consumed=n_consumed[0])
+    check_path_counters(net, rp1, n_consumed=n_consumed[1])
     assert sum(fw.cnt.n_su_lower[4] for fw in (fwD, fwE, fwF, fwG)) == (2 if sum(n_consumed) == 0 else 0)
 
 
@@ -790,8 +791,8 @@ def test_tree3_statistical(
     )
     fws = {node.name: node.get_app(ProactiveForwarder) for node in net.nodes}
 
-    for path in path0, path1:
-        install_path(net, RoutingPathStatic(path, m_v=QubitAllocationType.DISABLED))
+    rp0 = install_path(net, RoutingPathStatic(path0, m_v=QubitAllocationType.DISABLED))
+    rp1 = install_path(net, RoutingPathStatic(path1, m_v=QubitAllocationType.DISABLED))
 
     def expand_etgs():
         for t, edges in enumerate(etgs.split(":")):
@@ -802,5 +803,5 @@ def test_tree3_statistical(
     simulator.run()
     print_fw_counters(net)
 
-    assert fws[path0[0]].cnt.n_consumed == n_consumed[0]
-    assert fws[path1[0]].cnt.n_consumed == n_consumed[1]
+    check_path_counters(net, rp0, n_consumed=n_consumed[0])
+    check_path_counters(net, rp1, n_consumed=n_consumed[1])

--- a/tests/fw/test_r_swap.py
+++ b/tests/fw/test_r_swap.py
@@ -8,13 +8,20 @@ from itertools import pairwise
 import pytest
 
 from mqns.entity.cchannel import ClassicCommandDispatcherMixin, ClassicPacket, classic_cmd_handler
-from mqns.network.fw import RoutingController, RoutingPathStatic
+from mqns.network.fw import ForwarderConsumeCounters, RoutingController, RoutingPathStatic
 from mqns.network.network import TimingModeSync
 from mqns.network.reactive import ReactiveForwarder, ReactiveRoutingController
 from mqns.network.reactive.message import LinkStateEntry, LinkStateMsg
 from mqns.simulator import func_to_event
 
-from .fw_common import build_linear_network, build_tree_network, check_fw_counters, print_fw_counters, provide_entanglements
+from .fw_common import (
+    build_linear_network,
+    build_tree_network,
+    check_fw_counters,
+    check_path_counters,
+    print_fw_counters,
+    provide_entanglements,
+)
 
 
 class ManualController(ClassicCommandDispatcherMixin, RoutingController):
@@ -60,7 +67,8 @@ def test_tree2_one():
     simulator.run()
     print_fw_counters(net)
 
-    assert fwD.cnt.n_consumed == 1
+    consume_cnt = ForwarderConsumeCounters.of_path(net, "D", "F")
+    assert consume_cnt.n_consumed == 1
 
 
 def test_tree2_two():
@@ -107,8 +115,10 @@ def test_tree2_two():
     simulator.run()
     print_fw_counters(net)
 
-    assert fwD.cnt.n_consumed == 1
-    assert fwE.cnt.n_consumed == 1
+    consumeDF = ForwarderConsumeCounters.of_path(net, "D", "F")
+    assert consumeDF.n_consumed == 1
+    consumeEG = ForwarderConsumeCounters.of_path(net, "E", "G")
+    assert consumeEG.n_consumed == 1
 
 
 @pytest.mark.parametrize(
@@ -154,6 +164,6 @@ def test_3_minimal(req_active: tuple[float, float], etg12: list[float], etg23: l
     assert (ctrl.cnt.n_ls, ctrl.cnt.n_satisfy) == cnt
     check_fw_counters(
         net,
-        n_consumed=(cnt[1], 0, cnt[1]),
         n_swapped=(0, cnt[1], 0),
     )
+    check_path_counters(net, n_consumed=cnt[1])

--- a/tests/fw/test_simple.py
+++ b/tests/fw/test_simple.py
@@ -44,7 +44,7 @@ def test_path_validation():
 
     route3 = ["A", "B", "C"]
     swap3 = [1, 0, 1]
-    scut3 = [-1, 1000, -1]
+    scut3 = [2000, 1000]
     mv3 = [(1, 1)] * 2
 
     with pytest.raises(ValueError, match="route is empty"):
@@ -57,7 +57,7 @@ def test_path_validation():
 
     with pytest.raises(ValueError, match="swap_cutoff"):
         validate_path_instructions(
-            {"req_id": 0, "route": route3, "swap": swap3, "swap_cutoff": [-1, 1000, 1000, -1], "purif": {}}
+            {"req_id": 0, "route": route3, "swap": swap3, "swap_cutoff": [2000, 1000, 1000], "purif": {}}
         )
 
     with pytest.raises(ValueError, match="multiplexing vector"):

--- a/tests/models/test_mixed_state.py
+++ b/tests/models/test_mixed_state.py
@@ -43,7 +43,6 @@ def test_swap():
 
     e1 = MixedStateEntanglement(fidelity=0.95, fidelity_time=now, decohere_time=decohere)
     e2 = MixedStateEntanglement(fidelity=0.95, fidelity_time=now, decohere_time=decohere)
-    e1.read, e2.read = True, True
 
     ne, local_success = MixedStateEntanglement.swap(e1, e2, now=now)
     assert local_success is True


### PR DESCRIPTION
This PR includes several refactorings in support of the upcoming `swap_2links_unit_capacity` (s2uc) example.
It also includes an initial version of s2uc example, which would be further refined.

## NetworkBuilder Refactoring

Previously, `NetworkBuilder` has drastically different APIs for linear and generic topology.
It was due to historical reason, because linear topology API was developed before generic topology API.
Both the linear and generic topology API have some sort of `broadcast` functionality for a subset of parameters such as channel capacity and link architecture; most other parameters are global despite the underlying `CustomTopology` can support having distinct values per-node or per-link.

The s2uc example requires a distinct `t_cohere` value on each node, but this parameter wasn't supported in existing `NetworkBuilder.topo_linear()` API.
While I could convert this parameter to support broadcast, the same process would have to be repeated for each parameter in the future, until `topo_linear` becomes a mess of too many parameters.

Instead, I refactored both linear and generic topology APIs to accept global parameters along with overrides for either nodes or channels.

* Global Defaults: Both linear and generic topology APIs now accept top-level node and link parameters to serve as global defaults.
* Linear Topology API (`.topo_linear`):
  * Accepts a required number of nodes or an explicit list of nodes.
  * Nodes utilizing all global defaults can be specified simply by their string name.
  * Nodes requiring unique configurations can be passed as a `NodeDef` instance, specifying only the parameters that differ from the defaults.
  * Link parameters can be provided via a list of `ChannelParam` instances (without node names), which must cover all links chronologically if specified.
* Generic Topology API (`.topo`):
  * Accepts a required list of links as `ChannelDef` instances (with node names specified), defining only parameters that differ from the global defaults.
    A shorthand tuple form remains supported when only channel length and capacity are modified.
  * Accepts an optional list of unique nodes via `NodeDef` instances.

The parameters currently passed to `LinkLayer` constructor are still global-only.
`init_fidelity` is moved from `LinkLayer` to `QuantumChannel` so it can have distinct values per channel, which is needed by s2uc example.

All existing examples have been migrated.
Note that certain syntax in `template_linear.py` is deleted, replacing a notice that developer should refer to `NetworkBuilder` API for advanced overrides.

## End-to-end Fidelity Accuracy

Consider a swap chain A-B-C-D (equal channel lengths) with r2l swap order.
In this scenario, node B performs the final swap, meaning node A receives heralding and runs `Forwarder.consume_and_release` before node D.

In previous code:

1. Node A calls `memory.read(set_fidelity=True)`, which sets `.read=True` flag on the EPR object and applies memory error models for both qubits.
2. Node A increments `n_consumed` counter and stores the snapshot fidelity as reported by the EPR object.
3. Later, node D calls `memory.read(set_fidelity=True)`, which does not apply memory error models because `.read` flag is already true.
4. Node D also increments `n_consumed` counter and stores the previously fidelity as reported by the EPR object.

This approach has these pitfalls:

* The memory error suffered by node D's qubit between node A's consumption and node D's consumption is unaccounted for, leading to overestimation of the fidelity.
* If node D's qubit decoheres before it receives heralding, the EPR isn't actually usable because node D couldn't consume it, but node A's `n_consumed` counter still included this EPR.
  Moreover, many scenario scripts only read node A's counters, leading to overestimation of the end-to-end entanglement rate.

The refactored code fixes this problem:

* During consumption (but not swapping), each end node only applies memory error model for its own qubit.
* The EPR object contains a "hidden" attribute ("hidden" as in, it cannot affect decisions) that indicates whether left/right end has consumed the EPR.
* Only the end node that consumes the second/last qubit increments `n_consumed` counter and saves the fidelity.
* `.read` flag and `memory.read(set_fidelity=True)` are deleted.

A breaking change is that, a node's `n_consumed` counter only reflects the arrivals where this node was the last to complete consumption.
To accommodate this semantical change, all existing examples have been updated to collect consumption related counters (including `n_consumed` and fidelity) from both ends of a path, utilizing the new `ForwarderConsumeCounters.of_path()` helper to sum them up cleanly.

Metrics comparison between old and new code show reductions in end-to-end entanglement rate and fidelity, because the pitfalls described above have been resolved.

## Memory Error During Swapping

Previously, the memory errors ceases to accumulate at the start of a swap.
Now this is made configurable at either start or finish time, needed by s2uc example.

## Independent Wait-time Budgets for Left and Right Channels

Previously, the FIB entry has a single wait-time budget for each node, applied to both left and right channels.
It turns out that the algorithm needs different wait-time budgets for each channel, because they have different arrival rates.

To avoid complicating external controllers, the `PathInstructions.swap_cutoff` field is made optional and it is deleted from extctrl Rust program.
