### PR TITLE
protocol: introduce Consumer application

### DIFF
--- a/docs/source/_static/examples/multiplexing.svg
+++ b/docs/source/_static/examples/multiplexing.svg
@@ -1,0 +1,70 @@
+<svg width="500" height="400" xmlns="http://www.w3.org/2000/svg">
+  <style>text, tspan {
+      text-anchor: middle;
+      dominant-baseline: middle;
+    }</style>
+  <g transform="translate(50 50)">
+    <line x2="100" y2="150" stroke="#111" stroke-width="2"/>
+    <circle r="30" fill="#7FDBFF"/>
+    <text font-size="20">A</text>
+  </g>
+  <g transform="translate(50 150)">
+    <line x2="100" y2="50" stroke="#111" stroke-width="2"/>
+    <circle r="30" fill="#7FDBFF"/>
+    <text font-size="20">B</text>
+  </g>
+  <g transform="translate(50 250)">
+    <line x2="100" y2="-50" stroke="#111" stroke-width="2"/>
+    <circle r="30" fill="#7FDBFF"/>
+    <text font-size="20">C</text>
+  </g>
+  <g transform="translate(50 350)">
+    <line x2="100" y2="-150" stroke="#111" stroke-width="2"/>
+    <circle r="30" fill="#7FDBFF"/>
+    <text font-size="20">D</text>
+  </g>
+  <g transform="translate(150 300)">
+    <line x2="100" y2="-100" stroke="#111" stroke-width="2"/>
+    <circle r="30" fill="#7FDBFF"/>
+    <text font-size="20">G</text>
+  </g>
+  <g transform="translate(250 300)">
+    <line y2="-100" stroke="#111" stroke-width="2"/>
+    <circle r="30" fill="#7FDBFF"/>
+    <text font-size="20">H</text>
+  </g>
+  <g transform="translate(350 300)">
+    <line x2="-100" y2="-100" stroke="#111" stroke-width="2"/>
+    <circle r="30" fill="#7FDBFF"/>
+    <text font-size="20">I</text>
+  </g>
+  <g transform="translate(450 100)">
+    <line x2="-100" y2="100" stroke="#111" stroke-width="2"/>
+    <circle r="30" fill="#7FDBFF"/>
+    <text font-size="20">K</text>
+  </g>
+  <g transform="translate(450 200)">
+    <line x2="-100" stroke="#111" stroke-width="2"/>
+    <circle r="30" fill="#7FDBFF"/>
+    <text font-size="20">L</text>
+  </g>
+  <g transform="translate(450 300)">
+    <line x2="-100" y2="-100" stroke="#111" stroke-width="2"/>
+    <circle r="30" fill="#7FDBFF"/>
+    <text font-size="20">M</text>
+  </g>
+  <g transform="translate(150 200)">
+    <line x2="100" stroke="#111" stroke-width="2"/>
+    <circle r="30" fill="#7FDBFF"/>
+    <text font-size="20">E</text>
+  </g>
+  <g transform="translate(250 200)">
+    <line x2="100" stroke="#111" stroke-width="2"/>
+    <circle r="30" fill="#7FDBFF"/>
+    <text font-size="20">F</text>
+  </g>
+  <g transform="translate(350 200)">
+    <circle r="30" fill="#7FDBFF"/>
+    <text font-size="20">J</text>
+  </g>
+</svg>

--- a/docs/source/_static/qubit-state.svg
+++ b/docs/source/_static/qubit-state.svg
@@ -1,0 +1,90 @@
+<svg width="450" height="400" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="35" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" />
+    </marker>
+  </defs>
+  <style>
+    text, tspan {
+      text-anchor: middle;
+      dominant-baseline: middle;
+    }
+  </style>
+  <g transform="translate(50 50)">
+    <line x1="100" y1="100" marker-end="url(#arrow)" stroke="#111" stroke-width="2"/>
+    <line x2="100" marker-end="url(#arrow)" stroke="#111" stroke-width="2"/>
+    <circle r="30" fill="#AAAAAA"/>
+    <text font-size="12">RAW</text>
+  </g>
+  <g transform="translate(150 50)">
+    <line x2="100" marker-end="url(#arrow)" stroke="#111" stroke-width="2"/>
+    <circle r="30" fill="#39CCCC"/>
+    <text font-size="12">ACTIVE</text>
+  </g>
+  <g transform="translate(250 50)">
+    <line y2="100" marker-end="url(#arrow)" stroke="#111" stroke-width="2"/>
+    <circle r="30" fill="#39CCCC"/>
+    <text font-size="12">RESERVED</text>
+  </g>
+  <g transform="translate(250 150)">
+    <line y2="100" marker-end="url(#arrow)" stroke="#111" stroke-width="2"/>
+    <line x2="-100" marker-end="url(#arrow)" stroke="#111" stroke-width="2"/>
+    <circle r="30" fill="#F012BE"/>
+    <text y="-10" font-size="9">ENTANGLED0</text>
+    <line x1="-30" x2="30" stroke="#111"/>
+    <text y="10" font-size="9">ENTANGLED1</text>
+  </g>
+  <g transform="translate(250 250)">
+    <line x2="100" marker-start="url(#arrow)" marker-end="url(#arrow)" stroke="#111" stroke-width="2"/>
+    <line y2="100" marker-end="url(#arrow)" stroke="#111" stroke-width="2"/>
+    <line x2="-100" y2="-100" marker-end="url(#arrow)" stroke="#111" stroke-width="2"/>
+    <circle r="30" fill="#F012BE"/>
+    <text font-size="12">PURIF</text>
+  </g>
+  <g transform="translate(350 250)">
+    <line x2="-200" y2="-100" marker-end="url(#arrow)" stroke="#111" stroke-width="2"/>
+    <circle r="30" fill="#F012BE"/>
+    <text font-size="12">PENDING</text>
+  </g>
+  <g transform="translate(250 350)">
+    <line x2="-100" y2="-200" marker-end="url(#arrow)" stroke="#111" stroke-width="2"/>
+    <line x2="-200" marker-end="url(#arrow)" stroke="#111" stroke-width="2"/>
+    <line x2="-100" y2="-100" marker-end="url(#arrow)" stroke="#111" stroke-width="2"/>
+    <circle r="30" fill="#F012BE"/>
+    <text font-size="12">ELIGIBLE</text>
+  </g>
+  <g transform="translate(150 250)">
+    <line y2="-100" marker-end="url(#arrow)" stroke="#111" stroke-width="2"/>
+    <circle r="30" fill="#F012BE"/>
+    <text font-size="12">SWAPPING</text>
+  </g>
+  <g transform="translate(50 350)">
+    <line x2="100" y2="-200" marker-end="url(#arrow)" stroke="#111" stroke-width="2"/>
+    <circle r="30" fill="#FF851B"/>
+    <text font-size="12">CONSUME</text>
+  </g>
+  <g transform="translate(150 150)">
+    <circle r="30" fill="#AAAAAA"/>
+    <text font-size="12">RELEASE</text>
+  </g>
+  <g transform="translate(350 20)">
+    <rect x="-10" width="100" height="125" stroke="#DDD" fill="#FFF"/>
+    <text x="40" y="10" font-size="12" font-weight="bold">OWNER LEGEND</text>
+    <g transform="translate(0 25)">
+      <rect width="80" height="20" fill="#AAAAAA"/>
+      <text x="40" y="10" font-size="12">unused</text>
+    </g>
+    <g transform="translate(0 50)">
+      <rect width="80" height="20" fill="#39CCCC"/>
+      <text x="40" y="10" font-size="12">LinkLayer</text>
+    </g>
+    <g transform="translate(0 75)">
+      <rect width="80" height="20" fill="#F012BE"/>
+      <text x="40" y="10" font-size="12">Forwarder</text>
+    </g>
+    <g transform="translate(0 100)">
+      <rect width="80" height="20" fill="#FF851B"/>
+      <text x="40" y="10" font-size="12">Consumer</text>
+    </g>
+  </g>
+</svg>

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -33,6 +33,11 @@ multi_request_single_path example
 
 .. automodule:: multi_request_single_path
 
+multiplexing example
+--------------------
+
+.. automodule:: multiplexing
+
 single_request_multipath example
 --------------------------------
 

--- a/examples/3_nodes_purif.py
+++ b/examples/3_nodes_purif.py
@@ -3,7 +3,7 @@ import pandas as pd
 from tap import Tap
 
 from mqns.network.builder import CTRL_DELAY, NetworkBuilder
-from mqns.network.fw import ForwarderConsumeCounters
+from mqns.network.protocol.consumer import RequestCounters
 from mqns.simulator import Simulator
 from mqns.utils import log, rng
 
@@ -45,8 +45,8 @@ def run_simulation(t_cohere: float, seed: int):
     s.run()
 
     #### get stats
-    consume_cnt = ForwarderConsumeCounters.of_path(net, "S", "D")
-    return consume_cnt.get_rate(sim_duration), consume_cnt.consumed_avg_fidelity
+    req_cnt = RequestCounters.of(net, 0, "S-D")
+    return req_cnt.get_rate(sim_duration), req_cnt.consumed_avg_fidelity
 
 
 results = {"T_cohere": [], "Mean Rate": [], "Std Rate": [], "Mean F": [], "Std F": []}

--- a/examples/3_nodes_thruput.py
+++ b/examples/3_nodes_thruput.py
@@ -32,7 +32,7 @@ import pandas as pd
 from tap import Tap
 
 from mqns.network.builder import CTRL_DELAY, ChannelParam, EprTypeLiteral, LinkArchLiteral, NetworkBuilder, tap_configure
-from mqns.network.fw import ForwarderConsumeCounters
+from mqns.network.protocol.consumer import RequestCounters
 from mqns.network.protocol.link_layer import LinkLayerCounters
 from mqns.simulator import Simulator
 from mqns.utils import log, rng
@@ -120,27 +120,27 @@ def run_simulation(seed: int, args: Args, t_cohere: float) -> Stats:
     match args.mode:
         case "PCA":
             total_duration += CTRL_DELAY
-            b.proactive_centralized(has_consumer=False)
+            b.proactive_centralized()
         case "PCS":
-            b.proactive_centralized(has_consumer=False, timing=args.sync_timing)
+            b.proactive_centralized(timing=args.sync_timing)
         case "RCS":
-            b.reactive_centralized(has_consumer=False, timing=args.sync_timing)
+            b.reactive_centralized(timing=args.sync_timing)
 
-    b.request("S-D")
+    b.request("S-D", req_id=0)
     net = b.make_network()
     del b
 
     s = Simulator(0, total_duration, accuracy=1000000, install_to=(log, net))
     s.run()
 
-    consume_cnt = ForwarderConsumeCounters.of_path(net, "S", "D")
+    req_cnt = RequestCounters.of(net, 0, "S-D")
     ll_cnt = LinkLayerCounters.aggregate(net.nodes)
     stats = Stats(
         t_cohere=t_cohere,
-        throughput_eps=consume_cnt.get_rate(args.sim_duration),
-        mean_fidelity=consume_cnt.consumed_avg_fidelity,
+        throughput_eps=req_cnt.get_rate(args.sim_duration),
+        mean_fidelity=req_cnt.consumed_avg_fidelity,
         expired_ratio=ll_cnt.decoh_ratio,
-        expired_per_e2e=consume_cnt.get_per_consumed(ll_cnt.n_decoh),
+        expired_per_e2e=req_cnt.get_per_consumed(ll_cnt.n_decoh),
     )
     return stats
 

--- a/examples/3_nodes_thruput.py
+++ b/examples/3_nodes_thruput.py
@@ -120,11 +120,11 @@ def run_simulation(seed: int, args: Args, t_cohere: float) -> Stats:
     match args.mode:
         case "PCA":
             total_duration += CTRL_DELAY
-            b.proactive_centralized()
+            b.proactive_centralized(has_consumer=False)
         case "PCS":
-            b.proactive_centralized(timing=args.sync_timing)
+            b.proactive_centralized(has_consumer=False, timing=args.sync_timing)
         case "RCS":
-            b.reactive_centralized(timing=args.sync_timing)
+            b.reactive_centralized(has_consumer=False, timing=args.sync_timing)
 
     b.request("S-D")
     net = b.make_network()

--- a/examples/3_nodes_wait.py
+++ b/examples/3_nodes_wait.py
@@ -47,8 +47,9 @@ from mqns.entity.base_channel import default_light_speed
 from mqns.models.error import TimeDecayInput
 from mqns.models.error.input import ErrorModelInputBasic, ErrorModelInputLength
 from mqns.network.builder import CTRL_DELAY, EprTypeLiteral, LinkArchLiteral, NetworkBuilder, tap_configure
-from mqns.network.fw import CutoffSchemeWaitTime, ForwarderConsumeCounters
+from mqns.network.fw import CutoffSchemeWaitTime
 from mqns.network.proactive import ProactiveForwarder
+from mqns.network.protocol.consumer import RequestCounters
 from mqns.simulator import Simulator
 from mqns.utils import json_default, log, rng
 
@@ -115,7 +116,7 @@ def run_simulation(seed: int, args: Args, t_cohere: float, t_wait: float):
         .make_network()
     )
 
-    ForwarderConsumeCounters.enable_collect_all_on_path(net, "S", "D")
+    RequestCounters.enable_collect_all(net, 0, "S-D")
     fwR = net.get_node("R").get_app(ProactiveForwarder)
     waitR = CutoffSchemeWaitTime.of(fwR)
     waitR.cnt.enable_collect_all()
@@ -124,12 +125,12 @@ def run_simulation(seed: int, args: Args, t_cohere: float, t_wait: float):
     s.run()
     log.install(None)
 
-    consume_cnt = ForwarderConsumeCounters.of_path(net, "S", "D")
-    rate = consume_cnt.get_rate(args.sim_duration)
+    req_cnt = RequestCounters.of(net, 0, "S-D")
+    rate = req_cnt.get_rate(args.sim_duration)
     discard = fwR.cnt.n_cutoff[0] / args.sim_duration
-    assert consume_cnt.consumed_fidelity_values is not None
+    assert req_cnt.consumed_fidelity_values is not None
     assert waitR.cnt.wait_values is not None
-    return [rate], [discard], consume_cnt.consumed_fidelity_values, waitR.cnt.wait_values
+    return [rate], [discard], req_cnt.consumed_fidelity_values, waitR.cnt.wait_values
 
 
 class Stats(TypedDict):

--- a/examples/asymmetric_channel_3_nodes.py
+++ b/examples/asymmetric_channel_3_nodes.py
@@ -21,7 +21,7 @@ from tap import Tap
 
 from mqns.entity.qchannel import LinkArch, LinkArchDimBk, LinkArchSim, LinkArchSr
 from mqns.network.builder import CTRL_DELAY, ChannelParam, NetworkBuilder
-from mqns.network.fw import ForwarderConsumeCounters
+from mqns.network.protocol.consumer import RequestCounters
 from mqns.simulator import Simulator
 from mqns.utils import log, rng
 
@@ -72,7 +72,7 @@ def run_simulation(
     s.run()
 
     #### get stats
-    consume_cnt = ForwarderConsumeCounters.of_path(net, "S", "D")
+    consume_cnt = RequestCounters.of(net, 0, "S-D")
     return consume_cnt.get_rate(sim_duration), consume_cnt.consumed_avg_fidelity
 
 

--- a/examples/asymmetric_channel_memory.py
+++ b/examples/asymmetric_channel_memory.py
@@ -45,7 +45,7 @@ def run_simulation(seed: int, args: Args):
             channels=[(32, (4, 3)), (18, (1, 2)), (10, (2, 4))],
             t_cohere=0.01,
         )
-        .proactive_centralized(has_consumer=True)
+        .proactive_centralized()
         .request("S-D", swap="l2r")
         .make_network()
     )

--- a/examples/asymmetric_channel_memory.py
+++ b/examples/asymmetric_channel_memory.py
@@ -20,7 +20,7 @@ impact the end-to-end entanglement rate and qubit decoherence ratios.
 from tap import Tap
 
 from mqns.network.builder import CTRL_DELAY, NetworkBuilder
-from mqns.network.fw import ForwarderConsumeCounters
+from mqns.network.protocol.consumer import RequestCounters
 from mqns.network.protocol.link_layer import LinkLayerCounters
 from mqns.simulator import Simulator
 from mqns.utils import log, rng
@@ -45,7 +45,7 @@ def run_simulation(seed: int, args: Args):
             channels=[(32, (4, 3)), (18, (1, 2)), (10, (2, 4))],
             t_cohere=0.01,
         )
-        .proactive_centralized()
+        .proactive_centralized(has_consumer=True)
         .request("S-D", swap="l2r")
         .make_network()
     )
@@ -54,9 +54,9 @@ def run_simulation(seed: int, args: Args):
     s.run()
 
     #### get stats
-    consume_cnt = ForwarderConsumeCounters.of_path(net, "S", "D")
+    req_cnt = RequestCounters.of(net, 0, "S-D")
     ll_cnt = LinkLayerCounters.aggregate(net.nodes)
-    return consume_cnt.get_rate(args.sim_duration), ll_cnt.decoh_ratio
+    return req_cnt.get_rate(args.sim_duration), ll_cnt.decoh_ratio
 
 
 if __name__ == "__main__":

--- a/examples/extctrl/README.md
+++ b/examples/extctrl/README.md
@@ -63,6 +63,9 @@ bash run.sh --mode RCS
 
 # reactive-centralized-sync mode, set coherence time and sync timing (both must be specified)
 bash run.sh --mode RCS --sync_timing 0.026950 0.000050 0.003000 -- --t_cohere 0.030000
+
+# reactive-centralized-sync mode, enable both paths with different swap orders
+bash run.sh --mode RCS -- -- --path1 l2r --path2 asap
 ```
 
 During the scenario execution, you can view NATS messages on a separate console:

--- a/examples/extctrl/extctrl_dp.py
+++ b/examples/extctrl/extctrl_dp.py
@@ -1,4 +1,6 @@
 import math
+from collections.abc import Iterable
+from dataclasses import dataclass
 from typing import Literal, override
 
 from tap import Tap
@@ -6,6 +8,7 @@ from tap import Tap
 from mqns.network.builder import EprTypeLiteral, NetworkBuilder, tap_configure
 from mqns.network.fw import Forwarder, ForwarderCounters
 from mqns.network.protocol.classicbridge import ClassicBridge
+from mqns.network.protocol.consumer import RequestCounters
 from mqns.simulator import Simulator
 from mqns.utils import log, rng
 
@@ -30,7 +33,24 @@ class Args(Tap):
         self.add_argument("--M", metavar=("M_edge", "M_center"))
 
 
-def run_simulation(args: Args) -> dict[str, ForwarderCounters]:
+@dataclass
+class Stats:
+    path1: RequestCounters
+    path2: RequestCounters
+    fw: dict[str, ForwarderCounters]
+
+    def _describe(self) -> Iterable[str]:
+        yield f"PATH1: {self.path1}"
+        yield f"PATH2: {self.path2}"
+        yield "fw:"
+        for node_name in "S1", "D1", "S2", "D2", "R1", "R2":
+            yield f"  {node_name}: {self.fw[node_name].repr_without_consume()}"
+
+    def __repr__(self) -> str:
+        return "\n".join(self._describe())
+
+
+def run_simulation(args: Args) -> Stats:
     rng.reseed(args.seed)
 
     b = NetworkBuilder(
@@ -61,16 +81,19 @@ def run_simulation(args: Args) -> dict[str, ForwarderCounters]:
     s = Simulator(0, math.inf, accuracy=args.sim_accuracy, install_to=(log, net))
     s.run()
 
-    results: dict[str, ForwarderCounters] = {}
+    stats = Stats(
+        path1=RequestCounters.of(net, 10, "S1-D1"),
+        path2=RequestCounters.of(net, 20, "S2-D2"),
+        fw={},
+    )
     for node in net.nodes:
-        results[node.name] = node.get_app(Forwarder).cnt
-    return results
+        stats.fw[node.name] = node.get_app(Forwarder).cnt
+    return stats
 
 
 if __name__ == "__main__":
     args = Args().parse_args()
-    results = run_simulation(args)
+    stats = run_simulation(args)
     print("")
-    print("---- RESULTS ----")
-    for node_name in ("S1", "D1", "S2", "D2", "R1", "R2"):
-        print(f"[{node_name}] {results[node_name]}")
+    print("---- STATS ----")
+    print(stats)

--- a/examples/extctrl/extctrl_dp.py
+++ b/examples/extctrl/extctrl_dp.py
@@ -44,7 +44,7 @@ class Stats:
         yield f"PATH2: {self.path2}"
         yield "fw:"
         for node_name in "S1", "D1", "S2", "D2", "R1", "R2":
-            yield f"  {node_name}: {self.fw[node_name].repr_without_consume()}"
+            yield f"  {node_name}: {self.fw[node_name]}"
 
     def __repr__(self) -> str:
         return "\n".join(self._describe())

--- a/examples/extctrl/src/lib.rs
+++ b/examples/extctrl/src/lib.rs
@@ -38,7 +38,9 @@ pub struct PathInstructions {
     pub req_id: u32,
     pub route: Vec<String>,
     pub swap: Vec<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub swap_cutoff: Option<Vec<i32>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub m_v: Option<Vec<MultiplexingVectorElem>>,
     pub purif: HashMap<String, String>,
 }

--- a/examples/multi_request_single_path.py
+++ b/examples/multi_request_single_path.py
@@ -18,7 +18,9 @@ on end-to-end throughput and average state fidelity for both paths, outputting c
 and JSON data summaries.
 """
 
+import itertools
 import json
+from multiprocessing import Pool, freeze_support
 from typing import NamedTuple, cast
 
 import numpy as np
@@ -35,6 +37,7 @@ log.set_default_level("CRITICAL")
 
 
 class Args(Tap):
+    workers: int = 1  # number of workers for parallel execution
     runs: int = 3  # number of trials per parameter set
     sim_duration: float = 3  # simulation duration in seconds
     json: str = ""  # save results as JSON file
@@ -164,7 +167,7 @@ def plot(results: dict[str, list[list[PathStats]]], *, save_plt: str):
 
     axs[1, -1].legend(title="Strategy", loc="lower right")
     fig.tight_layout(rect=(0, 0, 1, 0.95))
-    plt_save(args.plt)
+    plt_save(save_plt)
 
 
 # Simulation constants
@@ -176,15 +179,19 @@ STRATEGIES: dict[str, MuxScheme] = {
 T_COHERE_VALUES = [5e-3, 10e-3, 20e-3]
 
 if __name__ == "__main__":
+    freeze_support()
     args = Args().parse_args()
 
-    results: dict[str, list[list[PathStats]]] = {}  # strategy->path->t_cohere_index
-    for strategy in STRATEGIES:
-        results[strategy] = [[] for _ in PATH_TITLES]
-        for t_cohere in T_COHERE_VALUES:
-            row = run_row(args, strategy, t_cohere)
-            for path, stats in enumerate(row):
-                results[strategy][path].append(stats)
+    with Pool(processes=args.workers) as pool:
+        rows = pool.starmap(run_row, itertools.product([args], STRATEGIES, T_COHERE_VALUES))
+
+    results: dict[str, list[list[PathStats]]] = {
+        strategy: [[] for _ in PATH_TITLES] for strategy in STRATEGIES
+    }  # strategy->path->t_cohere_index
+    for (strategy, t_cohere), row in zip(itertools.product(STRATEGIES, T_COHERE_VALUES), rows, strict=True):
+        _ = t_cohere
+        for path, stats in enumerate(row):
+            results[strategy][path].append(stats)
 
     if args.json:
         with open(args.json, "w") as file:

--- a/examples/multi_request_single_path.py
+++ b/examples/multi_request_single_path.py
@@ -38,7 +38,7 @@ log.set_default_level("CRITICAL")
 
 class Args(Tap):
     workers: int = 1  # number of workers for parallel execution
-    runs: int = 3  # number of trials per parameter set
+    runs: int = 10  # number of trials per parameter set
     sim_duration: float = 3  # simulation duration in seconds
     json: str = ""  # save results as JSON file
     plt: str = ""  # save plot as image file
@@ -48,14 +48,6 @@ SEED_BASE = 100
 PATH_TITLES = ("S1-D1", "S2-D2")
 N_PATHS = len(PATH_TITLES)
 
-# Quantum channel lengths
-ch_S1_R1 = 10
-ch_R1_R2 = 10
-ch_R2_R3 = 10
-ch_R3_D1 = 10
-ch_S2_R2 = 10
-ch_R3_D2 = 10
-
 
 def run_simulation(seed: int, args: Args, mux: MuxScheme, t_cohere: float):
     rng.reseed(seed)
@@ -64,12 +56,13 @@ def run_simulation(seed: int, args: Args, mux: MuxScheme, t_cohere: float):
         NetworkBuilder()
         .topo(
             channels=[
-                ("S1-R1", ch_S1_R1),
-                ("R1-R2", ch_R1_R2),
-                ("R2-R3", ch_R2_R3),
-                ("R3-D1", ch_R3_D1),
-                ("S2-R2", ch_S2_R2),
-                ("R3-D2", ch_R3_D2),
+                ("S1-R1", 10),
+                ("R1-R2", 10),
+                ("R2-R3", 10),
+                ("R3-D1", 10),
+                ("S2-R4", 10),
+                ("R4-R2", 15),
+                ("R3-D2", 15),
             ],
             t_cohere=t_cohere,
         )

--- a/examples/multi_request_single_path.py
+++ b/examples/multi_request_single_path.py
@@ -67,7 +67,7 @@ def run_simulation(seed: int, args: Args, mux: MuxScheme, t_cohere: float):
             ],
             t_cohere=t_cohere,
         )
-        .proactive_centralized(has_consumer=True, mux=mux)
+        .proactive_centralized(mux=mux)
         .request("S1-D1", req_id=1)
         .request("S2-D2", req_id=2)
         .make_network()

--- a/examples/multi_request_single_path.py
+++ b/examples/multi_request_single_path.py
@@ -27,7 +27,8 @@ import numpy as np
 from tap import Tap
 
 from mqns.network.builder import CTRL_DELAY, NetworkBuilder
-from mqns.network.fw import ForwarderConsumeCounters, MuxScheme, MuxSchemeDynamicEpr, MuxSchemeStatistical
+from mqns.network.fw import MuxScheme, MuxSchemeDynamicEpr, MuxSchemeStatistical
+from mqns.network.protocol.consumer import RequestCounters
 from mqns.simulator import Simulator
 from mqns.utils import log, rng
 
@@ -66,9 +67,9 @@ def run_simulation(seed: int, args: Args, mux: MuxScheme, t_cohere: float):
             ],
             t_cohere=t_cohere,
         )
-        .proactive_centralized(mux=mux)
-        .request("S1-D1")
-        .request("S2-D2")
+        .proactive_centralized(has_consumer=True, mux=mux)
+        .request("S1-D1", req_id=1)
+        .request("S2-D2", req_id=2)
         .make_network()
     )
 
@@ -78,8 +79,8 @@ def run_simulation(seed: int, args: Args, mux: MuxScheme, t_cohere: float):
     #### get stats: e2e_rate and mean_fidelity
     # [(path 1), (path 2), ...]
     consume_cnts = [
-        ForwarderConsumeCounters.of_path(net, "S1", "D1"),
-        ForwarderConsumeCounters.of_path(net, "S2", "D2"),
+        RequestCounters.of(net, 1, "S1-D1"),
+        RequestCounters.of(net, 2, "S2-D2"),
     ]
     return [(c.get_rate(args.sim_duration), c.consumed_avg_fidelity) for c in consume_cnts]
 

--- a/examples/multiplexing.py
+++ b/examples/multiplexing.py
@@ -1,3 +1,42 @@
+"""
+Simulate a multi-tenant quantum network to evaluate multiplexing strategies.
+
+This script benchmarks different link-sharing methodologies across a 13-node tree/star
+topology characterized by two highly contested central backbone routing links: ``E-F`` and ``F-J``.
+
+.. figure:: /_static/examples/multiplexing.svg
+   :alt: topology diagram
+   :align: center
+   :width: 100%
+
+Five competing end-to-end data flows share segments of this backbone infrastructure:
+
+* ``AK``: A -> E -> F -> J -> K
+* ``BL``: B -> E -> F -> J -> L
+* ``CI``: C -> E -> F -> I
+* ``DH``: D -> E -> F -> H
+* ``GM``: G -> F -> J -> M
+
+Evaluated Multiplexing Strategies (``STRATEGIES``):
+
+1.  **Statistical Multiplexing (``MuxSchemeStatistical``):** Flows access link-level entanglement on a competitive,
+    best-effort basis without advance hardware reservations.
+2.  **Buffer-Space Multiplexing (``MuxSchemeBufferSpace``):** Enforces a strict, proactive partitioning of
+    available channel memories per active flow along contested trunks.
+
+Experimental Protocol:
+The script systematically executes a matrix of multi-flow loading scenarios (from isolated
+single flows up to full 5-way traffic saturation) across both routing schemes.
+It collects source-destination throughput rates (eps), state fidelities, memory decoherence
+counts, and swap scheduling contentions.
+
+Outputs:
+
+* **JSON Report (``--json``):** Scenario metrics per run including rate and fidelity.
+* **Stacked Bar Charts (``--plt_stat``, ``--plt_buff``):** Visual summaries breaking down
+  aggregate network throughput by individual flow contributions relative to uncontested baselines.
+"""
+
 import json
 from collections.abc import Sequence
 from typing import NamedTuple
@@ -140,18 +179,6 @@ def _mv_for_flow(flow: str, route: list[str], active_flows: set[str]):
 
 def build_network(mux: MuxScheme, active_flows: Sequence[FlowDef]):
     b = NetworkBuilder()
-    # ------------------------------
-    # 13-node topology (A..M) with shared trunks EF and FJ
-    # All quantum links 30 km
-    #
-    # A                         K
-    #  \                       /
-    # B-\                     /
-    #    +E--------F--------J+--L
-    # C-/         /|\         \
-    #  /         / | \         \
-    # D         G  H  I         M
-    # ------------------------------
     b.topo(
         channels=[
             # left spokes -> E

--- a/examples/multiplexing.py
+++ b/examples/multiplexing.py
@@ -7,7 +7,6 @@ from tap import Tap
 
 from mqns.network.builder import CTRL_DELAY, NetworkBuilder
 from mqns.network.fw import (
-    ForwarderConsumeCounters,
     MultiplexingVector,
     MuxScheme,
     MuxSchemeBufferSpace,
@@ -16,6 +15,7 @@ from mqns.network.fw import (
     RoutingPathStatic,
 )
 from mqns.network.proactive import ProactiveForwarder
+from mqns.network.protocol.consumer import RequestCounters
 from mqns.network.protocol.link_layer import LinkLayer
 from mqns.simulator import Simulator
 from mqns.utils import log, rng
@@ -39,7 +39,8 @@ RX_QUBITS = 32
 
 
 class FlowDef:
-    def __init__(self, route: Sequence[str], color: str):
+    def __init__(self, req_id: int, route: Sequence[str], color: str):
+        self.req_id = req_id
         self.route = list(route)
         self.label = f"{self.route[0]}{self.route[-1]}"
         self.color = color
@@ -47,11 +48,11 @@ class FlowDef:
 
 
 FLOWS = [
-    FLOW_AK := FlowDef("AEFJK", "tab:blue"),
-    FLOW_BL := FlowDef("BEFJL", "tab:orange"),
-    FLOW_CI := FlowDef("CEFI", "tab:green"),
-    FLOW_DH := FlowDef("DEFH", "tab:red"),
-    FLOW_GM := FlowDef("GFJM", "tab:purple"),
+    FLOW_AK := FlowDef(1, "AEFJK", "tab:blue"),
+    FLOW_BL := FlowDef(2, "BEFJL", "tab:orange"),
+    FLOW_CI := FlowDef(3, "CEFI", "tab:green"),
+    FLOW_DH := FlowDef(4, "DEFH", "tab:red"),
+    FLOW_GM := FlowDef(5, "GFJM", "tab:purple"),
 ]
 N_FLOWS = len(FLOWS)
 for i, flow in enumerate(FLOWS):
@@ -182,11 +183,15 @@ def build_network(mux: MuxScheme, active_flows: Sequence[FlowDef]):
         # Explicit static paths with per-hop MVs
         active_flows_set = set(f.label for f in active_flows)
         for flow in active_flows:
-            b.request(RoutingPathStatic(flow.route, m_v=_mv_for_flow(flow.label, flow.route, active_flows_set), swap="asap"))
+            b.request(
+                RoutingPathStatic(
+                    flow.route, req_id=flow.req_id, m_v=_mv_for_flow(flow.label, flow.route, active_flows_set), swap="asap"
+                )
+            )
     else:
         # Statistical: best-effort usage; no pre-split
         for flow in active_flows:
-            b.request(RoutingPathStatic(flow.route, m_v=QubitAllocationType.DISABLED, swap="asap"))
+            b.request(RoutingPathStatic(flow.route, req_id=flow.req_id, m_v=QubitAllocationType.DISABLED, swap="asap"))
 
     return b.make_network()
 
@@ -201,7 +206,7 @@ def run_simulation(seed: int, args: Args, mux: MuxScheme, active_flows: list[Flo
 
     # Collect per-source stats in fixed order [AK, BL, CI, DH, GM]
     def _get_rate_fid(flow: FlowDef):
-        consume_cnt = ForwarderConsumeCounters.of_path(net, flow.route[0], flow.route[-1])
+        consume_cnt = RequestCounters.of(net, flow.req_id, (flow.route[0], flow.route[-1]))
         return consume_cnt.get_rate(args.sim_duration), consume_cnt.consumed_avg_fidelity
 
     stats: list[tuple[float, float]] = []  # [(AK), (BL), (CI), (DH), (GM)] # disabled flows have zero stats

--- a/examples/s2uc.py
+++ b/examples/s2uc.py
@@ -16,7 +16,7 @@ from tap import Tap
 from mqns.entity.qchannel import LinkArchDimDual
 from mqns.models.epr import MixedStateEntanglement
 from mqns.network.builder import CTRL_DELAY, ChannelParam, NetworkBuilder, NodeDef, tap_configure
-from mqns.network.fw import ForwarderConsumeCounters
+from mqns.network.protocol.consumer import RequestCounters
 from mqns.simulator import Simulator
 from mqns.utils import log, rng
 
@@ -115,16 +115,16 @@ def run_simulation(seed: int, args: Args, ri: RowInput) -> Stats:
         .make_network()
     )
 
-    ForwarderConsumeCounters.enable_collect_all_on_path(net, "S", "D")
+    RequestCounters.enable_collect_all(net, 0, "S-D")
 
     s = Simulator(0, args.sim_duration + CTRL_DELAY, accuracy=SIMULATOR_ACCURACY, install_to=(log, net))
     s.run()
 
-    consume_cnt = ForwarderConsumeCounters.of_path(net, "S", "D")
-    assert consume_cnt.consumed_fidelity_values is not None
+    req_cnt = RequestCounters.of(net, 0, "S-D")
+    assert req_cnt.consumed_fidelity_values is not None
     return Stats(
-        count=consume_cnt.n_consumed,
-        fid=consume_cnt.consumed_fidelity_values,
+        count=req_cnt.n_consumed,
+        fid=req_cnt.consumed_fidelity_values,
     )
 
 

--- a/examples/scalability_randomtopo/srt_detail/defs.py
+++ b/examples/scalability_randomtopo/srt_detail/defs.py
@@ -13,6 +13,7 @@ from mqns.entity.node import Controller
 from mqns.network.fw import MuxSchemeStatistical
 from mqns.network.network import QuantumNetwork
 from mqns.network.proactive import ProactiveForwarder, ProactiveRoutingController
+from mqns.network.protocol.consumer import Consumer
 from mqns.network.protocol.link_layer import LinkLayer
 from mqns.network.topology import ClassicTopology, RandomTopology
 from mqns.utils import rng
@@ -111,6 +112,7 @@ def build_network(args: RunArgs) -> QuantumNetwork:
                 frequency=frequency,
             ),
             ProactiveForwarder(p_swap=p_swap, mux=MuxSchemeStatistical()),
+            Consumer(),
         ],
     )
     topo.controller = Controller("ctrl", apps=[ProactiveRoutingController()])

--- a/examples/scalability_randomtopo/srt_mqns.py
+++ b/examples/scalability_randomtopo/srt_mqns.py
@@ -2,9 +2,10 @@ import json
 import os.path
 
 from mqns.entity.node import QNode
-from mqns.network.fw import ForwarderConsumeCounters, QubitAllocationType, RoutingPathSingle
+from mqns.network.fw import QubitAllocationType, RoutingPathSingle
 from mqns.network.network import Request
 from mqns.network.proactive import ProactiveForwarder, ProactiveRoutingController
+from mqns.network.protocol.consumer import RequestCounters
 from mqns.network.protocol.link_layer import LinkLayer
 from mqns.simulator import Simulator
 from mqns.utils import WallClockTimeout, json_default, log
@@ -26,7 +27,7 @@ def run_simulation(args: RunArgs) -> RunResult:
     ctrl = net.get_controller().get_app(ProactiveRoutingController)
     for req in net.requests:
         ctrl.install_path(
-            RoutingPathSingle(req.src.name, req.dst.name, qubit_allocation=QubitAllocationType.DISABLED, swap="asap")
+            RoutingPathSingle(req.src.name, req.dst.name, req_id=req.req_id, qubit_allocation=QubitAllocationType.DISABLED)
         )
 
     # Run the simulation.
@@ -37,16 +38,13 @@ def run_simulation(args: RunArgs) -> RunResult:
 
     # Collect results.
     def gather_request_stats(req: Request) -> RequestStats:
-        consume_cnt = ForwarderConsumeCounters.of_path(net, req.src.name, req.dst.name)
-        return consume_cnt.get_rate(sim_duration), consume_cnt.consumed_avg_fidelity
+        req_cnt = RequestCounters.of(net, req.req_id, (req.src.name, req.dst.name))
+        return req_cnt.get_rate(sim_duration), req_cnt.consumed_avg_fidelity
 
     def gather_node_stats(node: QNode):
         fw = node.get_app(ProactiveForwarder)
         ll = node.get_app(LinkLayer)
-        return [
-            ll.cnt,
-            fw.cnt,
-        ]
+        return [ll.cnt, fw.cnt]
 
     return RunResult(
         time_spent=s.time_spend,

--- a/examples/single_request_multipath.py
+++ b/examples/single_request_multipath.py
@@ -62,7 +62,7 @@ def run_simulation(seed: int, args: Args):
             ],
             t_cohere=0.01,
         )
-        .proactive_centralized(has_consumer=True)
+        .proactive_centralized()
         .request("S-D", swap="r2l")
         .make_network()
     )

--- a/examples/single_request_multipath.py
+++ b/examples/single_request_multipath.py
@@ -17,7 +17,7 @@ alter the total end-to-end entanglement generation rate and overall qubit decohe
 from tap import Tap
 
 from mqns.network.builder import CTRL_DELAY, NetworkBuilder
-from mqns.network.fw import ForwarderConsumeCounters
+from mqns.network.protocol.consumer import RequestCounters
 from mqns.network.protocol.link_layer import LinkLayerCounters
 from mqns.network.route import YenRouteAlgorithm
 from mqns.simulator import Simulator
@@ -62,7 +62,7 @@ def run_simulation(seed: int, args: Args):
             ],
             t_cohere=0.01,
         )
-        .proactive_centralized()
+        .proactive_centralized(has_consumer=True)
         .request("S-D", swap="r2l")
         .make_network()
     )
@@ -72,7 +72,7 @@ def run_simulation(seed: int, args: Args):
 
     #### get stats
     decoh_ratio = LinkLayerCounters.aggregate(net.nodes).decoh_ratio
-    consume_cnt = ForwarderConsumeCounters.of_path(net, "S", "D")
+    consume_cnt = RequestCounters.of(net, 0, "S-D")
     return consume_cnt.get_rate(args.sim_duration), decoh_ratio
 
 

--- a/examples/swapping_policies_6_nodes.py
+++ b/examples/swapping_policies_6_nodes.py
@@ -29,7 +29,8 @@ import numpy as np
 from tap import Tap
 
 from mqns.network.builder import CTRL_DELAY, NetworkBuilder
-from mqns.network.fw import ForwarderConsumeCounters, SwapPolicy
+from mqns.network.fw import SwapPolicy
+from mqns.network.protocol.consumer import RequestCounters
 from mqns.simulator import Simulator
 from mqns.utils import log, rng
 
@@ -72,8 +73,8 @@ def run_simulation(
     s.run()
 
     #### get stats
-    consume_cnt = ForwarderConsumeCounters.of_path(net, "S", "D")
-    return consume_cnt.get_rate(sim_duration)
+    req_cnt = RequestCounters.of(net, 0, "S-D")
+    return req_cnt.get_rate(sim_duration)
 
 
 type Results = dict[str, dict[SwapPolicy, dict[float, tuple[float, float]]]]

--- a/examples/template_linear.py
+++ b/examples/template_linear.py
@@ -22,7 +22,8 @@ from tap import Tap
 
 from mqns.entity.qchannel import LinkArchDimBk, LinkArchSim, LinkArchSr
 from mqns.network.builder import CTRL_DELAY, NetworkBuilder
-from mqns.network.fw import ForwarderConsumeCounters, SwapSequenceInput
+from mqns.network.fw import SwapSequenceInput
+from mqns.network.protocol.consumer import RequestCounters
 from mqns.network.protocol.link_layer import LinkLayerCounters
 from mqns.simulator import Simulator
 from mqns.utils import log, rng
@@ -173,7 +174,7 @@ def run_simulation(
         .proactive_centralized(
             p_swap=P_SWAP,
         )
-        .request("S-D", swap=swap)
+        .request("S-D", req_id=0, swap=swap)
         .make_network()
     )
 
@@ -184,18 +185,18 @@ def run_simulation(
     # ── Extract metrics ───────────────────────────────────────────────────────
     out: dict[str, float] = {}
 
-    consume_cnt = ForwarderConsumeCounters.of_path(net, "S", "D")
+    req_cnt = RequestCounters.of(net, 0, "S-D")
 
     if "throughput" in MEASURES:
-        out["throughput_eps"] = consume_cnt.get_rate(SIM_DURATION)
+        out["throughput_eps"] = req_cnt.get_rate(SIM_DURATION)
 
     if "mean_fidelity" in MEASURES:
-        out["mean_fidelity"] = consume_cnt.consumed_avg_fidelity
+        out["mean_fidelity"] = req_cnt.consumed_avg_fidelity
 
     if "expired_ratio" in MEASURES:
         ll_cnt = LinkLayerCounters.aggregate(net.nodes)
         out["expired_ratio"] = float(ll_cnt.decoh_ratio)
-        out["expired_per_e2e_safe"] = consume_cnt.get_per_consumed(ll_cnt.n_decoh)
+        out["expired_per_e2e_safe"] = req_cnt.get_per_consumed(ll_cnt.n_decoh)
 
     return out
 

--- a/examples/template_routing.py
+++ b/examples/template_routing.py
@@ -49,7 +49,6 @@ from tap import Tap
 
 from mqns.network.builder import CTRL_DELAY, NetworkBuilder
 from mqns.network.fw import (
-    ForwarderConsumeCounters,
     MultiplexingVector,
     MuxScheme,
     MuxSchemeBufferSpace,
@@ -62,6 +61,7 @@ from mqns.network.fw import (
 )
 from mqns.network.network import QuantumNetwork
 from mqns.network.network.timing import TimingModeSync
+from mqns.network.protocol.consumer import RequestCounters
 from mqns.network.route import DijkstraRouteAlgorithm, YenRouteAlgorithm
 from mqns.simulator import Simulator
 from mqns.utils import log, rng
@@ -300,7 +300,7 @@ def run_one(t_cohere: float, seed: int) -> dict[str, tuple[float, float]]:
     # Collect stats for selected requests
     out: dict[str, tuple[float, float]] = {}
     for rp, label in zip(SC.install_paths, SC.measured_labels, strict=True):
-        consume_cnt = ForwarderConsumeCounters.of_path(net, rp.src, rp.dst)
+        consume_cnt = RequestCounters.of(net, rp)
         out[label] = consume_cnt.get_rate(SIM_DURATION), consume_cnt.consumed_avg_fidelity
 
     return out

--- a/examples/vora_evaluation.py
+++ b/examples/vora_evaluation.py
@@ -51,9 +51,10 @@ import pandas as pd
 from tap import Tap
 
 from mqns.network.builder import CTRL_DELAY, NetworkBuilder
-from mqns.network.fw import ForwarderConsumeCounters, SwapPolicy, SwapSequence, SwapSequenceInput
+from mqns.network.fw import SwapPolicy, SwapSequence, SwapSequenceInput
 from mqns.network.network import QuantumNetwork
 from mqns.network.proactive import compute_vora_swap_sequence
+from mqns.network.protocol.consumer import RequestCounters
 from mqns.network.protocol.link_layer import LinkLayerCounters
 from mqns.simulator import Simulator
 from mqns.utils import log, rng
@@ -193,9 +194,9 @@ def run_simulation(p: ParameterSet, seed: int) -> tuple[float, float]:
     s.run()
 
     #### get stats
-    consume_cnt = ForwarderConsumeCounters.of_path(net, "S", "D")
+    req_cnt = RequestCounters.of(net, 0, "S-D")
     ll_cnt = LinkLayerCounters.aggregate(net.nodes)
-    return consume_cnt.get_rate(p.sim_duration), consume_cnt.get_per_consumed(ll_cnt.n_decoh)
+    return req_cnt.get_rate(p.sim_duration), req_cnt.get_per_consumed(ll_cnt.n_decoh)
 
 
 def run_row(p: ParameterSet, num_routers: int, dist_prop: str, swap_conf: str) -> dict:

--- a/mqns/entity/memory/memory_qubit.py
+++ b/mqns/entity/memory/memory_qubit.py
@@ -25,6 +25,15 @@ from mqns.simulator import EventHandleSet
 
 
 class QubitState(Enum):
+    """
+    Indicates qubit state following a finite state machine.
+
+    .. figure:: /_static/qubit-state.svg
+       :alt: finite state machine
+       :align: center
+       :width: 100%
+    """
+
     RAW = auto()
     """
     Qubit is unused.
@@ -75,6 +84,10 @@ class QubitState(Enum):
     The forwarder is performing local swapping between this and another memory qubit.
     If the qubit is released from this state, the local swapping would be aborted.
     """
+    CONSUME = auto()
+    """
+    Qubit is part of an end-to-end entangled pair and ready for consumption by application.
+    """
     RELEASE = auto()
     """
     Qubit is not used by the forwarder.
@@ -90,10 +103,14 @@ ALLOWED_STATE_TRANSITIONS: dict[QubitState, tuple[QubitState, ...]] = {
     QubitState.ENTANGLED1: (QubitState.RELEASE, QubitState.PURIF),
     QubitState.PURIF: (QubitState.RELEASE, QubitState.PENDING, QubitState.ELIGIBLE),
     QubitState.PENDING: (QubitState.RELEASE, QubitState.PURIF),
-    QubitState.ELIGIBLE: (QubitState.SWAPPING, QubitState.RELEASE),
+    QubitState.ELIGIBLE: (QubitState.SWAPPING, QubitState.CONSUME, QubitState.RELEASE),
     QubitState.SWAPPING: (QubitState.RELEASE,),
+    QubitState.CONSUME: (QubitState.RELEASE,),
     QubitState.RELEASE: (QubitState.RAW,),
 }
+"""
+Allowed state transitions, mapped from old state to allowed new states.
+"""
 
 
 class PathDirection(Enum):
@@ -154,7 +171,15 @@ class MemoryQubit:
 
     @property
     def state(self) -> QubitState:
-        """State of the qubit according to the FSM."""
+        """
+        Retrieve or set qubit state.
+
+        In the setter:
+
+        * If the state transition is not allowed, raises ValueError,
+        * If the new state is either ``RAW`` or ``RELEASE``, cancel events.
+        * If the new state is ``RAW``, clear LinkLayer and Forwarder related fields.
+        """
         return self._state
 
     @state.setter
@@ -200,5 +225,5 @@ def _describe(mq: MemoryQubit) -> Iterable[str]:
     if mq.epr_path_ids:
         yield f"epr-path-ids={mq.epr_path_ids}"
 
-    if mq._state in (QubitState.PURIF, QubitState.PENDING, QubitState.ELIGIBLE, QubitState.SWAPPING):
+    if mq._state in (QubitState.PURIF, QubitState.PENDING, QubitState.ELIGIBLE, QubitState.SWAPPING, QubitState.CONSUME):
         yield f"purif_rounds={mq.purif_rounds}"

--- a/mqns/entity/node/__init__.py
+++ b/mqns/entity/node/__init__.py
@@ -28,14 +28,19 @@
 from mqns.entity.node.app import Application
 from mqns.entity.node.controller import Controller
 from mqns.entity.node.node import Node
+from mqns.entity.node.pair import NodePair, split_node_pair
 from mqns.entity.node.qnode import QNode
 
 __all__ = [
     "Application",
     "Controller",
     "Node",
+    "NodePair",
     "QNode",
+    "split_node_pair",
 ]
 
 for name in __all__:
+    if name in ("NodePair",):
+        continue
     globals()[name].__module__ = __name__

--- a/mqns/entity/node/pair.py
+++ b/mqns/entity/node/pair.py
@@ -1,0 +1,16 @@
+from typing import cast
+
+type NodePair = str | tuple[str, str]
+"""
+Two node names on a channel or routing path.
+This could be either a tuple of two node names, or a string delimited by hyphen (``-``).
+"""
+
+
+def split_node_pair(np: NodePair) -> tuple[str, str]:
+    if isinstance(np, str):
+        tokens = np.split("-")
+        if len(tokens) != 2:
+            raise ValueError(f"expect two node names in '{np}'")
+        return cast(tuple[str, str], tuple(tokens))
+    return np

--- a/mqns/network/builder.py
+++ b/mqns/network/builder.py
@@ -6,7 +6,7 @@ from typing import Literal, NotRequired, Self, TypedDict, Unpack, cast, overload
 from tap import Tap
 
 from mqns.entity.memory import QuantumMemoryInitKwargs
-from mqns.entity.node import Application, QNode
+from mqns.entity.node import Application, NodePair, QNode, split_node_pair
 from mqns.entity.qchannel import (
     LinkArch,
     LinkArchDimBk,
@@ -32,17 +32,12 @@ from mqns.network.fw import (
 from mqns.network.network import QuantumNetwork, TimingMode, TimingModeAsync, TimingModeSync
 from mqns.network.proactive import ProactiveForwarder, ProactiveRoutingController
 from mqns.network.protocol.classicbridge import ClassicBridge
+from mqns.network.protocol.consumer import Consumer
 from mqns.network.protocol.link_layer import LinkLayer
 from mqns.network.reactive import ReactiveForwarder, ReactiveRoutingController
 from mqns.network.route import DijkstraRouteAlgorithm, RouteAlgorithm, YenRouteAlgorithm
 from mqns.network.topology import ClassicTopology, Topology
 from mqns.network.topology.customtopo import CustomTopology, Topo, TopoController, TopoQChannel, TopoQNode
-
-type NodePair = str | tuple[str, str]
-"""
-Two node names on a channel or routing path.
-This could be either a tuple of two node names, or a string delimited by hyphen (``-``).
-"""
 
 type EprTypeLiteral = Literal["W", "M"]
 """
@@ -214,6 +209,10 @@ class AppsCommonArgs(TypedDict, total=False):
     Network timing mode, defaults to ASYNC.
     If specified as three floats, construct ``TimingModeSync`` with these durations.
     """
+    has_consumer: bool
+    """
+    Whether to include ``Consumer`` application, defaults to true.
+    """
 
 
 class AppsForwarderArgs(AppsCommonArgs, ForwarderInitKwargs):
@@ -223,15 +222,6 @@ class AppsForwarderArgs(AppsCommonArgs, ForwarderInitKwargs):
     Args:
         p_swap: Probability of successful entanglement swapping in forwarder, defaults to ``0.5``.
     """
-
-
-def _split_node_pair(np: NodePair) -> tuple[str, str]:
-    if isinstance(np, str):
-        tokens = np.split("-")
-        if len(tokens) != 2:
-            raise ValueError(f"expect two node names in '{np}'")
-        return cast(tuple[str, str], tuple(tokens))
-    return np
 
 
 class NetworkBuilder:
@@ -380,7 +370,7 @@ class NetworkBuilder:
                 if opt_capacity:
                     (capacity,) = opt_capacity
                 d = None
-            self._add_qchannel(*_split_node_pair(np), d, length, capacity)
+            self._add_qchannel(*split_node_pair(np), d, length, capacity)
 
         return self
 
@@ -462,6 +452,8 @@ class NetworkBuilder:
                 timing = (t_cohere / 2 - 2 * CTRL_DELAY, 4 * CTRL_DELAY, t_cohere / 2 - 2 * CTRL_DELAY)
             self.timing = TimingModeSync(durations=timing)
 
+        self.has_consumer = d.pop("has_consumer", True)
+
     def _add_link_layer(self):
         self.qnode_apps.append(
             LinkLayer(
@@ -472,6 +464,10 @@ class NetworkBuilder:
                 tau_0=self.d.get("tau_0", 0.0),
             )
         )
+
+    def _add_consumer(self):
+        if self.has_consumer:
+            self.qnode_apps.append(Consumer())
 
     def proactive_centralized(
         self,
@@ -497,6 +493,7 @@ class NetworkBuilder:
         self.qnode_apps.append(
             ProactiveForwarder(**kwargs),
         )
+        self._add_consumer()
         self.controller_apps.append(
             ProactiveRoutingController(),
         )
@@ -529,6 +526,7 @@ class NetworkBuilder:
         self.qnode_apps.append(
             ReactiveForwarder(**kwargs),
         )
+        self._add_consumer()
         self.controller_apps.append(
             ReactiveRoutingController(swap=swap),
         )
@@ -564,8 +562,8 @@ class NetworkBuilder:
         if isinstance(arg1, RoutingPath):
             return arg1
         if isinstance(self.route, YenRouteAlgorithm):
-            return RoutingPathMulti(*_split_node_pair(arg1), **d)
-        return RoutingPathSingle(*_split_node_pair(arg1), **d, qubit_allocation=self.qubit_allocation)
+            return RoutingPathMulti(*split_node_pair(arg1), **d)
+        return RoutingPathSingle(*split_node_pair(arg1), **d, qubit_allocation=self.qubit_allocation)
 
     @functools.singledispatchmethod
     def _add_request(self, ctrl: Application, arg1: RoutingPath | NodePair, d: RoutingPathInitArgs) -> None:
@@ -581,7 +579,7 @@ class NetworkBuilder:
         _ = d
         if isinstance(arg1, RoutingPath):
             raise TypeError(f"{type(ctrl)} does not support .request(RoutingPath)")
-        self.requests.append(_split_node_pair(arg1))
+        self.requests.append(split_node_pair(arg1))
 
     @overload
     def request(self, src_dst: NodePair, /, **kwargs: Unpack[RoutingPathInitArgs]) -> Self:

--- a/mqns/network/builder.py
+++ b/mqns/network/builder.py
@@ -209,10 +209,6 @@ class AppsCommonArgs(TypedDict, total=False):
     Network timing mode, defaults to ASYNC.
     If specified as three floats, construct ``TimingModeSync`` with these durations.
     """
-    has_consumer: bool
-    """
-    Whether to include ``Consumer`` application, defaults to true.
-    """
 
 
 class AppsForwarderArgs(AppsCommonArgs, ForwarderInitKwargs):
@@ -261,7 +257,7 @@ class NetworkBuilder:
         self.controller_apps: list[Application] = []
 
         self.qubit_allocation = QubitAllocationType.DISABLED
-        self.requests: list[tuple[str, str]] = []
+        self.requests: list[tuple[str, str, int]] = []
 
     def _save_topo_args(self, d: TopoCommonArgs) -> None:
         self.d = d
@@ -452,8 +448,6 @@ class NetworkBuilder:
                 timing = (t_cohere / 2 - 2 * CTRL_DELAY, 4 * CTRL_DELAY, t_cohere / 2 - 2 * CTRL_DELAY)
             self.timing = TimingModeSync(durations=timing)
 
-        self.has_consumer = d.pop("has_consumer", True)
-
     def _add_link_layer(self):
         self.qnode_apps.append(
             LinkLayer(
@@ -466,8 +460,7 @@ class NetworkBuilder:
         )
 
     def _add_consumer(self):
-        if self.has_consumer:
-            self.qnode_apps.append(Consumer())
+        self.qnode_apps.append(Consumer())
 
     def proactive_centralized(
         self,
@@ -579,7 +572,7 @@ class NetworkBuilder:
         _ = d
         if isinstance(arg1, RoutingPath):
             raise TypeError(f"{type(ctrl)} does not support .request(RoutingPath)")
-        self.requests.append(split_node_pair(arg1))
+        self.requests.append((*split_node_pair(arg1), d.get("req_id", -1)))
 
     @overload
     def request(self, src_dst: NodePair, /, **kwargs: Unpack[RoutingPathInitArgs]) -> Self:
@@ -642,8 +635,8 @@ class NetworkBuilder:
             timing=self.timing,
             epr_type=self.epr_type,
         )
-        for src, dst in self.requests:
-            net.add_request(net.get_node(src), net.get_node(dst))
+        for src, dst, req_id in self.requests:
+            net.add_request(net.get_node(src), net.get_node(dst), req_id=req_id)
 
         if connect_controller and topo.controller:
             topo.connect_controller(net.nodes, delay=CTRL_DELAY)

--- a/mqns/network/fw/__init__.py
+++ b/mqns/network/fw/__init__.py
@@ -1,7 +1,7 @@
 from mqns.network.fw.controller import RoutingController
 from mqns.network.fw.cutoff import CutoffScheme, CutoffSchemeWaitTime, CutoffSchemeWaitTimeCounters
 from mqns.network.fw.fib import Fib, FibEntry
-from mqns.network.fw.forwarder import Forwarder, ForwarderConsumeCounters, ForwarderCounters, ForwarderInitKwargs
+from mqns.network.fw.forwarder import Forwarder, ForwarderCounters, ForwarderInitKwargs
 from mqns.network.fw.fw_classic import fw_control_cmd_handler, fw_signaling_cmd_handler
 from mqns.network.fw.message import MultiplexingVector, SwapSequence
 from mqns.network.fw.mux import MuxScheme
@@ -31,7 +31,6 @@ __all__ = [
     "Fib",
     "FibEntry",
     "Forwarder",
-    "ForwarderConsumeCounters",
     "ForwarderCounters",
     "ForwarderInitKwargs",
     "fw_control_cmd_handler",

--- a/mqns/network/fw/forwarder.py
+++ b/mqns/network/fw/forwarder.py
@@ -19,8 +19,6 @@ import copy
 from abc import abstractmethod
 from typing import Literal, TypedDict, Unpack, override
 
-import numpy as np
-
 from mqns.entity.memory import MemoryDecohereEvent, MemoryQubit, PathDirection, QubitState
 from mqns.entity.node import Application, QNode
 from mqns.entity.qchannel import QuantumChannel
@@ -44,8 +42,7 @@ from mqns.network.fw.message import (
 from mqns.network.fw.mux import MuxScheme
 from mqns.network.fw.mux_buffer_space import MuxSchemeBufferSpace
 from mqns.network.fw.select import SelectPurifQubit, call_select_purif_qubit
-from mqns.network.network import QuantumNetwork, TimingPhase, TimingPhaseEvent
-from mqns.network.protocol.consumer import Consumer
+from mqns.network.network import TimingPhase, TimingPhaseEvent
 from mqns.network.protocol.event import EntanglementReadyEvent, QubitEntangledEvent, QubitReleasedEvent
 from mqns.simulator import Time, event_handler
 from mqns.utils import json_encodable, log
@@ -69,99 +66,7 @@ class ForwarderInitKwargs(TypedDict, total=False):
 
 
 @json_encodable
-class ForwarderConsumeCounters:
-    """
-    Consumption counters of ``Forwarder``.
-
-    Each entangled pair is delivered and consumed by two forwarders, possibly at different times due to
-    heralding timing. However, only the forwarder that measures the second qubit logs the consumption,
-    because the final end-to-end fidelity can only be calculate when memory error models on both sides are applied.
-    """
-
-    n_consumed = 0
-    """How many entanglements were consumed (either end-to-end or in swap-disabled mode)."""
-    consumed_sum_fidelity = 0.0
-    """
-    Sum of fidelity of consumed entanglements.
-    """
-    consumed_fidelity_values: list[float] | None = None
-    """
-    Fidelity values of consumed entanglements, None disables collection.
-    """
-
-    @staticmethod
-    def of_path(net: QuantumNetwork, src: str, dst: str) -> "ForwarderConsumeCounters":
-        """
-        Obtain consumption counters of a path.
-
-        Args:
-            net: Quantum network.
-            src: Left end node, which must belong to exactly one path.
-            dst: Right end node, which must belong to exactly one path.
-        """
-        a = net.get_node(src).get_app(Forwarder).cnt
-        b = net.get_node(dst).get_app(Forwarder).cnt
-
-        g = ForwarderConsumeCounters()
-        g.n_consumed = a.n_consumed + b.n_consumed
-        g.consumed_sum_fidelity = a.consumed_sum_fidelity + b.consumed_sum_fidelity
-        if a.consumed_fidelity_values is b.consumed_fidelity_values:
-            g.consumed_fidelity_values = a.consumed_fidelity_values
-        return g
-
-    @staticmethod
-    def enable_collect_all_on_path(net: QuantumNetwork, src: str, dst: str) -> None:
-        """
-        Enable collecting all values for histogram generation.
-
-        Args:
-            net: Quantum network.
-            src: Left end node, which must belong to exactly one path.
-            dst: Right end node, which must belong to exactly one path.
-        """
-        a = net.get_node(src).get_app(Forwarder).cnt
-        b = net.get_node(dst).get_app(Forwarder).cnt
-
-        assert a.consumed_fidelity_values is None
-        assert b.consumed_fidelity_values is None
-        a.consumed_fidelity_values = b.consumed_fidelity_values = []
-
-    def increment_n_consumed(self, fidelity: float) -> None:
-        self.n_consumed += 1
-        self.consumed_sum_fidelity += fidelity
-        if self.consumed_fidelity_values is not None:
-            self.consumed_fidelity_values.append(fidelity)
-
-    @property
-    def consumed_avg_fidelity(self) -> float:
-        """Average fidelity of consumed entanglements."""
-        if self.consumed_fidelity_values is not None and len(self.consumed_fidelity_values) == self.n_consumed > 0:
-            return np.mean(self.consumed_fidelity_values).item()
-        return self.get_per_consumed(self.consumed_sum_fidelity)
-
-    def get_rate(self, duration: float) -> float:
-        """
-        Calculate entanglement rate.
-
-        Args:
-            duration: How many seconds did the path remain active.
-
-        Returns: Entanglement rate in entanglements per second.
-        """
-        return self.n_consumed / duration
-
-    def get_per_consumed(self, x: float) -> float:
-        """
-        Divide a value by ``n_consumed``, but return zero if ``n_consumed`` is zero.
-        """
-        return x / self.n_consumed if self.n_consumed > 0 else 0.0
-
-    def __repr__(self) -> str:
-        return f"consumed={self.n_consumed} (F={self.consumed_avg_fidelity})"
-
-
-@json_encodable
-class ForwarderCounters(ForwarderConsumeCounters):
+class ForwarderCounters:
     """Counters of ``Forwarder``."""
 
     def __init__(self):
@@ -215,15 +120,12 @@ class ForwarderCounters(ForwarderConsumeCounters):
             self.n_cutoff += [0] * (minlen - len(self.n_cutoff))
         self.n_cutoff[2 * round + (0 if local else 1)] += 1
 
-    def repr_without_consume(self) -> str:
+    def __repr__(self) -> str:
         return (
             f"entg={self.n_entg} purif={self.n_purif} eligible={self.n_eligible} "
             f"swapped={self.n_swapped} swap-fail={self.n_swap_fail} "
             f"su-lower={self.n_su_lower} su-same={self.n_su_same} cutoff-discard={self.n_cutoff}"
         )
-
-    def __repr__(self) -> str:
-        return f"{self.repr_without_consume()} {ForwarderConsumeCounters.__repr__(self)}"
 
 
 class Forwarder(ForwarderClassicMixin, Application[QNode]):
@@ -563,12 +465,7 @@ class Forwarder(ForwarderClassicMixin, Application[QNode]):
             return
 
         _, epr = self.memory.read(qubit.addr, has=self.epr_type)
-        if (req_id := self.can_consume(fib_entry, epr)) >= 0:
-            if self.node.get_apps(Consumer):
-                self.simulator.add_event(EntanglementReadyEvent(self.node, qubit, epr, t=self.simulator.tc, req_id=req_id))
-            else:
-                # legacy code path until all examples and tests have Consumer app
-                self.consume_and_release(qubit)
+        if self._try_consume(qubit, epr, fib_entry):
             return
 
         swap_candidates = self.memory.find(
@@ -585,29 +482,26 @@ class Forwarder(ForwarderClassicMixin, Application[QNode]):
         else:
             self.cutoff.before_store_eligible(qubit, PathDirection.L if epr.src is self.node else PathDirection.R, fib_entry)
 
-    def can_consume(self, fib_entry: FibEntry | None, epr: Entanglement) -> int:
+    def _try_consume(self, qubit: MemoryQubit, epr: Entanglement, fib_entry: FibEntry | None) -> bool:
+        """
+        If the EPR matches an end-to-end request, inform ``Consumer`` to consume the EPR.
+        """
         if fib_entry is None:
             assert epr.src is not None
             assert epr.dst is not None
             src, dst = epr.src.name, epr.dst.name
             for req in self.fib.find_request(lambda g: g.src == src and g.dst == dst):
-                return req.req_id
-            return -1
+                req_id = req.req_id
+                break
+            return False
 
         if fib_entry.is_swap_disabled or fib_entry.own_idx in (0, len(fib_entry.route) - 1):
-            return fib_entry.req_id
-        return -1
+            req_id = fib_entry.req_id
+        else:
+            return False
 
-    def consume_and_release(self, qubit: MemoryQubit):
-        """
-        Consume an entangled qubit.
-        """
-        _, epr = self.memory.read(qubit.addr, has=self.epr_type, remove=True)
-        log.debug(f"{self}: consume EPR: {epr}")
-        if epr.consume_with_store_decay_side(self.simulator.tc, side=0 if epr.src is self.node else 1):
-            self.cnt.increment_n_consumed(epr.fidelity)
-
-        self.release_qubit(qubit)
+        self.simulator.add_event(EntanglementReadyEvent(self.node, qubit, epr, t=self.simulator.tc, req_id=req_id))
+        return True
 
     @event_handler
     def qubit_is_decohered(self, event: MemoryDecohereEvent):

--- a/mqns/network/fw/forwarder.py
+++ b/mqns/network/fw/forwarder.py
@@ -43,7 +43,7 @@ from mqns.network.fw.mux import MuxScheme
 from mqns.network.fw.mux_buffer_space import MuxSchemeBufferSpace
 from mqns.network.fw.select import SelectPurifQubit, call_select_purif_qubit
 from mqns.network.network import TimingPhase, TimingPhaseEvent
-from mqns.network.protocol.event import EntanglementReadyEvent, QubitEntangledEvent, QubitReleasedEvent
+from mqns.network.protocol.event import QubitConsumeEvent, QubitEntangledEvent, QubitReleasedEvent
 from mqns.simulator import Time, event_handler
 from mqns.utils import json_encodable, log
 
@@ -500,7 +500,8 @@ class Forwarder(ForwarderClassicMixin, Application[QNode]):
         else:
             return False
 
-        self.simulator.add_event(EntanglementReadyEvent(self.node, qubit, epr, t=self.simulator.tc, req_id=req_id))
+        qubit.state = QubitState.CONSUME
+        self.simulator.add_event(QubitConsumeEvent(self.node, qubit, epr, t=self.simulator.tc, req_id=req_id))
         return True
 
     @event_handler

--- a/mqns/network/fw/forwarder.py
+++ b/mqns/network/fw/forwarder.py
@@ -45,7 +45,8 @@ from mqns.network.fw.mux import MuxScheme
 from mqns.network.fw.mux_buffer_space import MuxSchemeBufferSpace
 from mqns.network.fw.select import SelectPurifQubit, call_select_purif_qubit
 from mqns.network.network import QuantumNetwork, TimingPhase, TimingPhaseEvent
-from mqns.network.protocol.event import QubitEntangledEvent, QubitReleasedEvent
+from mqns.network.protocol.consumer import Consumer
+from mqns.network.protocol.event import EntanglementReadyEvent, QubitEntangledEvent, QubitReleasedEvent
 from mqns.simulator import Time, event_handler
 from mqns.utils import json_encodable, log
 
@@ -214,13 +215,15 @@ class ForwarderCounters(ForwarderConsumeCounters):
             self.n_cutoff += [0] * (minlen - len(self.n_cutoff))
         self.n_cutoff[2 * round + (0 if local else 1)] += 1
 
-    def __repr__(self) -> str:
+    def repr_without_consume(self) -> str:
         return (
             f"entg={self.n_entg} purif={self.n_purif} eligible={self.n_eligible} "
             f"swapped={self.n_swapped} swap-fail={self.n_swap_fail} "
-            f"su-lower={self.n_su_lower} su-same={self.n_su_same} cutoff-discard={self.n_cutoff} "
-            f"{ForwarderConsumeCounters.__repr__(self)}"
+            f"su-lower={self.n_su_lower} su-same={self.n_su_same} cutoff-discard={self.n_cutoff}"
         )
+
+    def __repr__(self) -> str:
+        return f"{self.repr_without_consume()} {ForwarderConsumeCounters.__repr__(self)}"
 
 
 class Forwarder(ForwarderClassicMixin, Application[QNode]):
@@ -560,8 +563,12 @@ class Forwarder(ForwarderClassicMixin, Application[QNode]):
             return
 
         _, epr = self.memory.read(qubit.addr, has=self.epr_type)
-        if self.can_consume(fib_entry, epr):
-            self.consume_and_release(qubit)
+        if (req_id := self.can_consume(fib_entry, epr)) >= 0:
+            if self.node.get_apps(Consumer):
+                self.simulator.add_event(EntanglementReadyEvent(self.node, qubit, epr, t=self.simulator.tc, req_id=req_id))
+            else:
+                # legacy code path until all examples and tests have Consumer app
+                self.consume_and_release(qubit)
             return
 
         swap_candidates = self.memory.find(
@@ -578,14 +585,18 @@ class Forwarder(ForwarderClassicMixin, Application[QNode]):
         else:
             self.cutoff.before_store_eligible(qubit, PathDirection.L if epr.src is self.node else PathDirection.R, fib_entry)
 
-    def can_consume(self, fib_entry: FibEntry | None, epr: Entanglement) -> bool:
+    def can_consume(self, fib_entry: FibEntry | None, epr: Entanglement) -> int:
         if fib_entry is None:
             assert epr.src is not None
             assert epr.dst is not None
             src, dst = epr.src.name, epr.dst.name
-            return next(self.fib.find_request(lambda g: g.src == src and g.dst == dst), None) is not None
+            for req in self.fib.find_request(lambda g: g.src == src and g.dst == dst):
+                return req.req_id
+            return -1
 
-        return fib_entry.is_swap_disabled or fib_entry.own_idx in (0, len(fib_entry.route) - 1)
+        if fib_entry.is_swap_disabled or fib_entry.own_idx in (0, len(fib_entry.route) - 1):
+            return fib_entry.req_id
+        return -1
 
     def consume_and_release(self, qubit: MemoryQubit):
         """

--- a/mqns/network/fw/routing.py
+++ b/mqns/network/fw/routing.py
@@ -71,13 +71,13 @@ class RoutingPath(ABC):
         """
         Request identifier.
 
-        If unspecified, the controller will assign the next unused value before calling ``compute_paths``.
+        If negative, the controller will assign the next unused value before calling ``compute_paths``.
         """
         self.path_id = kwargs.get("path_id", -1)
         """
         Path identifier for the first path.
 
-        If unspecified, the controller will assign the next unused value before calling ``compute_paths``.
+        If negative, the controller will assign the next unused value before calling ``compute_paths``.
 
         When ``compute_paths`` yields multiple paths, this is the path_id on the first path,
         while subsequent paths are given consecutive path_ids.

--- a/mqns/network/network/network.py
+++ b/mqns/network/network/network.py
@@ -288,7 +288,7 @@ class QuantumNetwork:
         allow_overlay=False,
         min_hops=1,
         max_hops=10,
-        attr: RequestAttr = {},
+        attr: RequestAttr = RequestAttr(),
         forbid_endpoint_internal=True,  # reject endpoint-vs-internal conflicts
     ):
         """
@@ -301,6 +301,7 @@ class QuantumNetwork:
             min_hops: Minimum number of hops (inclusive).
             max_hops: Maximum number of hops (inclusive).
             attr: Request attributes.
+                ``req_id`` is overwritten as 0-based index.
             forbid_endpoint_internal: If True, eliminate requests that
                 would fail the rank-based endpoint-vs-internal check in SWAP-ASAP.
         """
@@ -338,7 +339,7 @@ class QuantumNetwork:
                         return True
             return False
 
-        for _ in range(n):
+        for i in range(n):
             while True:
                 src_idx = rng.integers(0, nnodes, dtype=int)
                 dst_idx = rng.integers(0, nnodes, dtype=int)
@@ -367,5 +368,6 @@ class QuantumNetwork:
                 if not allow_overlay:
                     used_nodes.extend([src_idx, dst_idx])
 
+                attr["req_id"] = i
                 self.add_request(src, dst, **attr)
                 break

--- a/mqns/network/network/network.py
+++ b/mqns/network/network/network.py
@@ -25,7 +25,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from typing import cast, overload
+from typing import Unpack, cast, overload
 
 from mqns.entity.base_channel import BaseChannel
 from mqns.entity.cchannel import ClassicChannel
@@ -268,16 +268,16 @@ class QuantumNetwork:
         """
         return self.route.query(src, dest)
 
-    def add_request(self, src: QNode, dst: QNode, attr: RequestAttr | None = None):
+    def add_request(self, src: QNode, dst: QNode, **kwargs: Unpack[RequestAttr]):
         """
         Add a request (src, dst) pair to the network, placed in ``self.requests`` list.
 
         Args:
             src: Source node.
             dst: Destination node.
-            attr: Other attributes.
+            kwargs: Other attributes.
         """
-        req = Request(src, dst, **(attr or {}))
+        req = Request(src, dst, **kwargs)
         self.requests.append(req)
 
     def random_requests(
@@ -288,7 +288,7 @@ class QuantumNetwork:
         allow_overlay=False,
         min_hops=1,
         max_hops=10,
-        attr: RequestAttr | None = None,
+        attr: RequestAttr = {},
         forbid_endpoint_internal=True,  # reject endpoint-vs-internal conflicts
     ):
         """
@@ -367,5 +367,5 @@ class QuantumNetwork:
                 if not allow_overlay:
                     used_nodes.extend([src_idx, dst_idx])
 
-                self.add_request(src, dst, attr)
+                self.add_request(src, dst, **attr)
                 break

--- a/mqns/network/network/request.py
+++ b/mqns/network/network/request.py
@@ -6,9 +6,13 @@ from mqns.entity.node import QNode
 class RequestAttr(TypedDict, total=False):
     """
     Request attributes.
+    """
 
-    This is currently empty.
-    In the future, it may contain properties such as minimum fidelity and desired throughput.
+    req_id: int
+    """
+    Request identifier, identifies source-destination pair.
+    Default is auto-generated.
+    Specifying this value allows retrieving consumer counters.
     """
 
 
@@ -20,10 +24,16 @@ class Request:
         Args:
             src: Left node to receive one of the entangled qubits.
             dst: Right node to receive one of the entangled qubits.
+            attr: Request attributes.
         """
         self.src = src
         self.dst = dst
-        _ = attr
+        self.attr = attr
+
+    @property
+    def req_id(self) -> int:
+        """Return ``req_id`` attribute, defaults to ``-1``."""
+        return self.attr.get("req_id", -1)
 
     def __repr__(self) -> str:
         return f"<Request {self.src}-{self.dst}>"

--- a/mqns/network/protocol/consumer.py
+++ b/mqns/network/protocol/consumer.py
@@ -6,7 +6,7 @@ import numpy as np
 from mqns.entity.memory import QubitState
 from mqns.entity.node import Application, NodePair, QNode, split_node_pair
 from mqns.network.network import QuantumNetwork
-from mqns.network.protocol.event import EntanglementReadyEvent, QubitReleasedEvent
+from mqns.network.protocol.event import QubitConsumeEvent, QubitReleasedEvent
 from mqns.simulator import event_handler
 from mqns.utils import json_encodable, log
 
@@ -169,7 +169,7 @@ class Consumer(Application[QNode]):
         """Quantum memory of the node."""
 
     @event_handler
-    def handle_ready(self, event: EntanglementReadyEvent) -> None:
+    def handle_ready(self, event: QubitConsumeEvent) -> None:
         qubit = event.qubit
         epr = event.epr
         req_id = event.req_id

--- a/mqns/network/protocol/consumer.py
+++ b/mqns/network/protocol/consumer.py
@@ -1,0 +1,143 @@
+from collections import defaultdict
+from typing import Protocol, override
+
+import numpy as np
+
+from mqns.entity.memory import QubitState
+from mqns.entity.node import Application, QNode
+from mqns.network.network import QuantumNetwork
+from mqns.network.protocol.event import EntanglementReadyEvent, QubitReleasedEvent
+from mqns.simulator import event_handler
+from mqns.utils import json_encodable, log
+
+
+class RequestLike(Protocol):
+    req_id: int
+    src: str
+    dst: str
+
+
+@json_encodable
+class RequestCounters:
+    """
+    Consumption counters for an end-to-end request.
+
+    Each entangled pair is delivered to two consumers, possibly at different times due to heralding timing.
+    However, only the consumer that measures the second qubit logs the consumption,
+    because the final end-to-end fidelity can only be calculated after applying memory error models on both sides.
+    """
+
+    n_consumed = 0
+    """How many entanglements were consumed (either end-to-end or in swap-disabled mode)."""
+    consumed_sum_fidelity = 0.0
+    """
+    Sum of fidelity of consumed entanglements.
+    """
+    consumed_fidelity_values: list[float] | None = None
+    """
+    Fidelity values of consumed entanglements, None disables collection.
+    """
+
+    @staticmethod
+    def of(net: QuantumNetwork, req: RequestLike) -> "RequestCounters":
+        """
+        Obtain consumption counters of a request.
+
+        Args:
+            net: Quantum network.
+            req: ``RoutingPath`` instance.
+
+        Returns: ConsumerPathCounters for the request, aggregated from src and dst nodes.
+        """
+        a = net.get_node(req.src).get_app(Consumer).cnt.get(req.req_id, RequestCounters())
+        b = net.get_node(req.dst).get_app(Consumer).cnt.get(req.req_id, RequestCounters())
+
+        g = RequestCounters()
+        g.n_consumed = a.n_consumed + b.n_consumed
+        g.consumed_sum_fidelity = a.consumed_sum_fidelity + b.consumed_sum_fidelity
+        if a.consumed_fidelity_values is b.consumed_fidelity_values:
+            g.consumed_fidelity_values = a.consumed_fidelity_values
+        return g
+
+    @staticmethod
+    def enable_collect_all(net: QuantumNetwork, req: RequestLike) -> None:
+        """
+        Enable collecting all values for histogram generation.
+
+        Args:
+            net: Quantum network.
+            req: ``RoutingPath`` instance.
+        """
+        a = net.get_node(req.src).get_app(Consumer).cnt[req.req_id]
+        b = net.get_node(req.dst).get_app(Consumer).cnt[req.req_id]
+
+        assert a.consumed_fidelity_values is None
+        assert b.consumed_fidelity_values is None
+        a.consumed_fidelity_values = b.consumed_fidelity_values = []
+
+    def increment_n_consumed(self, fidelity: float) -> None:
+        self.n_consumed += 1
+        self.consumed_sum_fidelity += fidelity
+        if self.consumed_fidelity_values is not None:
+            self.consumed_fidelity_values.append(fidelity)
+
+    @property
+    def consumed_avg_fidelity(self) -> float:
+        """Average fidelity of consumed entanglements."""
+        if self.consumed_fidelity_values is not None and len(self.consumed_fidelity_values) == self.n_consumed > 0:
+            return np.mean(self.consumed_fidelity_values).item()
+        return self.get_per_consumed(self.consumed_sum_fidelity)
+
+    def get_rate(self, duration: float) -> float:
+        """
+        Calculate entanglement rate.
+
+        Args:
+            duration: How many seconds did the path remain active.
+
+        Returns: Entanglement rate in entanglements per second.
+        """
+        return self.n_consumed / duration
+
+    def get_per_consumed(self, x: float) -> float:
+        """
+        Divide a value by ``n_consumed``, but return zero if ``n_consumed`` is zero.
+        """
+        return x / self.n_consumed if self.n_consumed > 0 else 0.0
+
+    def __repr__(self) -> str:
+        return f"consumed={self.n_consumed} (F={self.consumed_avg_fidelity})"
+
+
+class Consumer(Application[QNode]):
+    """
+    T-class application that consumes entanglements.
+    """
+
+    def __init__(self):
+        self.cnt = defaultdict[int, RequestCounters](RequestCounters)
+        """
+        Path counters keyed by req_id.
+        """
+
+    @override
+    def install(self, node):
+        self._application_install(node, QNode)
+        self.memory = self.node.memory
+        """Quantum memory of the node."""
+
+    @event_handler
+    def handle_ready(self, event: EntanglementReadyEvent) -> None:
+        qubit = event.qubit
+        epr = event.epr
+        req_id = event.req_id
+
+        role_str = "first"
+        if epr.consume_with_store_decay_side(self.simulator.tc, side=0 if epr.src is self.node else 1):
+            role_str = "second"
+            self.cnt[req_id].increment_n_consumed(epr.fidelity)
+        log.debug(f"{self}: consume EPR {role_str} for request {req_id}: {epr}")
+
+        self.memory.read(qubit.addr, remove=True)
+        qubit.state = QubitState.RELEASE
+        self.simulator.add_event(QubitReleasedEvent(self.node, qubit, t=self.simulator.tc))

--- a/mqns/network/protocol/consumer.py
+++ b/mqns/network/protocol/consumer.py
@@ -1,10 +1,10 @@
 from collections import defaultdict
-from typing import Protocol, override
+from typing import Protocol, overload, override
 
 import numpy as np
 
 from mqns.entity.memory import QubitState
-from mqns.entity.node import Application, QNode
+from mqns.entity.node import Application, NodePair, QNode, split_node_pair
 from mqns.network.network import QuantumNetwork
 from mqns.network.protocol.event import EntanglementReadyEvent, QubitReleasedEvent
 from mqns.simulator import event_handler
@@ -39,7 +39,14 @@ class RequestCounters:
     """
 
     @staticmethod
-    def of(net: QuantumNetwork, req: RequestLike) -> "RequestCounters":
+    def _parse_req(arg1: RequestLike | int, np: NodePair) -> tuple[int, str, str]:
+        if isinstance(arg1, int):
+            return arg1, *split_node_pair(np)
+        return arg1.req_id, arg1.src, arg1.dst
+
+    @staticmethod
+    @overload
+    def of(net: QuantumNetwork, req: RequestLike, /) -> "RequestCounters":
         """
         Obtain consumption counters of a request.
 
@@ -49,8 +56,26 @@ class RequestCounters:
 
         Returns: ConsumerPathCounters for the request, aggregated from src and dst nodes.
         """
-        a = net.get_node(req.src).get_app(Consumer).cnt.get(req.req_id, RequestCounters())
-        b = net.get_node(req.dst).get_app(Consumer).cnt.get(req.req_id, RequestCounters())
+
+    @staticmethod
+    @overload
+    def of(net: QuantumNetwork, req_id: int, np: NodePair, /) -> "RequestCounters":
+        """
+        Obtain consumption counters of a request.
+
+        Args:
+            net: Quantum network.
+            req_id: Request ID.
+            np: Two node names.
+
+        Returns: ConsumerPathCounters for the request, aggregated from src and dst nodes.
+        """
+
+    @staticmethod
+    def of(net: QuantumNetwork, arg1: RequestLike | int, np: NodePair = "") -> "RequestCounters":
+        req_id, src, dst = RequestCounters._parse_req(arg1, np)
+        a = net.get_node(src).get_app(Consumer).cnt.get(req_id, RequestCounters())
+        b = net.get_node(dst).get_app(Consumer).cnt.get(req_id, RequestCounters())
 
         g = RequestCounters()
         g.n_consumed = a.n_consumed + b.n_consumed
@@ -60,16 +85,33 @@ class RequestCounters:
         return g
 
     @staticmethod
-    def enable_collect_all(net: QuantumNetwork, req: RequestLike) -> None:
+    @overload
+    def enable_collect_all(net: QuantumNetwork, req: RequestLike, /) -> None:
         """
-        Enable collecting all values for histogram generation.
+        Enable collection of all fidelity values.
 
         Args:
             net: Quantum network.
             req: ``RoutingPath`` instance.
         """
-        a = net.get_node(req.src).get_app(Consumer).cnt[req.req_id]
-        b = net.get_node(req.dst).get_app(Consumer).cnt[req.req_id]
+
+    @staticmethod
+    @overload
+    def enable_collect_all(net: QuantumNetwork, req_id: int, np: NodePair, /) -> None:
+        """
+        Enable collection of all fidelity values.
+
+        Args:
+            net: Quantum network.
+            req_id: Request ID.
+            np: Two node names.
+        """
+
+    @staticmethod
+    def enable_collect_all(net: QuantumNetwork, arg1: RequestLike | int, np: NodePair = "") -> None:
+        req_id, src, dst = RequestCounters._parse_req(arg1, np)
+        a = net.get_node(src).get_app(Consumer).cnt[req_id]
+        b = net.get_node(dst).get_app(Consumer).cnt[req_id]
 
         assert a.consumed_fidelity_values is None
         assert b.consumed_fidelity_values is None

--- a/mqns/network/protocol/event.py
+++ b/mqns/network/protocol/event.py
@@ -108,6 +108,34 @@ class QubitEntangledEvent(Event):
 
 
 @final
+class EntanglementReadyEvent(Event):
+    """
+    Event sent by Forwarder to notify Consumer about end-to-end entanglement.
+    """
+
+    def __init__(
+        self,
+        node: QNode,
+        qubit: MemoryQubit,
+        epr: Entanglement,
+        *,
+        t: Time,
+        req_id: int,
+    ):
+        super().__init__(t, f"EntanglementReadyEvent({qubit.addr}, {epr.name})")
+        self.node = node
+        self.qubit = qubit
+        self.epr = epr
+        self.req_id = req_id
+        assert qubit.state is QubitState.ELIGIBLE, f"unexpected state {qubit.state}"
+
+    @override
+    def invoke(self) -> None:
+        assert self.qubit.state is QubitState.ELIGIBLE, f"unexpected state {self.qubit.state}"
+        self.node.handle(self)
+
+
+@final
 class QubitReleasedEvent(Event):
     """
     Event sent by Forwarder to inform LinkLayer about a released (no longer needed) qubit.

--- a/mqns/network/protocol/event.py
+++ b/mqns/network/protocol/event.py
@@ -108,7 +108,7 @@ class QubitEntangledEvent(Event):
 
 
 @final
-class EntanglementReadyEvent(Event):
+class QubitConsumeEvent(Event):
     """
     Event sent by Forwarder to notify Consumer about end-to-end entanglement.
     """
@@ -127,18 +127,18 @@ class EntanglementReadyEvent(Event):
         self.qubit = qubit
         self.epr = epr
         self.req_id = req_id
-        assert qubit.state is QubitState.ELIGIBLE, f"unexpected state {qubit.state}"
+        assert qubit.state is QubitState.CONSUME, f"unexpected state {qubit.state}"
 
     @override
     def invoke(self) -> None:
-        assert self.qubit.state is QubitState.ELIGIBLE, f"unexpected state {self.qubit.state}"
+        assert self.qubit.state is QubitState.CONSUME, f"unexpected state {self.qubit.state}"
         self.node.handle(self)
 
 
 @final
 class QubitReleasedEvent(Event):
     """
-    Event sent by Forwarder to inform LinkLayer about a released (no longer needed) qubit.
+    Event sent by Forwarder/Consumer to inform LinkLayer about a released (no longer needed) qubit.
     """
 
     def __init__(

--- a/mqns/network/reactive/controller.py
+++ b/mqns/network/reactive/controller.py
@@ -137,7 +137,7 @@ class ReactiveRoutingController(ClassicCommandDispatcherMixin, RoutingController
             if (qubits := self._try_consume(route)) is None:
                 continue
 
-            self.install_path(RoutingPathStatic(route, m_v=qubits, swap=self.swap))
+            self.install_path(RoutingPathStatic(route, req_id=req.req_id, m_v=qubits, swap=self.swap))
             return True
 
         return False

--- a/tests/fw/fw_common.py
+++ b/tests/fw/fw_common.py
@@ -88,7 +88,6 @@ class BuildNetworkArgs(TypedDict, total=False):
     end_time: float  # simulation end time, defaults to 10.0 seconds
     timing: TimingMode  # network timing mode, defaults to ASYNC
     epr_type: type[Entanglement]  # entanglement type, defaults to werner state
-    has_consumer: bool  # whether to include Consumer application, defaults to True
     has_link_layer: bool  # whether to include full LinkLayer application, defaults to False
 
 
@@ -107,8 +106,7 @@ def _make_topo_args(d: BuildNetworkArgs, *, memory_capacity_factor: int) -> Topo
         case "R":
             nodes_apps.append(ReactiveForwarder(**fw_args))
 
-    if d.get("has_consumer", True):
-        nodes_apps.append(Consumer())
+    nodes_apps.append(Consumer())
 
     qchannel_capacity = d.get("qchannel_capacity", 1)
     return TopologyInitKwargs(

--- a/tests/fw/fw_common.py
+++ b/tests/fw/fw_common.py
@@ -16,6 +16,7 @@ from mqns.network.fw import Forwarder, ForwarderConsumeCounters, ForwarderInitKw
 from mqns.network.fw.fw_swap import ForwarderSwapProc
 from mqns.network.network import QuantumNetwork, TimingMode, TimingModeAsync, TimingPhase, TimingPhaseEvent
 from mqns.network.proactive import ProactiveForwarder, ProactiveRoutingController
+from mqns.network.protocol.consumer import Consumer
 from mqns.network.protocol.event import QubitEntangledEvent, QubitReleasedEvent
 from mqns.network.protocol.link_layer import LinkLayer
 from mqns.network.reactive import ReactiveForwarder, ReactiveRoutingController
@@ -87,12 +88,11 @@ class BuildNetworkArgs(TypedDict, total=False):
     end_time: float  # simulation end time, defaults to 10.0 seconds
     timing: TimingMode  # network timing mode, defaults to ASYNC
     epr_type: type[Entanglement]  # entanglement type, defaults to werner state
+    has_consumer: bool  # whether to include Consumer application, defaults to True
     has_link_layer: bool  # whether to include full LinkLayer application, defaults to False
 
 
 def _make_topo_args(d: BuildNetworkArgs, *, memory_capacity_factor: int) -> TopologyInitKwargs:
-    qchannel_capacity = d.get("qchannel_capacity", 1)
-
     nodes_apps: list[Application[QNode]] = []
     if d.get("has_link_layer", False):
         nodes_apps.append(LinkLayer())
@@ -107,6 +107,10 @@ def _make_topo_args(d: BuildNetworkArgs, *, memory_capacity_factor: int) -> Topo
         case "R":
             nodes_apps.append(ReactiveForwarder(**fw_args))
 
+    if d.get("has_consumer", True):
+        nodes_apps.append(Consumer())
+
+    qchannel_capacity = d.get("qchannel_capacity", 1)
     return TopologyInitKwargs(
         nodes_naming="A",
         nodes_apps=nodes_apps,
@@ -246,6 +250,15 @@ def collect_cpacket_counts(monkeypatch: pytest.MonkeyPatch, *, inc_controller=Fa
     return d
 
 
+def print_node_counters(net: QuantumNetwork):
+    for node in net.nodes:
+        fw = node.get_app(Forwarder)
+        cons = node.get_app(Consumer)
+        print(f"{node.name} {fw.cnt.repr_without_consume()}")
+        for req_id, pcnt in cons.cnt.items():
+            print(f"    #{req_id}: {pcnt}")
+
+
 def print_fw_counters(net: QuantumNetwork):
     for node in net.nodes:
         fw = node.get_app(Forwarder)
@@ -289,6 +302,7 @@ def install_path(
 
 
 def check_path_counters(net: QuantumNetwork, rp: RoutingPath | None = None, *, n_consumed: int):
+    """Check path consumption counter with ``ForwarderConsumeCounters``."""
     if rp is None:
         cnt = ForwarderConsumeCounters.of_path(net, net.nodes[0].name, net.nodes[-1].name)
     else:

--- a/tests/fw/fw_common.py
+++ b/tests/fw/fw_common.py
@@ -12,7 +12,7 @@ from mqns.entity.memory import QubitState
 from mqns.entity.node import Application, Controller, Node, QNode
 from mqns.entity.qchannel import LinkArchAlways, LinkArchDimBk, QuantumChannelInitKwargs
 from mqns.models.epr import Entanglement, WernerStateEntanglement
-from mqns.network.fw import Forwarder, ForwarderConsumeCounters, ForwarderInitKwargs, RoutingController, RoutingPath
+from mqns.network.fw import Forwarder, ForwarderInitKwargs, RoutingController, RoutingPath
 from mqns.network.fw.fw_swap import ForwarderSwapProc
 from mqns.network.network import QuantumNetwork, TimingMode, TimingModeAsync, TimingPhase, TimingPhaseEvent
 from mqns.network.proactive import ProactiveForwarder, ProactiveRoutingController
@@ -252,15 +252,9 @@ def print_node_counters(net: QuantumNetwork):
     for node in net.nodes:
         fw = node.get_app(Forwarder)
         cons = node.get_app(Consumer)
-        print(f"{node.name} {fw.cnt.repr_without_consume()}")
+        print(f"{node.name} {fw.cnt}")
         for req_id, pcnt in cons.cnt.items():
             print(f"    #{req_id}: {pcnt}")
-
-
-def print_fw_counters(net: QuantumNetwork):
-    for node in net.nodes:
-        fw = node.get_app(Forwarder)
-        print(node.name, fw.cnt)
 
 
 def check_fw_counters(net: QuantumNetwork, **kwargs: Iterable[int | Iterable[int]]) -> None:
@@ -297,15 +291,6 @@ def install_path(
         simulator.add_event(func_to_event(simulator.time(sec=t_uninstall), ctrl.uninstall_path, rp))
 
     return rp
-
-
-def check_path_counters(net: QuantumNetwork, rp: RoutingPath | None = None, *, n_consumed: int):
-    """Check path consumption counter with ``ForwarderConsumeCounters``."""
-    if rp is None:
-        cnt = ForwarderConsumeCounters.of_path(net, net.nodes[0].name, net.nodes[-1].name)
-    else:
-        cnt = ForwarderConsumeCounters.of_path(net, rp.src, rp.dst)
-    assert cnt.n_consumed == n_consumed
 
 
 _provide_entanglements_autoid = AutoIncrementIdentifier("Tpe_")

--- a/tests/fw/test_p_integ.py
+++ b/tests/fw/test_p_integ.py
@@ -8,12 +8,13 @@ import pytest
 
 from mqns.entity.timer import Timer
 from mqns.models.epr import Entanglement, MixedStateEntanglement, WernerStateEntanglement
-from mqns.network.fw import ForwarderConsumeCounters, RoutingPathSingle, RoutingPathStatic, SwapSequenceInput
+from mqns.network.fw import RoutingPathSingle, RoutingPathStatic, SwapSequenceInput
 from mqns.network.network import TimingModeAsync, TimingModeSync
 from mqns.network.proactive import ProactiveForwarder
+from mqns.network.protocol.consumer import RequestCounters
 from mqns.network.protocol.link_layer import LinkLayer
 
-from .fw_common import build_linear_network, build_rect_network, install_path, print_fw_counters
+from .fw_common import build_linear_network, build_rect_network, install_path, print_node_counters
 
 
 @pytest.mark.parametrize(
@@ -34,17 +35,16 @@ def test_4_swap(epr_type: type[Entanglement], timing_mode: str, swap: SwapSequen
     )
     _, fwB, fwC, _ = (node.get_app(ProactiveForwarder) for node in net.nodes)
 
-    install_path(net, RoutingPathSingle("A", "D", swap=swap))
+    rp = install_path(net, RoutingPathSingle("A", "D", swap=swap))
     simulator.run()
-    print_fw_counters(net)
+    print_node_counters(net)
 
     # The main purpose of integrated test is to verify that the forwarder can return released qubits back to LinkLayer
     # for re-generating elementary entanglements.
     # Hence, these numeric bounds are much smaller than usual values, but must be greater than the memory capacity.
     assert fwB.cnt.n_swapped >= 16
     assert fwC.cnt.n_swapped >= 16
-    consume_cnt = ForwarderConsumeCounters.of_path(net, "A", "D")
-    assert consume_cnt.n_consumed >= 16
+    assert RequestCounters.of(net, rp).n_consumed >= 16
 
 
 def test_rect_uninstall_path():
@@ -59,7 +59,7 @@ def test_rect_uninstall_path():
     counters: list[tuple[int, int, int, int, int]] = []
 
     def save_counters():
-        print_fw_counters(net)
+        print_node_counters(net)
         counters.append(
             (
                 fwB.cnt.n_swapped,

--- a/tests/fw/test_p_purif.py
+++ b/tests/fw/test_p_purif.py
@@ -6,14 +6,14 @@ import pytest
 
 from mqns.network.fw import RoutingPathSingle
 from mqns.network.proactive import ProactiveForwarder
+from mqns.network.protocol.consumer import RequestCounters
 from mqns.utils import rng
 
 from .fw_common import (
     build_linear_network,
     check_fw_counters,
-    check_path_counters,
     install_path,
-    print_fw_counters,
+    print_node_counters,
     provide_entanglements,
 )
 
@@ -57,11 +57,11 @@ def test_link_rounds(monkeypatch: pytest.MonkeyPatch, n_rounds: int, purif_succe
     fwA = net.get_node("A").get_app(ProactiveForwarder)
     fwB = net.get_node("B").get_app(ProactiveForwarder)
 
-    install_path(net, RoutingPathSingle("A", "B", swap=[0, 0], purif={"A-B": n_rounds}))
+    rp = install_path(net, RoutingPathSingle("A", "B", swap=[0, 0], purif={"A-B": n_rounds}))
     provide_entanglements(*((1.001 + i / 1000, fwA, fwB) for i in range(n_etg)))
     force_purify_outcome(monkeypatch, *(True if i > 0 else False for i in purif_success))
     simulator.run()
-    print_fw_counters(net)
+    print_node_counters(net)
 
     assert fwA.cnt.n_purif == n_purif == fwB.cnt.n_purif
     n_eligible = 0 if len(n_purif) < n_rounds else n_purif[-1]
@@ -70,7 +70,7 @@ def test_link_rounds(monkeypatch: pytest.MonkeyPatch, n_rounds: int, purif_succe
         n_entg=(n_etg, n_etg),
         n_eligible=(n_eligible, n_eligible),
     )
-    check_path_counters(net, n_consumed=n_eligible)
+    assert RequestCounters.of(net, rp).n_consumed == n_eligible
 
 
 def test_4_l2r(monkeypatch: pytest.MonkeyPatch):
@@ -78,7 +78,7 @@ def test_4_l2r(monkeypatch: pytest.MonkeyPatch):
     net, simulator = build_linear_network(4, qchannel_capacity=8, fw={"p_swap": 1.0})
     fwA, fwB, fwC, fwD = (node.get_app(ProactiveForwarder) for node in net.nodes)
 
-    install_path(
+    rp = install_path(
         net,
         RoutingPathSingle("A", "D", swap=[2, 0, 1, 2], purif={"A-B": 1, "B-C": 1, "C-D": 1, "A-C": 1, "A-D": 1}),
     )
@@ -106,7 +106,7 @@ def test_4_l2r(monkeypatch: pytest.MonkeyPatch):
     )
     force_purify_outcome(monkeypatch, *[True] * 19)
     simulator.run()
-    print_fw_counters(net)
+    print_node_counters(net)
 
     assert fwA.cnt.n_purif == [4 + 2 + 1]  # 4 with fwB, 2 with fwC, 1 with fwD
     assert fwB.cnt.n_purif == [4 + 4]  # 4 with fwA, 4 with fwC
@@ -123,4 +123,4 @@ def test_4_l2r(monkeypatch: pytest.MonkeyPatch):
         # fwD: 1 with fwA
         n_eligible=(1, 4 + 4, 2 + 2, 1),
     )
-    check_path_counters(net, n_consumed=1)
+    assert RequestCounters.of(net, rp).n_consumed == 1

--- a/tests/fw/test_p_swap.py
+++ b/tests/fw/test_p_swap.py
@@ -16,7 +16,6 @@ from mqns.models.error import PerfectErrorModel
 from mqns.network.fw import (
     Fib,
     Forwarder,
-    ForwarderConsumeCounters,
     MemoryEprTuple,
     MuxSchemeDynamicEpr,
     MuxSchemeStatistical,
@@ -26,6 +25,7 @@ from mqns.network.fw import (
 )
 from mqns.network.network import TimingModeSync
 from mqns.network.proactive import ProactiveForwarder
+from mqns.network.protocol.consumer import Consumer, RequestCounters
 from mqns.simulator import func_to_event
 
 from .fw_common import (
@@ -35,10 +35,9 @@ from .fw_common import (
     build_tree_network,
     check_fw_counters,
     check_memory_released,
-    check_path_counters,
     collect_cpacket_counts,
     install_path,
-    print_fw_counters,
+    print_node_counters,
     provide_entanglements,
 )
 
@@ -61,12 +60,14 @@ def test_3_disabled():
         (1.002, fwB, fwC),
     )
     simulator.run()
-    print_fw_counters(net)
+    print_node_counters(net)
     check_fw_counters(
         net,
         n_swapped=(0, 0, 0),
     )
-    assert fwA.cnt.n_consumed + fwB.cnt.n_consumed + fwC.cnt.n_consumed == 2
+
+    n_consumed = sum(node.get_app(Consumer).cnt[rp.req_id].n_consumed for node in net.nodes)
+    assert n_consumed == 2
 
 
 @pytest.mark.parametrize(
@@ -94,18 +95,18 @@ def test_3_decohere(swap_delay: float, n_consumed: int):
     net, simulator = build_linear_network(3, t_cohere=0.002, fw={"p_swap": 1.0, "swap_delay": swap_delay}, end_time=2)
     fwA, fwB, fwC = (node.get_app(ProactiveForwarder) for node in net.nodes)
 
-    install_path(net, RoutingPathStatic("ABC"))
+    rp = install_path(net, RoutingPathStatic("ABC"))
     provide_entanglements(
         (1, fwA, fwB),
         (1, fwB, fwC),
     )
     simulator.run()
-    print_fw_counters(net)
+    print_node_counters(net)
     check_fw_counters(
         net,
         n_su_lower=(1, 0, 1),
     )
-    check_path_counters(net, n_consumed=n_consumed)
+    assert RequestCounters.of(net, rp).n_consumed == n_consumed
 
 
 @pytest.mark.parametrize(
@@ -142,13 +143,13 @@ def test_3_waittime(etg_sec: tuple[float, float], swap_delay: float, n_consumed:
     net, simulator = build_linear_network(3, t_cohere=0.004, fw={"p_swap": 1.0, "swap_delay": swap_delay}, end_time=1.010)
     fwA, fwB, fwC = (node.get_app(ProactiveForwarder) for node in net.nodes)
 
-    install_path(net, RoutingPathStatic("ABC", swap_cutoff=[0.002, 0.002]))
+    rp = install_path(net, RoutingPathStatic("ABC", swap_cutoff=[0.002, 0.002]))
     provide_entanglements(
         (etg_sec[0], fwA, fwB),
         (etg_sec[1], fwB, fwC),
     )
     simulator.run()
-    print_fw_counters(net)
+    print_node_counters(net)
 
     check_fw_counters(
         net,
@@ -157,7 +158,7 @@ def test_3_waittime(etg_sec: tuple[float, float], swap_delay: float, n_consumed:
     assert fwA.cnt.n_cutoff == [0, n_cutoff[0]]
     assert fwB.cnt.n_cutoff == [sum(n_cutoff), 0]
     assert fwC.cnt.n_cutoff == [0, n_cutoff[1]]
-    check_path_counters(net, n_consumed=n_consumed)
+    assert RequestCounters.of(net, rp).n_consumed == n_consumed
 
 
 @pytest.mark.parametrize(
@@ -196,17 +197,17 @@ def test_4_sync(t_ext: float, expected: tuple[int, int, int, int]):
     net, simulator = build_linear_network(4, t_cohere=0.015000, fw={"p_swap": 1.0}, timing=timing, end_time=0.029999)
     fwA, fwB, fwC, fwD = (node.get_app(ProactiveForwarder) for node in net.nodes)
 
-    install_path(net, RoutingPathStatic("ABCD", swap=[2, 0, 1, 2]))
+    rp = install_path(net, RoutingPathStatic("ABCD", swap=[2, 0, 1, 2]))
     provide_entanglements(
         ([0.001000] * 3, (fwA, fwB, fwC, fwD)),
     )
     simulator.run()
-    print_fw_counters(net)
+    print_node_counters(net)
     check_fw_counters(
         net,
         n_swapped=(0, expected[1], expected[2], 0),
     )
-    check_path_counters(net, n_consumed=min(expected[0], expected[3]))
+    assert RequestCounters.of(net, rp).n_consumed == min(expected[0], expected[3])
 
 
 @pytest.mark.parametrize(
@@ -229,13 +230,13 @@ def test_4_asap(etg_ms: tuple[int, int, int], ps3: int):
     fwA, fwB, fwC, fwD = (node.get_app(ProactiveForwarder) for node in net.nodes)
     fwC.swap.ps = ps3
 
-    install_path(net, RoutingPathStatic("ABCD"))
+    rp = install_path(net, RoutingPathStatic("ABCD"))
     provide_entanglements(
         (etg_ms, (fwA, fwB, fwC, fwD)),
         transform_t=lambda ms: 1 + ms / 1000,
     )
     simulator.run()
-    print_fw_counters(net)
+    print_node_counters(net)
     if ps3 == 1:
         check_fw_counters(
             net,
@@ -244,7 +245,7 @@ def test_4_asap(etg_ms: tuple[int, int, int], ps3: int):
             n_su_same=(0, 1, 1, 0),
             n_su_lower=(1, 0, 0, 1),
         )
-        check_path_counters(net, n_consumed=1)
+        assert RequestCounters.of(net, rp).n_consumed == 1
     else:
         check_fw_counters(
             net,
@@ -253,7 +254,7 @@ def test_4_asap(etg_ms: tuple[int, int, int], ps3: int):
             n_su_same=(0, 1, (0, 1), 0),  # if B hears C's failure before its own swap, it does not herald C
             n_su_lower=(1, 0, 0, 1),
         )
-        check_path_counters(net, n_consumed=0)
+        assert RequestCounters.of(net, rp).n_consumed == 0
     check_memory_released(net)
 
 
@@ -342,7 +343,7 @@ def test_4_delayed(
     timer = Timer("save_counters", start_time=1.018, end_time=1.088, step_time=0.010, trigger_func=save_counter)
     timer.install(simulator)
 
-    install_path(net, RoutingPathStatic("ABCD"))
+    rp = install_path(net, RoutingPathStatic("ABCD"))
     provide_entanglements(
         (1.000, fwA, fwB),
         (1.000, fwC, fwD),
@@ -351,15 +352,15 @@ def test_4_delayed(
     )
     cpacket_cnt = collect_cpacket_counts(monkeypatch)
     simulator.run()
-    print_fw_counters(net)
+    print_node_counters(net)
     check_memory_released(net)
     print("cpacket_cnt", cpacket_cnt)
 
     assert fwB_n_swapped_values == [0, 0, 0, 0, 0, n_swap2, n_swap2, n_swap2]
-    consume_cnt = ForwarderConsumeCounters.of_path(net, "A", "D")
-    assert consume_cnt.n_consumed == n_consumed
+    req_cnt = RequestCounters.of(net, rp)
+    assert req_cnt.n_consumed == n_consumed
     if n_consumed > 0:
-        assert 0.5 < consume_cnt.consumed_avg_fidelity <= 0.75
+        assert 0.5 < req_cnt.consumed_avg_fidelity <= 0.75
 
     assert list(fw.node.get_app(QubitReleaseReset).last_t for fw in (fwA, fwB, fwC, fwD)) == [
         simulator.time(sec=t) for t in t_release
@@ -401,17 +402,17 @@ def test_4_decohere(swap_delay: float, n_consumed: int):
     net, simulator = build_linear_network(4, t_cohere=0.003, fw={"p_swap": 1.0, "swap_delay": swap_delay}, end_time=2)
     fwA, fwB, fwC, fwD = (node.get_app(ProactiveForwarder) for node in net.nodes)
 
-    install_path(net, RoutingPathStatic("ABCD"))
+    rp = install_path(net, RoutingPathStatic("ABCD"))
     provide_entanglements(
         ([1.000] * 3, (fwA, fwB, fwC, fwD)),
     )
     simulator.run()
-    print_fw_counters(net)
+    print_node_counters(net)
     check_fw_counters(
         net,
         n_su_lower=(1, 0, 0, 1),
     )
-    check_path_counters(net, n_consumed=n_consumed)
+    assert RequestCounters.of(net, rp).n_consumed == n_consumed
     check_memory_released(net)
 
 
@@ -427,13 +428,13 @@ def test_5_asap(
     fwA, fwB, fwC, fwD, fwE = (node.get_app(ProactiveForwarder) for node in net.nodes)
     fwC.swap.ps = ps3
 
-    install_path(net, RoutingPathStatic("ABCDE"))
+    rp = install_path(net, RoutingPathStatic("ABCDE"))
     provide_entanglements(
         (etg_ms, (fwA, fwB, fwC, fwD, fwE)),
         transform_t=lambda ms: 1 + ms / 1000,
     )
     simulator.run()
-    print_fw_counters(net)
+    print_node_counters(net)
     check_fw_counters(
         net,
         n_swapped=(0, 1, n_consumed, 1, 0),
@@ -441,7 +442,7 @@ def test_5_asap(
         n_su_same=(0, 1, (0, 1, 2), 1, 0),
         n_su_lower=(1, 0, 0, 0, 1),
     )
-    check_path_counters(net, n_consumed=n_consumed)
+    assert RequestCounters.of(net, rp).n_consumed == n_consumed
     check_memory_released(net)
 
 
@@ -465,13 +466,13 @@ def test_5_sequential(swap_sulower: tuple[Sequence[int], Sequence[int]], etg_ms:
     net, simulator = build_linear_network(5, fw={"p_swap": 1.0})
     fwA, fwB, fwC, fwD, fwE = (node.get_app(ProactiveForwarder) for node in net.nodes)
 
-    install_path(net, RoutingPathStatic("ABCDE", swap=swap))
+    rp = install_path(net, RoutingPathStatic("ABCDE", swap=swap))
     provide_entanglements(
         (etg_ms, (fwA, fwB, fwC, fwD, fwE)),
         transform_t=lambda ms: 1 + ms / 1000,
     )
     simulator.run()
-    print_fw_counters(net)
+    print_node_counters(net)
     check_fw_counters(
         net,
         n_swapped=(0, 1, 1, 1, 0),
@@ -479,7 +480,7 @@ def test_5_sequential(swap_sulower: tuple[Sequence[int], Sequence[int]], etg_ms:
         n_su_same=(0, 0, 0, 0, 0),
         n_su_lower=su_lower,
     )
-    check_path_counters(net, n_consumed=1)
+    assert RequestCounters.of(net, rp).n_consumed == 1
 
 
 @pytest.mark.parametrize(
@@ -529,18 +530,18 @@ def test_5_decohere(
     fwA, fwB, fwC, fwD, fwE = (node.get_app(ProactiveForwarder) for node in net.nodes)
 
     swap_cutoff = None if cutoff4 is None else [-1, -1, -1, -1, cutoff4, cutoff4]
-    install_path(net, RoutingPathStatic("ABCDE", swap_cutoff=swap_cutoff))
+    rp = install_path(net, RoutingPathStatic("ABCDE", swap_cutoff=swap_cutoff))
     provide_entanglements(
         (etg_ms, (fwA, fwB, fwC, fwD, fwE)),
         transform_t=lambda ms: 1 + ms / 1000,
     )
     simulator.run()
-    print_fw_counters(net)
+    print_node_counters(net)
     # check_fw_counters(
     #     net,
     #     n_su_lower=(1, 0, 0, 0, 1),
     # )
-    check_path_counters(net, n_consumed=n_consumed)
+    assert RequestCounters.of(net, rp).n_consumed == n_consumed
     check_memory_released(net)
     assert list(node.get_app(QubitReleaseReset).last_t for node in net.nodes[: len(t_release)]) == [
         simulator.time(sec=t) for t in t_release
@@ -576,8 +577,8 @@ def test_rect_multipath(has_etg: tuple[int, int, int, int], n_swapped: tuple[int
         (1.002 if has_etg[3] else -1, fwC, fwD),
     )
     simulator.run()
-    print_fw_counters(net)
-    check_path_counters(net, n_consumed=n_consumed)
+    print_node_counters(net)
+    assert RequestCounters.of(net, rp).n_consumed == n_consumed
     assert (fwB.cnt.n_swapped, fwC.cnt.n_swapped) == n_swapped
 
 
@@ -633,10 +634,9 @@ def test_tree2_dynepr(t_edge_etg: float, selected_path: tuple[int, int], n_consu
         (1.005, fwA, fwC),
     )
     simulator.run()
-    print_fw_counters(net)
-
-    check_path_counters(net, rp0, n_consumed=n_consumed[0])
-    check_path_counters(net, rp1, n_consumed=n_consumed[1])
+    print_node_counters(net)
+    assert RequestCounters.of(net, rp0).n_consumed == n_consumed[0]
+    assert RequestCounters.of(net, rp1).n_consumed == n_consumed[1]
 
 
 @pytest.mark.parametrize(
@@ -713,13 +713,13 @@ def test_tree2_statistical(
         transform_t=lambda ms: 1 + ms / 1000,
     )
     simulator.run()
-    print_fw_counters(net)
+    print_node_counters(net)
     if -1 in etg_ms:
         # For test cases without unused EPRs, swap conflict should release memory quickly.
         check_memory_released(net)
 
-    check_path_counters(net, rp0, n_consumed=n_consumed[0])
-    check_path_counters(net, rp1, n_consumed=n_consumed[1])
+    assert RequestCounters.of(net, rp0).n_consumed == n_consumed[0]
+    assert RequestCounters.of(net, rp1).n_consumed == n_consumed[1]
     assert sum(fw.cnt.n_su_lower[4] for fw in (fwD, fwE, fwF, fwG)) == (2 if sum(n_consumed) == 0 else 0)
 
 
@@ -801,7 +801,6 @@ def test_tree3_statistical(
 
     provide_entanglements(*expand_etgs(), transform_t=lambda ms: 1 + ms / 1000)
     simulator.run()
-    print_fw_counters(net)
-
-    check_path_counters(net, rp0, n_consumed=n_consumed[0])
-    check_path_counters(net, rp1, n_consumed=n_consumed[1])
+    print_node_counters(net)
+    assert RequestCounters.of(net, rp0).n_consumed == n_consumed[0]
+    assert RequestCounters.of(net, rp1).n_consumed == n_consumed[1]

--- a/tests/fw/test_r_swap.py
+++ b/tests/fw/test_r_swap.py
@@ -44,10 +44,11 @@ def test_tree2_one():
     net, simulator = build_tree_network(
         2,
         mode="R",
+        ctrl=ctrl,
         fw={"p_swap": 1.0},
         end_time=0.010,
         timing=TimingModeSync(t_ext=0.006, t_rtg=0.001, t_int=0.003),
-        ctrl=ctrl,
+        has_consumer=False,
     )
     fwA, fwB, fwC, fwD, _, fwF, _ = (node.get_app(ReactiveForwarder) for node in net.nodes)
 
@@ -78,10 +79,11 @@ def test_tree2_two():
         2,
         mode="R",
         qchannel_capacity=2,
+        ctrl=ctrl,
         fw={"p_swap": 1.0},
         end_time=0.010,
         timing=TimingModeSync(t_ext=0.006, t_rtg=0.001, t_int=0.003),
-        ctrl=ctrl,
+        has_consumer=False,
     )
     fwA, fwB, fwC, fwD, fwE, fwF, fwG = (node.get_app(ReactiveForwarder) for node in net.nodes)
 
@@ -122,7 +124,7 @@ def test_tree2_two():
 
 
 @pytest.mark.parametrize(
-    ("req_active", "etg12", "etg23", "cnt"),
+    ("req_active", "etgAB", "etgBC", "cnt"),
     [
         # Request is active in both slots, EPRs arrive in first slot, request satisfied.
         ((0, 0.020), [0.001], [0.002], (3, 1)),
@@ -138,7 +140,7 @@ def test_tree2_two():
         ((0, 0.010), [0.001, 0.003], [0.002, 0.004], (3, 2)),
     ],
 )
-def test_3_minimal(req_active: tuple[float, float], etg12: list[float], etg23: list[float], cnt: tuple[int, int]):
+def test_3_minimal(req_active: tuple[float, float], etgAB: list[float], etgBC: list[float], cnt: tuple[int, int]):
     """Test 3-node minimal swap, two time slots."""
     net, simulator = build_linear_network(
         3,
@@ -147,6 +149,7 @@ def test_3_minimal(req_active: tuple[float, float], etg12: list[float], etg23: l
         fw={"p_swap": 1.0},
         end_time=0.020,
         timing=TimingModeSync(t_ext=0.006, t_rtg=0.001, t_int=0.003),
+        has_consumer=False,
     )
     ctrl = net.get_controller().get_app(ReactiveRoutingController)
     fwA, fwB, fwC = (node.get_app(ReactiveForwarder) for node in net.nodes)
@@ -154,8 +157,8 @@ def test_3_minimal(req_active: tuple[float, float], etg12: list[float], etg23: l
     simulator.add_event(func_to_event(simulator.time(sec=req_active[0]), lambda: net.add_request(fwA.node, fwC.node)))
     simulator.add_event(func_to_event(simulator.time(sec=req_active[1]), net.requests.clear))
     provide_entanglements(
-        *((t, fwA, fwB) for t in etg12),
-        *((t, fwB, fwC) for t in etg23),
+        *((t, fwA, fwB) for t in etgAB),
+        *((t, fwB, fwC) for t in etgBC),
     )
     simulator.run()
     print(ctrl.cnt)

--- a/tests/fw/test_r_swap.py
+++ b/tests/fw/test_r_swap.py
@@ -8,18 +8,18 @@ from itertools import pairwise
 import pytest
 
 from mqns.entity.cchannel import ClassicCommandDispatcherMixin, ClassicPacket, classic_cmd_handler
-from mqns.network.fw import ForwarderConsumeCounters, RoutingController, RoutingPathStatic
-from mqns.network.network import TimingModeSync
+from mqns.network.fw import RoutingController, RoutingPathStatic
+from mqns.network.network import TimingModeSync, TimingPhase, TimingPhaseEvent
+from mqns.network.protocol.consumer import RequestCounters
 from mqns.network.reactive import ReactiveForwarder, ReactiveRoutingController
 from mqns.network.reactive.message import LinkStateEntry, LinkStateMsg
-from mqns.simulator import func_to_event
+from mqns.simulator import event_handler, func_to_event
 
 from .fw_common import (
     build_linear_network,
     build_tree_network,
     check_fw_counters,
-    check_path_counters,
-    print_fw_counters,
+    print_node_counters,
     provide_entanglements,
 )
 
@@ -30,6 +30,13 @@ class ManualController(ClassicCommandDispatcherMixin, RoutingController):
 
         self.ls_pkts: list[tuple[ClassicPacket, LinkStateMsg]] = []
         self.ls_entries: list[LinkStateEntry] = []
+
+    @event_handler
+    def handle_sync_phase(self, event: TimingPhaseEvent):
+        match event.action:
+            case TimingPhase.ROUTING, False:
+                self.ls_pkts.clear()
+                self.ls_entries.clear()
 
     @classic_cmd_handler("LS")
     def handle_ls(self, pkt: ClassicPacket, msg: LinkStateMsg):
@@ -44,32 +51,34 @@ def test_tree2_one():
     net, simulator = build_tree_network(
         2,
         mode="R",
+        qchannel_capacity=2,
         ctrl=ctrl,
         fw={"p_swap": 1.0},
-        end_time=0.010,
+        end_time=0.020,
         timing=TimingModeSync(t_ext=0.006, t_rtg=0.001, t_int=0.003),
-        has_consumer=False,
     )
     fwA, fwB, fwC, fwD, _, fwF, _ = (node.get_app(ReactiveForwarder) for node in net.nodes)
 
     def do_routing():
         assert len(ctrl.ls_pkts) == 5
         assert len(ctrl.ls_entries) == 8
-        ctrl.install_path(RoutingPathStatic(["D", "B", "A", "C", "F"], swap=[2, 0, 1, 0, 2]))
+        ctrl.install_path(RoutingPathStatic("DBACF", req_id=1, swap=[2, 0, 1, 0, 2]))
 
-    simulator.add_event(func_to_event(simulator.time(sec=0.0065), do_routing))
-
-    provide_entanglements(
-        (0.0011, fwD, fwB),
-        (0.0012, fwB, fwA),
-        (0.0013, fwA, fwC),
-        (0.0014, fwC, fwF),
-    )
+    for slot in 0.000, 0.010:
+        t0 = slot
+        simulator.add_event(func_to_event(simulator.time(sec=t0 + 0.0065), do_routing))
+        provide_entanglements(
+            (0.0011, fwD, fwB),
+            (0.0012, fwB, fwA),
+            (0.0013, fwA, fwC),
+            (0.0014, fwC, fwF),
+            transform_t=lambda s: t0 + s,
+        )
     simulator.run()
-    print_fw_counters(net)
+    print_node_counters(net)
 
-    consume_cnt = ForwarderConsumeCounters.of_path(net, "D", "F")
-    assert consume_cnt.n_consumed == 1
+    reqDF = RequestCounters.of(net, 1, "D-F")
+    assert reqDF.n_consumed == 2
 
 
 def test_tree2_two():
@@ -78,12 +87,11 @@ def test_tree2_two():
     net, simulator = build_tree_network(
         2,
         mode="R",
-        qchannel_capacity=2,
+        qchannel_capacity=4,
         ctrl=ctrl,
         fw={"p_swap": 1.0},
-        end_time=0.010,
+        end_time=0.020,
         timing=TimingModeSync(t_ext=0.006, t_rtg=0.001, t_int=0.003),
-        has_consumer=False,
     )
     fwA, fwB, fwC, fwD, fwE, fwF, fwG = (node.get_app(ReactiveForwarder) for node in net.nodes)
 
@@ -95,32 +103,38 @@ def test_tree2_two():
         for entry in ctrl.ls_entries:
             qubits_by_channel[f"{entry['node']}{entry['neighbor']}"].append(entry["qubit"])
 
-        for route in "DBACF", "EBACG":
+        for i, route in enumerate(("DBACF", "EBACG")):
             ctrl.install_path(
                 RoutingPathStatic(
-                    route, swap=[2, 0, 1, 0, 2], m_v=[qubits_by_channel[f"{a}{b}"].pop() for a, b in pairwise(route)]
+                    route,
+                    req_id=1 + i,
+                    swap=[2, 0, 1, 0, 2],
+                    m_v=[qubits_by_channel[f"{a}{b}"].pop() for a, b in pairwise(route)],
                 )
             )
 
-    simulator.add_event(func_to_event(simulator.time(sec=0.0065), do_routing))
+    for slot in 0.000, 0.010:
+        t0 = slot
+        simulator.add_event(func_to_event(simulator.time(sec=t0 + 0.0065), do_routing))
+        provide_entanglements(
+            (0.0011, fwD, fwB),
+            (0.0012, fwB, fwA),
+            (0.0013, fwA, fwC),
+            (0.0014, fwC, fwF),
+            (0.0021, fwE, fwB),
+            (0.0022, fwB, fwA),
+            (0.0023, fwA, fwC),
+            (0.0024, fwC, fwG),
+            transform_t=lambda s: t0 + s,
+        )
 
-    provide_entanglements(
-        (0.0011, fwD, fwB),
-        (0.0012, fwB, fwA),
-        (0.0013, fwA, fwC),
-        (0.0014, fwC, fwF),
-        (0.0021, fwE, fwB),
-        (0.0022, fwB, fwA),
-        (0.0023, fwA, fwC),
-        (0.0024, fwC, fwG),
-    )
     simulator.run()
-    print_fw_counters(net)
+    print_node_counters(net)
 
-    consumeDF = ForwarderConsumeCounters.of_path(net, "D", "F")
-    assert consumeDF.n_consumed == 1
-    consumeEG = ForwarderConsumeCounters.of_path(net, "E", "G")
-    assert consumeEG.n_consumed == 1
+    reqDF = RequestCounters.of(net, 1, "D-F")
+    assert reqDF.n_consumed == 2
+    reqEG = RequestCounters.of(net, 2, "E-G")
+    assert reqEG.n_consumed == 2
 
 
 @pytest.mark.parametrize(
@@ -149,12 +163,11 @@ def test_3_minimal(req_active: tuple[float, float], etgAB: list[float], etgBC: l
         fw={"p_swap": 1.0},
         end_time=0.020,
         timing=TimingModeSync(t_ext=0.006, t_rtg=0.001, t_int=0.003),
-        has_consumer=False,
     )
     ctrl = net.get_controller().get_app(ReactiveRoutingController)
     fwA, fwB, fwC = (node.get_app(ReactiveForwarder) for node in net.nodes)
 
-    simulator.add_event(func_to_event(simulator.time(sec=req_active[0]), lambda: net.add_request(fwA.node, fwC.node)))
+    simulator.add_event(func_to_event(simulator.time(sec=req_active[0]), lambda: net.add_request(fwA.node, fwC.node, req_id=1)))
     simulator.add_event(func_to_event(simulator.time(sec=req_active[1]), net.requests.clear))
     provide_entanglements(
         *((t, fwA, fwB) for t in etgAB),
@@ -162,11 +175,11 @@ def test_3_minimal(req_active: tuple[float, float], etgAB: list[float], etgBC: l
     )
     simulator.run()
     print(ctrl.cnt)
-    print_fw_counters(net)
+    print_node_counters(net)
 
     assert (ctrl.cnt.n_ls, ctrl.cnt.n_satisfy) == cnt
     check_fw_counters(
         net,
         n_swapped=(0, cnt[1], 0),
     )
-    check_path_counters(net, n_consumed=cnt[1])
+    assert RequestCounters.of(net, 1, "A-C").n_consumed == cnt[1]


### PR DESCRIPTION
refs #140

Introduce `Consumer` application that consumes end-to-end entangled pairs and publishes associated counters.
The consumption condition evaluation remains part of `Forwarder`, which hands off the ready-to-consume qubit to `Consumer` via `QubitConsumeEvent`.

Consumption counters, including `n_consumed` and average fidelity, are now per-request rather than per-node.
It is implemented as `RequestCounters` class and has the similar semantics as `ForwarderConsumeCounters`, i.e. only counted on the end node that measures the EPR last.
This enables the same node to serve as the src/dst of multiple requests, without mixing up the statistics.
However, `req_id` parameter is now required for retrieving these counters.

The `req_id` parameter can now be specified in `Request` class and in `NetworkBuilder.request()` method.
The `ReactiveRoutingController` copies `Request.req_id` to each `RoutingPath` derived from the request, so that the consumption is accumulated in the correct counter.

`MemoryQubit.state` has a new value `CONSUME` to indicate that the qubit is under the purview of an application.
A diagram is provided to show the allowed state transitions and the qubit owner when in each state.

Also, `multi_request_single_path.py` topology is fixed to match the topology diagram.
It was changed by mistake in #58.