### PR TITLE
protocol+fw: release memory upon UNINSTALL_PATH

### DIFF
--- a/docs/source/_static/qubit-state.svg
+++ b/docs/source/_static/qubit-state.svg
@@ -10,9 +10,10 @@
       dominant-baseline: middle;
     }
   </style>
-  <g transform="translate(50 50)">
-    <line x1="100" y1="100" marker-end="url(#arrow)" stroke="#111" stroke-width="2"/>
-    <line x2="100" marker-end="url(#arrow)" stroke="#111" stroke-width="2"/>
+  <g transform="translate(50 150)">
+    <line x1="100" marker-end="url(#arrow)" stroke="#111" stroke-width="2"/>
+    <line x2="100" y2="-100" marker-start="url(#arrow)" marker-end="url(#arrow)" stroke="#111" stroke-width="2"/>
+    <line x2="200" y2="-100" marker-start="url(#arrow)" marker-end="url(#arrow)" stroke="#111" stroke-width="2"/>
     <circle r="30" fill="#AAAAAA"/>
     <text font-size="12">RAW</text>
   </g>

--- a/mqns/entity/entity.py
+++ b/mqns/entity/entity.py
@@ -56,13 +56,12 @@ class Entity(ABC):
         """Global simulator instance."""
 
     @abstractmethod
-    def handle(self, event: Event) -> None:
+    def handle(self, event: Event, /) -> bool | None:
         """
-        Process a received event.
+        Process an event.
 
-        Args:
-            event: the event that targets this entity.
+        The return value is ignored.
         """
 
     def __repr__(self) -> str:
-        return f"<entity {self.name}>"
+        return f"{type(self).__name__}({self.name})"

--- a/mqns/entity/memory/memory.py
+++ b/mqns/entity/memory/memory.py
@@ -307,14 +307,16 @@ class QuantumMemory(EventDispatcherMixin, Entity):
         """
         Deallocate one or more qubits from any assigned path.
 
-        This method finds the memory qubit with the given address and clears its
-        path assignment (i.e., resets its ``path_id`` to None). It does not modify the
-        quantum state or remove the qubit from memory.
+        If a qubit is currently occupied, the deallocation takes effect when it next reaches RAW state.
         """
         for addr in addrs:
-            qubit, _ = self._storage[addr]
-            qubit.path_id = None
-            qubit.path_direction = None
+            mq, _ = self._storage[addr]
+            mq.on_raw(QuantumMemory._deallocate_qubit)
+
+    @staticmethod
+    def _deallocate_qubit(mq: MemoryQubit) -> None:
+        mq.path_id = None
+        mq.path_direction = None
 
     @overload
     def read(self, key: int | str, *, remove: bool | QuantumModel = False) -> tuple[MemoryQubit, QuantumModel | None] | None:

--- a/mqns/entity/memory/memory.py
+++ b/mqns/entity/memory/memory.py
@@ -25,11 +25,10 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import functools
 import heapq
 import itertools
-from collections.abc import Callable, Iterable, Iterator
-from typing import Any, Literal, TypedDict, Unpack, overload, override
+from collections.abc import Callable, Container, Iterable, Iterator
+from typing import TYPE_CHECKING, Any, Literal, TypedDict, Unpack, overload, override
 
 from mqns.entity.entity import Entity
 from mqns.entity.memory.event import (
@@ -46,7 +45,10 @@ from mqns.models.core import QuantumModel
 from mqns.models.delay import DelayInput, parse_delay
 from mqns.models.epr import Entanglement
 from mqns.models.error import TimeDecayInput, parse_time_decay
-from mqns.simulator import Event, Simulator
+from mqns.simulator import EventDispatcherMixin, Simulator, event_handler
+
+if TYPE_CHECKING:
+    from mqns.entity.node import QNode
 
 
 class QuantumMemoryInitKwargs(TypedDict, total=False):
@@ -62,7 +64,7 @@ class QuantumMemoryInitKwargs(TypedDict, total=False):
     """Time decay function for loss of quantum information, defaults to dephasing in ``t_cohere``."""
 
 
-class QuantumMemory(Entity):
+class QuantumMemory(EventDispatcherMixin, Entity):
     """
     Quantum memory stores qubits or entangled pairs.
 
@@ -73,29 +75,59 @@ class QuantumMemory(Entity):
     * Asynchronous mode, caller uses events to operate the memory asynchronously.
     """
 
+    node: QNode
+    """
+    QNode that owns this memory.
+
+    This is assigned by ``QNode.memory`` setter.
+    """
+
+    @staticmethod
+    def check_leaks(
+        nodes: Iterable["QNode"],
+        *,
+        states: Container[QubitState] = (QubitState.RAW, QubitState.RELEASE),
+        unassigned=False,
+    ) -> None:
+        """
+        Verify that all MemoryQubits on every node are released.
+
+        Args:
+            nodes: List of quantum nodes, such as ``QuantumNetwork.nodes``.
+            states: Acceptable states.
+            unassigned: If True, qubit must not be assigned to a channel.
+
+        Raises:
+            MemoryError: Some qubits have unacceptable state.
+        """
+        errors: list[str] = []
+        for node in nodes:
+            for mq, data in node.memory.find(lambda *_: True):
+                if mq.state not in states:
+                    errors.append(f"{node.name} {mq} has unexpected state {mq.state} | {data}")
+                if unassigned and mq.qchannel:
+                    errors.append(f"{node.name} {mq} is assigned to {mq.qchannel} | {data}")
+        if len(errors) > 0:
+            raise MemoryError(*errors)
+
     def __init__(self, name: str, **kwargs: Unpack[QuantumMemoryInitKwargs]):
         """
         Constructor.
 
         Args:
-            name: memory name.
+            name: Memory entity name.
         """
         super().__init__(name=name)
-        self.node: QNode
-        """
-        QNode that owns this memory.
 
-        This is assigned by ``QNode.memory`` setter.
-        """
         self.capacity = kwargs.get("capacity", 1)
         """
         Memory capacity, i.e. how many qubits can be stored.
-        Each qubit would have an address in `[0, capacity)`.
+        Each qubit has an address in `[0, capacity)`.
         """
         self.delay = parse_delay(kwargs.get("delay", 0))
-        """Read/write delay, only applicable to async access."""
+        """Async read/write delay."""
 
-        self._t_cohere = kwargs.get("t_cohere", 1.0)
+        self._t_cohere_input = kwargs.get("t_cohere", 1.0)
         self._time_decay_input = kwargs.get("time_decay")
 
         assert self.capacity >= 1
@@ -115,7 +147,7 @@ class QuantumMemory(Entity):
     def install(self, simulator: Simulator) -> None:
         super().install(simulator)
 
-        self.t_decohere = simulator.time(sec=self._t_cohere)
+        self.t_decohere = simulator.time(sec=self._t_cohere_input)
         """
         Memory decoherence time, often known as T2.
 
@@ -125,16 +157,8 @@ class QuantumMemory(Entity):
         self.time_decay = parse_time_decay(self._time_decay_input, self.t_decohere)
         """Time based decay function constructed from store error model."""
 
-    @override
-    def handle(self, event: Event) -> None:
-        self._handle(event)
-
-    @functools.singledispatchmethod
-    def _handle(self, event: Event) -> None:
-        raise RuntimeError(f"unexpected event {event}")
-
-    @_handle.register
-    def _(self, event: MemoryDecohereEvent):
+    @event_handler
+    def handle_decohere(self, event: MemoryDecohereEvent):
         if isinstance(event.qm, Entanglement):
             event.qm.is_decohered = True
 
@@ -146,14 +170,14 @@ class QuantumMemory(Entity):
         event.qubit.state = QubitState.RELEASE
         self.node.handle(event)
 
-    @_handle.register
-    def _(self, event: MemoryReadRequestEvent):
-        result = self.read(event.key)  # will not update fidelity
+    @event_handler
+    def async_read(self, event: MemoryReadRequestEvent):
+        result = self.read(event.key)
         t = self.simulator.tc + self.delay.calculate()
         self.simulator.add_event(MemoryReadResponseEvent(self.node, result, request=event, t=t))
 
-    @_handle.register
-    def _(self, event: MemoryWriteRequestEvent):
+    @event_handler
+    def async_write(self, event: MemoryWriteRequestEvent):
         qubit = next(self.find(lambda _, v: v is None), None)
         assert qubit is not None, "memory is full"
         result = self.write(qubit[0].addr, event.qubit)
@@ -436,6 +460,3 @@ class QuantumMemory(Entity):
             qubit.reset_state(QubitState.RAW)
             self._storage[qubit.addr] = (qubit, None)
         self._usage = 0
-
-    def __repr__(self) -> str:
-        return "<memory " + self.name + ">"

--- a/mqns/entity/memory/memory.py
+++ b/mqns/entity/memory/memory.py
@@ -46,6 +46,7 @@ from mqns.models.delay import DelayInput, parse_delay
 from mqns.models.epr import Entanglement
 from mqns.models.error import TimeDecayInput, parse_time_decay
 from mqns.simulator import EventDispatcherMixin, Simulator, event_handler
+from mqns.utils import log
 
 if TYPE_CHECKING:
     from mqns.entity.node import QNode
@@ -112,7 +113,8 @@ class QuantumMemory(EventDispatcherMixin, Entity):
                     errors.append(f"{node.name} {mq} is allocated to path {mq.path_id}")
                 if unassigned and mq.qchannel:
                     errors.append(f"{node.name} {mq} is assigned to {mq.qchannel}")
-        if len(errors) > 0:
+        if n := len(errors):
+            log.warning(f"QuantumMemory.check_leaks() found {n} errors:\n\t{'\n\t'.join(errors)}")
             raise MemoryError(*errors)
 
     def __init__(self, name: str, **kwargs: Unpack[QuantumMemoryInitKwargs]):

--- a/mqns/entity/memory/memory.py
+++ b/mqns/entity/memory/memory.py
@@ -152,14 +152,14 @@ class QuantumMemory(EventDispatcherMixin, Entity):
     def install(self, simulator: Simulator) -> None:
         super().install(simulator)
 
-        self.t_decohere = simulator.time(sec=self._t_cohere_input)
+        self.t_cohere = simulator.time(sec=self._t_cohere_input)
         """
         Memory decoherence time, often known as T2.
 
         Stored qubits trigger ``MemoryDecohereEvent`` at this timer.
         """
 
-        self.time_decay = parse_time_decay(self._time_decay_input, self.t_decohere)
+        self.time_decay = parse_time_decay(self._time_decay_input, self.t_cohere)
         """Time based decay function constructed from store error model."""
 
     @event_handler

--- a/mqns/entity/memory/memory.py
+++ b/mqns/entity/memory/memory.py
@@ -87,6 +87,7 @@ class QuantumMemory(EventDispatcherMixin, Entity):
         nodes: Iterable["QNode"],
         *,
         states: Container[QubitState] = (QubitState.RAW, QubitState.RELEASE),
+        deallocated=False,
         unassigned=False,
     ) -> None:
         """
@@ -95,18 +96,22 @@ class QuantumMemory(EventDispatcherMixin, Entity):
         Args:
             nodes: List of quantum nodes, such as ``QuantumNetwork.nodes``.
             states: Acceptable states.
+            deallocated: If True, qubit must not be allocated to a path.
             unassigned: If True, qubit must not be assigned to a channel.
 
         Raises:
             MemoryError: Some qubits have unacceptable state.
         """
+        __tracebackhide__ = True
         errors: list[str] = []
         for node in nodes:
             for mq, data in node.memory.find(lambda *_: True):
                 if mq.state not in states:
                     errors.append(f"{node.name} {mq} has unexpected state {mq.state} | {data}")
+                if deallocated and mq.path_id is not None:
+                    errors.append(f"{node.name} {mq} is allocated to path {mq.path_id}")
                 if unassigned and mq.qchannel:
-                    errors.append(f"{node.name} {mq} is assigned to {mq.qchannel} | {data}")
+                    errors.append(f"{node.name} {mq} is assigned to {mq.qchannel}")
         if len(errors) > 0:
             raise MemoryError(*errors)
 

--- a/mqns/entity/memory/memory_qubit.py
+++ b/mqns/entity/memory/memory_qubit.py
@@ -40,7 +40,7 @@ class QubitState(Enum):
     """
     ACTIVE = auto()
     """
-    The link layer has started a reservation on the qubit as the primary node.
+    The link layer has requested a reservation on the qubit as the primary node.
     ``qubit.active`` contains the reservation key.
     """
     RESERVED = auto()
@@ -96,9 +96,9 @@ class QubitState(Enum):
 
 
 ALLOWED_STATE_TRANSITIONS: dict[QubitState, tuple[QubitState, ...]] = {
-    QubitState.RAW: (QubitState.ACTIVE,),
-    QubitState.ACTIVE: (QubitState.RESERVED,),
-    QubitState.RESERVED: (QubitState.ENTANGLED0,),
+    QubitState.RAW: (QubitState.ACTIVE, QubitState.RESERVED),
+    QubitState.ACTIVE: (QubitState.RAW, QubitState.RESERVED),
+    QubitState.RESERVED: (QubitState.RAW, QubitState.ENTANGLED0),
     QubitState.ENTANGLED0: (QubitState.RELEASE, QubitState.ENTANGLED1),
     QubitState.ENTANGLED1: (QubitState.RELEASE, QubitState.PURIF),
     QubitState.PURIF: (QubitState.RELEASE, QubitState.PENDING, QubitState.ELIGIBLE),

--- a/mqns/entity/memory/memory_qubit.py
+++ b/mqns/entity/memory/memory_qubit.py
@@ -16,8 +16,9 @@
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from enum import Enum, auto
+from typing import Any
 
 from mqns.entity.node import QNode
 from mqns.entity.qchannel import QuantumChannel
@@ -172,6 +173,8 @@ class MemoryQubit:
     events: EventHandleSet
     """Events that are canceled upon reaching RELEASE state."""
 
+    _on_raw_callbacks: list[Callable[["MemoryQubit"], Any]] | None = None
+
     def __init__(self, addr: int):
         self.addr = addr
         self.events = EventHandleSet()
@@ -205,12 +208,32 @@ class MemoryQubit:
         """Reset state to RELEASE/RAW and clear associated fields."""
         self._state = state
         self.events.clear()
-        if state is QubitState.RAW:
-            self.key = None
-            self.partner = None
-            self.epr_path_ids = None
-            self.purif_rounds = 0
-            self.eligible_time = Time.SENTINEL
+        if state is not QubitState.RAW:
+            return
+
+        self.key = None
+        self.partner = None
+        self.epr_path_ids = None
+        self.purif_rounds = 0
+        self.eligible_time = Time.SENTINEL
+
+        if not self._on_raw_callbacks:
+            return
+        for fn in self._on_raw_callbacks:
+            fn(self)
+        del self._on_raw_callbacks
+
+    def on_raw(self, fn: Callable[["MemoryQubit"], Any]) -> None:
+        """
+        Schedule a function to be invoked when the qubit reaches RAW state.
+        If the qubit is already in RAW state, the function is called immediately.
+        """
+        if self._state is QubitState.RAW:
+            fn(self)
+        else:
+            if not self._on_raw_callbacks:
+                self._on_raw_callbacks = []
+            self._on_raw_callbacks.append(fn)
 
     def __repr__(self) -> str:
         return ", ".join(_describe(self)) + ")"

--- a/mqns/entity/node/node.py
+++ b/mqns/entity/node/node.py
@@ -45,8 +45,8 @@ class Node(Entity):
     def __init__(self, name: str, *, apps: list[Application] | None = None):
         """
         Args:
-            name: node name.
-            apps: applications on the node.
+            name: Node name.
+            apps: Applications on the node.
         """
         super().__init__(name)
         self.cchannels: list["ClassicChannel"] = []
@@ -58,14 +58,11 @@ class Node(Entity):
 
     @override
     def install(self, simulator: Simulator) -> None:
-        """Called from Network.install()"""
+        """Attach ``Simulator`` to entities within node."""
         super().install(simulator)
-        # initiate sub-entities
-        from mqns.entity.cchannel import ClassicChannel  # noqa: PLC0415
+        self._install_channels(self.cchannels, self._cchannel_by_dst)
+        self._node_install()
 
-        self._install_channels(ClassicChannel, self.cchannels, self._cchannel_by_dst)
-
-        # initiate applications
         apps_by_type = defaultdict[type, list[Application]](lambda: [])
         for app in self.apps:
             apps_by_type[type(app)].append(app)
@@ -75,6 +72,9 @@ class Node(Entity):
         for typ, apps in apps_by_type.items():
             if len(apps) == 1:
                 self._app_by_type[typ] = apps[0]
+
+    def _node_install(self) -> None:
+        pass
 
     @override
     def handle(self, event: Event) -> None:
@@ -146,9 +146,8 @@ class Node(Entity):
         channel.node_list.append(self)
         channels.append(channel)
 
-    def _install_channels[C: "BaseChannel"](self, typ: type[C], channels: list[C], by_neighbor: dict["Node", C]) -> None:
+    def _install_channels[C: "BaseChannel"](self, channels: list[C], by_neighbor: dict["Node", C]) -> None:
         for ch in channels:
-            assert isinstance(ch, typ)
             for dst in ch.node_list:
                 if dst is not self:
                     by_neighbor[dst] = ch

--- a/mqns/entity/node/qnode.py
+++ b/mqns/entity/node/qnode.py
@@ -15,11 +15,10 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 
 from mqns.entity.node.app import Application
 from mqns.entity.node.node import Node
-from mqns.simulator import Simulator
 
 if TYPE_CHECKING:
     from mqns.entity.memory import QuantumMemory
@@ -43,21 +42,14 @@ class QNode(Node):
         self._memory: "QuantumMemory|None" = None
         self.operators: list["QuantumOperator"] = []
 
-    def install(self, simulator: Simulator) -> None:
-        super().install(simulator)
-        # initiate sub-entities
-        from mqns.entity.memory import QuantumMemory  # noqa: PLC0415
-        from mqns.entity.operator import QuantumOperator  # noqa: PLC0415
-        from mqns.entity.qchannel import QuantumChannel  # noqa: PLC0415
+    @override
+    def _node_install(self) -> None:
+        self._install_channels(self.qchannels, self._qchannel_by_dst)
 
-        if self._memory is not None:
-            assert isinstance(self._memory, QuantumMemory)
-            self._memory.install(simulator)
+        if self._memory:
+            self._memory.install(self.simulator)
         for operator in self.operators:
-            assert isinstance(operator, QuantumOperator)
-            operator.install(simulator)
-
-        self._install_channels(QuantumChannel, self.qchannels, self._qchannel_by_dst)
+            operator.install(self.simulator)
 
     @property
     def memory(self) -> "QuantumMemory":

--- a/mqns/entity/qchannel/link_arch.py
+++ b/mqns/entity/qchannel/link_arch.py
@@ -295,7 +295,7 @@ class LinkArchBase(ABC, LinkArch):
         mem_a, mem_b = src.memory, dst.memory
         epr = self._make_epr(
             EntanglementInitKwargs(
-                decohere_time=t_epr_creation + min(mem_a.t_decohere, mem_b.t_decohere),
+                decohere_time=t_epr_creation + min(mem_a.t_cohere, mem_b.t_cohere),
                 fidelity_time=t_epr_creation,
                 src=src,
                 dst=dst,

--- a/mqns/network/fw/fib.py
+++ b/mqns/network/fw/fib.py
@@ -16,22 +16,31 @@
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
-from typing import Final, Literal, final
+from typing import TYPE_CHECKING, Final, Literal, final
 
 from mqns.network.fw.message import SwapSequence
 from mqns.simulator import Time
+
+if TYPE_CHECKING:
+    from mqns.network.fw.forwarder import Forwarder
 
 
 @final
 class FibEntry:
     """FIB entry."""
 
-    __slots__ = ("req_id", "path_id", "route", "own_idx", "swap", "swap_cutoff", "purif", "sg")
+    __slots__ = ("req_id", "path_id", "active_until", "route", "own_idx", "swap", "swap_cutoff", "purif", "sg")
 
     req_id: Final[int]
     """Request identifier, identifies source-destination pair."""
     path_id: Final[int]
     """Path identifier, identifies end-to-end path."""
+
+    active_until: Time
+    """
+    Active period upper bound (exclusive), ``Time.MAX`` means no restriction.
+    This field becomes valid when the request is added to a network and a simulator is installed into the network.
+    """
 
     route: Final[Sequence[str]]
     """List of nodes traversed by the path."""
@@ -59,6 +68,7 @@ class FibEntry:
     ):
         self.req_id = req_id
         self.path_id = path_id
+        self.active_until = Time.MAX
         self.route = route
         self.own_idx = own_idx
         self.swap = swap
@@ -81,6 +91,12 @@ class FibEntry:
         without attempting entanglement swapping.
         """
         return self.swap[0] == 0 == self.swap[-1]
+
+    def is_active(self, t: Time) -> bool:
+        """
+        Determine if the time point ``t`` is within the FIB entry's active period.
+        """
+        return t < self.active_until
 
     def find_index_and_swap_rank(self, node_name: str) -> tuple[int, int]:
         """
@@ -267,6 +283,9 @@ class Fib:
         Value contains aggregated information.
         """
 
+    def install(self, fw: "Forwarder") -> None:
+        self.simulator = fw.simulator
+
     def get(self, path_id: int) -> FibEntry:
         """
         Retrieve an entry by path_id.
@@ -308,10 +327,26 @@ class Fib:
         if rg.remove(entry):
             del self.by_req_id[entry.req_id]
 
-    def find_request(self, predicate: Callable[[FibRequestGroup], bool]) -> Iterator[FibRequestGroup]:
+    def find_request(
+        self,
+        predicate: Callable[[FibRequestGroup], bool],
+        *,
+        has_active=False,
+    ) -> Iterator[FibRequestGroup]:
+        """
+        List ``FibRequestGroup`` satisfying a predicate.
+
+        Args:
+            predicate: Function to determine the condition.
+            has_active: Also require at least one FIB entry to be within the active period.
+        """
         for rg in self.by_req_id.values():
-            if predicate(rg):
+            if predicate(rg) and ((not has_active) or self._request_has_active(rg)):
                 yield rg
+
+    def _request_has_active(self, rg: FibRequestGroup) -> bool:
+        now = self.simulator.tc
+        return any(self.table[path_id].is_active(now) for path_id in rg.path_ids)
 
     def __repr__(self):
         """Return a string representation of the forwarding table."""

--- a/mqns/network/fw/forwarder.py
+++ b/mqns/network/fw/forwarder.py
@@ -241,18 +241,18 @@ class Forwarder(ForwarderClassicMixin, Application[QNode]):
 
         # identify left/right neighbors
         # associate path with qchannel and allocate qubits
-        if l_neighbor := self._find_neighbor(fib_entry, -1):
-            self.mux.install_path_neighbor(instructions, fib_entry, PathDirection.L, *l_neighbor)
-        if r_neighbor := self._find_neighbor(fib_entry, +1):
-            self.mux.install_path_neighbor(instructions, fib_entry, PathDirection.R, *r_neighbor)
+        if ch_l := self._find_adj(fib_entry, -1):
+            self.mux.install_path_adj(instructions, fib_entry, PathDirection.L, ch_l)
+        if ch_r := self._find_adj(fib_entry, +1):
+            self.mux.install_path_adj(instructions, fib_entry, PathDirection.R, ch_r)
 
         # call subclass specialization
         self.handle_path_change(
             path_id=path_id,
             uninstall=False,
             fib_entry=fib_entry,
-            l_neighbor=l_neighbor,
-            r_neighbor=r_neighbor,
+            ch_l=ch_l,
+            ch_r=ch_r,
         )
 
     @fw_control_cmd_handler("UNINSTALL_PATH")
@@ -273,26 +273,26 @@ class Forwarder(ForwarderClassicMixin, Application[QNode]):
 
         # identify left/right neighbors
         # disassociate path with qchannel and deallocate qubits
-        if l_neighbor := self._find_neighbor(fib_entry, -1):
-            self.mux.uninstall_path_neighbor(fib_entry, PathDirection.L, *l_neighbor)
-        if r_neighbor := self._find_neighbor(fib_entry, +1):
-            self.mux.uninstall_path_neighbor(fib_entry, PathDirection.R, *r_neighbor)
+        if ch_l := self._find_adj(fib_entry, -1):
+            self.mux.uninstall_path_adj(fib_entry, PathDirection.L, ch_l)
+        if ch_r := self._find_adj(fib_entry, +1):
+            self.mux.uninstall_path_adj(fib_entry, PathDirection.R, ch_r)
 
         # call subclass specialization
         self.handle_path_change(
             path_id=path_id,
             uninstall=True,
             fib_entry=fib_entry,
-            l_neighbor=l_neighbor,
-            r_neighbor=r_neighbor,
+            ch_l=ch_l,
+            ch_r=ch_r,
         )
 
-    def _find_neighbor(self, fib_entry: FibEntry, route_offset: int) -> tuple[QNode, QuantumChannel] | None:
+    def _find_adj(self, fib_entry: FibEntry, route_offset: int) -> QuantumChannel | None:
         neigh_idx = fib_entry.own_idx + route_offset
         if neigh_idx in (-1, len(fib_entry.route)):  # no left/right neighbor if own node is the left/right end node
             return None
         neigh = self.network.get_node(fib_entry.route[neigh_idx])
-        return neigh, self.node.get_qchannel(neigh)
+        return self.node.get_qchannel(neigh)
 
     @abstractmethod
     def handle_path_change(
@@ -301,8 +301,8 @@ class Forwarder(ForwarderClassicMixin, Application[QNode]):
         path_id: int,
         uninstall: bool,
         fib_entry: FibEntry,
-        l_neighbor: tuple[QNode, QuantumChannel] | None,
-        r_neighbor: tuple[QNode, QuantumChannel] | None,
+        ch_l: QuantumChannel | None,
+        ch_r: QuantumChannel | None,
     ):
         """
         Process LinkLayer changes after a path has been installed or uninstalled.
@@ -311,8 +311,8 @@ class Forwarder(ForwarderClassicMixin, Application[QNode]):
             path_id: Path identifier.
             uninstall: Whether this is an uninstall command.
             fib_entry: FIB entry.
-            l_neighbor: Left neighbor and channel toward it.
-            r_neighbor: Right neighbor and channel toward it.
+            ch_l: Quantum channel toward left, if exists.
+            ch_r: Quantum channel toward right, if exists.
         """
 
     @fw_signaling_cmd_handler("CUTOFF_DISCARD")

--- a/mqns/network/fw/forwarder.py
+++ b/mqns/network/fw/forwarder.py
@@ -44,7 +44,7 @@ from mqns.network.fw.mux_buffer_space import MuxSchemeBufferSpace
 from mqns.network.fw.select import SelectPurifQubit, call_select_purif_qubit
 from mqns.network.network import TimingPhase, TimingPhaseEvent
 from mqns.network.protocol.event import QubitConsumeEvent, QubitEntangledEvent, QubitReleasedEvent
-from mqns.simulator import Time, event_handler
+from mqns.simulator import Time, event_handler, func_to_event
 from mqns.utils import json_encodable, log, unwrap_cast
 
 
@@ -183,8 +183,11 @@ class Forwarder(ForwarderClassicMixin, Application[QNode]):
 
         self.cutoff.install(self)
         self.mux.install(self)
+        self.fib.install(self)
         self.purif.install(self)
         self.swap.install(self)
+
+        self._fib_erase_delay = self.simulator.time(time_slot=4 * self.memory.t_cohere.time_slot)
 
     @event_handler
     def handle_sync_phase(self, event: TimingPhaseEvent):
@@ -211,13 +214,7 @@ class Forwarder(ForwarderClassicMixin, Application[QNode]):
 
     @fw_control_cmd_handler("INSTALL_PATH")
     def handle_install_path(self, msg: InstallPathMsg):
-        """
-        Process an INSTALL_PATH message from the controller.
-
-        1. Insert FIB entry.
-        2. Identify neighbors and qchannels.
-        3. Save the path and neighbors in the multiplexing scheme.
-        """
+        """Process an INSTALL_PATH message from the controller."""
         path_id = msg["path_id"]
         instructions = msg["instructions"]
         self.mux.validate_path_instructions(instructions)
@@ -257,19 +254,13 @@ class Forwarder(ForwarderClassicMixin, Application[QNode]):
 
     @fw_control_cmd_handler("UNINSTALL_PATH")
     def handle_uninstall_path(self, msg: UninstallPathMsg):
-        """
-        Process an UNINSTALL_PATH message from the controller.
-
-        1. Insert FIB entry.
-        2. Identify neighbors and qchannels.
-        3. Save the path and neighbors in the multiplexing scheme.
-        4. Notify LinkLayer to start elementary EPR generation toward the right neighbor.
-        """
+        """Process an UNINSTALL_PATH message from the controller."""
         path_id = msg["path_id"]
 
         # retrieve and erase FIB entry
         fib_entry = self.fib.get(path_id)
-        self.fib.erase(path_id)
+        fib_entry.active_until = self.simulator.tc
+        self.simulator.add_event(func_to_event(fib_entry.active_until + self._fib_erase_delay, self.fib.erase, path_id))
 
         # identify left/right neighbors
         # disassociate path with qchannel and deallocate qubits
@@ -489,7 +480,7 @@ class Forwarder(ForwarderClassicMixin, Application[QNode]):
         """
         if fib_entry is None:
             src, dst = unwrap_cast(epr.src).name, unwrap_cast(epr.dst).name
-            for req in self.fib.find_request(lambda g: g.src == src and g.dst == dst):
+            for req in self.fib.find_request(lambda g: g.src == src and g.dst == dst, has_active=True):
                 req_id = req.req_id
                 break
             return False

--- a/mqns/network/fw/fw_swap.py
+++ b/mqns/network/fw/fw_swap.py
@@ -105,7 +105,7 @@ class SwapTask:
     lb_key = UNKNOWN
     """Qubit reservation key between ``sg.nodes[0]`` and ``sg.l_neigh``."""
     rb_key = UNKNOWN
-    """Qubit reservation key between ``sg.nodes[-1]`` and ``sg.l_neigh``."""
+    """Qubit reservation key between ``sg.nodes[-1]`` and ``sg.r_neigh``."""
 
     has_expire_event = False
     """Whether ``ForwarderSwapProc._u_expire_task`` is scheduled."""
@@ -462,8 +462,12 @@ class ForwarderSwapProc:
         task_saved = self._s_put_task(task, arms)
 
         # Schedule swap completion event.
+        # If the FIB entry is being uninstalled, swap delay is bypassed and local swap is deemed failed.
         now = self.simulator.tc
-        finish_time = now + self.delay.calculate()
+        if fib_entry.is_active(now):
+            finish_time = now + self.delay.calculate()
+        else:
+            finish_time = now
         self.simulator.add_event(
             func_to_event(finish_time, self._s_finish, arms, fib_entry, finish_time if self.error_at_finish else now, task)
         )
@@ -548,6 +552,10 @@ class ForwarderSwapProc:
                 phy.ch_index = fib_entry.own_idx - 1 + i
             phy_eprs.append(phy)
 
+        # If the FIB entry is being uninstalled, local swap is deemed failed.
+        if not fib_entry.is_active(self.simulator.tc):
+            phy_eprs.clear()
+
         # Attempt physical swap.
         new_epr, outcome_str, local_success = self._s_physical_swap(error_t, phy_eprs)
         log.debug(f"{self}: {outcome_str} rank={fib_entry.own_swap_rank} | {arms[0]} x {arms[1]} = {new_epr}")
@@ -566,14 +574,14 @@ class ForwarderSwapProc:
         log.debug(f"{self}: SWAP_FINISH {task} retrieved-from={task_from} saved-at={task_saved}")
         self._heralds(heralds)
 
-    def _s_physical_swap(self, swap_start: Time, phy_eprs: Sequence[Entanglement]) -> tuple[Entanglement | None, str, bool]:
+    def _s_physical_swap(self, error_t: Time, phy_eprs: Sequence[Entanglement]) -> tuple[Entanglement | None, str, bool]:
         # If either memory qubit has decohered, abort the swap.
         if len(phy_eprs) != 2:
             return None, "SWAP_ABORT", False
 
         # Attempt the physical swap.
-        # Memory error model is applied as of the swap start time.
-        new_epr, local_success = Entanglement.swap(*phy_eprs, now=swap_start, ps=self.ps, error=self.error)
+        # Memory error model is applied as of the specified time point.
+        new_epr, local_success = Entanglement.swap(*phy_eprs, now=error_t, ps=self.ps, error=self.error)
 
         # Update physical swap counters.
         if local_success:
@@ -772,7 +780,7 @@ class ForwarderSwapProc:
             return
         task.has_expire_event = True
         t = self.simulator.tc if not task.expiry else self.simulator.time(time_slot=task.expiry)
-        t += self.memory.t_decohere  # delay deletion so that incoming messages can be replied to
+        t += self.memory.t_cohere  # delay deletion so that incoming messages can be replied to
         self.simulator.add_event(SwapTaskExpireEvent(task, t=t))
 
     def _expire_task(self, event: SwapTaskExpireEvent):

--- a/mqns/network/fw/fw_swap.py
+++ b/mqns/network/fw/fw_swap.py
@@ -387,7 +387,11 @@ class ForwarderSwapProc:
             self.simulator.add_event(event)
 
     def check_table_leak(self) -> None:
-        """Check for memory leak in internal data structures."""
+        """
+        Check for memory leak in internal data structures with ``table_leak_tol`` tolerance.
+
+        This function is scheduled automatically at the end of a finite simulation.
+        """
         max_table_size = 0
         for attr in ("waiting_su", "remote_swapped", "task_by_qubit"):
             table = getattr(self, attr)

--- a/mqns/network/fw/mux.py
+++ b/mqns/network/fw/mux.py
@@ -39,40 +39,36 @@ class MuxScheme(ABC):
         """Validate install_path instructions are compatible."""
 
     @abstractmethod
-    def install_path_neighbor(
+    def install_path_adj(
         self,
         instructions: PathInstructions,
         fib_entry: FibEntry,
         direction: PathDirection,
-        neighbor: QNode,
         qchannel: QuantumChannel,
     ) -> None:
         """
-        Store information about neighbor node and allocate resources.
+        Store information about adjacent quantum channel and allocate resources.
 
         Args:
             instructions: Path instructions.
             fib_entry: FIB entry derived from path instructions.
-            direction: LEFT for left neighbor or RIGHT for right neighbor.
-            neighbor: Neighbor node.
+            direction: Direction of adjacency.
             qchannel: Quantum channel to the neighbor.
         """
 
     @abstractmethod
-    def uninstall_path_neighbor(
+    def uninstall_path_adj(
         self,
         fib_entry: FibEntry,
         direction: PathDirection,
-        neighbor: QNode,
         qchannel: QuantumChannel,
     ) -> None:
         """
-        Erase information about neighbor node and deallocate resources.
+        Erase information about adjacent quantum channel and deallocate resources.
 
         Args:
             fib_entry: FIB entry.
-            direction: LEFT for left neighbor or RIGHT for right neighbor.
-            neighbor: Neighbor node.
+            direction: Direction of adjacency.
             qchannel: Quantum channel to the neighbor.
         """
 

--- a/mqns/network/fw/mux_buffer_space.py
+++ b/mqns/network/fw/mux_buffer_space.py
@@ -100,15 +100,13 @@ class MuxSchemeBufferSpace(MuxSchemeFibBase):
         assert "m_v" in instructions
 
     @override
-    def install_path_neighbor(
+    def install_path_adj(
         self,
         instructions: PathInstructions,
         fib_entry: FibEntry,
         direction: PathDirection,
-        neighbor: QNode,
         qchannel: QuantumChannel,
     ) -> None:
-        _ = neighbor
         assert "m_v" in instructions
         mv = instructions["m_v"]
         mv_offset, ch_side = (-1, 1) if direction == PathDirection.L else (0, 0)
@@ -134,10 +132,7 @@ class MuxSchemeBufferSpace(MuxSchemeFibBase):
         log.debug(f"{self.fw}: allocated {direction} qubits: {addrs}")
 
     @override
-    def uninstall_path_neighbor(
-        self, fib_entry: FibEntry, direction: PathDirection, neighbor: QNode, qchannel: QuantumChannel
-    ) -> None:
-        _ = neighbor
+    def uninstall_path_adj(self, fib_entry: FibEntry, direction: PathDirection, qchannel: QuantumChannel) -> None:
         qubits = self.memory.find(lambda q, _: q.path_id == fib_entry.path_id, qchannel=qchannel)
         addrs = [q[0].addr for q in qubits]
         self.memory.deallocate(*addrs)

--- a/mqns/network/fw/mux_buffer_space.py
+++ b/mqns/network/fw/mux_buffer_space.py
@@ -129,15 +129,16 @@ class MuxSchemeBufferSpace(MuxSchemeFibBase):
                 direction,
                 n="all" if n_qubits == 0 else n_qubits,
             )
-        log.debug(f"{self.fw}: allocated {direction} qubits: {addrs}")
+        log.debug(f"{self.fw}: allocating {direction} qubits: {addrs}")
 
     @override
     def uninstall_path_adj(self, fib_entry: FibEntry, direction: PathDirection, qchannel: QuantumChannel) -> None:
         qubits = self.memory.find(lambda q, _: q.path_id == fib_entry.path_id, qchannel=qchannel)
         addrs = [q[0].addr for q in qubits]
+        log.debug(f"{self.fw}: deallocating {direction} qubits: {addrs}")
+        # If some qubits are currently ACTIVE or RESERVED IN LinkLayer, deallocation would occur
+        # when they next reach RAW state.
         self.memory.deallocate(*addrs)
-        log.debug(f"{self.fw}: deallocated {direction} qubits: {addrs}")
-        pass
 
     @override
     def qubit_has_path_id(self) -> bool:

--- a/mqns/network/fw/mux_statistical.py
+++ b/mqns/network/fw/mux_statistical.py
@@ -35,29 +35,24 @@ class MuxSchemeDynamicBase(MuxScheme):
         assert "m_v" not in instructions
 
     @override
-    def install_path_neighbor(
+    def install_path_adj(
         self,
         instructions: PathInstructions,
         fib_entry: FibEntry,
         direction: PathDirection,
-        neighbor: QNode,
         qchannel: QuantumChannel,
     ) -> None:
-        _ = instructions
-        _ = direction
-        _ = neighbor
+        _ = instructions, direction
         self.qchannel_paths_map[qchannel.name].append(fib_entry.path_id)
 
     @override
-    def uninstall_path_neighbor(
+    def uninstall_path_adj(
         self,
         fib_entry: FibEntry,
         direction: PathDirection,
-        neighbor: QNode,
         qchannel: QuantumChannel,
     ) -> None:
         _ = direction
-        _ = neighbor
         paths = self.qchannel_paths_map[qchannel.name]
         paths.remove(fib_entry.path_id)
         if len(paths) == 0:

--- a/mqns/network/proactive/forwarder.py
+++ b/mqns/network/proactive/forwarder.py
@@ -17,8 +17,10 @@
 
 from typing import override
 
+from mqns.entity.node import QNode
+from mqns.entity.qchannel import QuantumChannel
 from mqns.network.fw import Forwarder
-from mqns.network.protocol.event import ManageActiveChannels
+from mqns.network.protocol.event import ManageActiveChannel
 
 
 class ProactiveForwarder(Forwarder):
@@ -29,7 +31,15 @@ class ProactiveForwarder(Forwarder):
     """
 
     @override
-    def handle_path_change(self, *, path_id, uninstall, r_neighbor, **_):
+    def handle_path_change(
+        self,
+        *,
+        path_id: int,
+        uninstall: bool,
+        l_neighbor: tuple[QNode, QuantumChannel] | None,
+        r_neighbor: tuple[QNode, QuantumChannel] | None,
+        **_,
+    ):
         """
         Process LinkLayer changes after a path has been installed or uninstalled.
 
@@ -41,14 +51,16 @@ class ProactiveForwarder(Forwarder):
 
         1. Notify LinkLayer to stop elementary EPR generation toward the right neighbor.
         """
-        if r_neighbor:
-            # instruct LinkLayer to start/stop generating EPRs on the qchannel toward the right neighbor
+        for i, neigh in enumerate((l_neighbor, r_neighbor)):
+            if neigh is None:
+                continue
             self.simulator.add_event(
-                ManageActiveChannels(
+                ManageActiveChannel(
                     self.node,
-                    *r_neighbor,
+                    neigh[1],
                     path_id=path_id if self.mux.qubit_has_path_id() else None,
                     start=not uninstall,
+                    is_primary=i == 1,
                     t=self.simulator.tc,
                 )
             )

--- a/mqns/network/proactive/forwarder.py
+++ b/mqns/network/proactive/forwarder.py
@@ -17,7 +17,6 @@
 
 from typing import override
 
-from mqns.entity.node import QNode
 from mqns.entity.qchannel import QuantumChannel
 from mqns.network.fw import Forwarder
 from mqns.network.protocol.event import ManageActiveChannel
@@ -36,8 +35,8 @@ class ProactiveForwarder(Forwarder):
         *,
         path_id: int,
         uninstall: bool,
-        l_neighbor: tuple[QNode, QuantumChannel] | None,
-        r_neighbor: tuple[QNode, QuantumChannel] | None,
+        ch_l: QuantumChannel | None,
+        ch_r: QuantumChannel | None,
         **_,
     ):
         """
@@ -51,13 +50,13 @@ class ProactiveForwarder(Forwarder):
 
         1. Notify LinkLayer to stop elementary EPR generation toward the right neighbor.
         """
-        for i, neigh in enumerate((l_neighbor, r_neighbor)):
-            if neigh is None:
+        for i, ch in enumerate((ch_l, ch_r)):
+            if ch is None:
                 continue
             self.simulator.add_event(
                 ManageActiveChannel(
                     self.node,
-                    neigh[1],
+                    ch,
                     path_id=path_id if self.mux.qubit_has_path_id() else None,
                     start=not uninstall,
                     is_primary=i == 1,

--- a/mqns/network/protocol/event.py
+++ b/mqns/network/protocol/event.py
@@ -15,7 +15,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from typing import ClassVar, final, override
+from typing import ClassVar, cast, final, override
 
 from mqns.entity.memory import MemoryQubit, QubitState
 from mqns.entity.node import QNode
@@ -56,29 +56,36 @@ class ManageActiveChannel(Event):
 
 
 @final
-class LinkArchSuccessEvent(Event):
+class LinkArchNotifySrcEvent(Event):
     """
-    Event in LinkLayer to notify itself or its neighbor about successful entanglement in link architecture.
+    Event in LinkLayer to notify the primary node about successful entanglement in link architecture.
     """
 
-    def __init__(
-        self,
-        node: QNode,
-        key: str,
-        epr: Entanglement,
-        *,
-        t: Time,
-        attempts: int,
-    ):
-        super().__init__(t, f"LinkArchSuccessEvent({node.name}, key={key}, epr={epr.name})")
-        self.node = node
+    def __init__(self, key: str, epr: Entanglement, *, t: Time, attempts: int):
+        super().__init__(t, f"{cast(QNode, epr.src).name}, key={key}, epr={epr.name}")
         self.key = key
         self.epr = epr
         self.attempts = attempts
 
     @override
     def invoke(self) -> None:
-        self.node.handle(self)
+        cast(QNode, self.epr.src).handle(self)
+
+
+@final
+class LinkArchNotifyDstEvent(Event):
+    """
+    Event in LinkLayer to notify the secondary node about successful entanglement in link architecture.
+    """
+
+    def __init__(self, key: str, epr: Entanglement, *, t: Time):
+        super().__init__(t, f"{cast(QNode, epr.dst).name}, key={key}, epr={epr.name}")
+        self.key = key
+        self.epr = epr
+
+    @override
+    def invoke(self) -> None:
+        cast(QNode, self.epr.dst).handle(self)
 
 
 @final
@@ -141,6 +148,8 @@ class QubitReleasedEvent(Event):
     Event sent by Forwarder/Consumer to inform LinkLayer about a released (no longer needed) qubit.
     """
 
+    REASON_STR: ClassVar = {True: "decoh", False: "release"}
+
     def __init__(
         self,
         node: QNode,
@@ -149,7 +158,7 @@ class QubitReleasedEvent(Event):
         t: Time,
         is_decoh=False,
     ):
-        super().__init__(t, f"addr={qubit.addr} key={qubit.key}")
+        super().__init__(t, f"addr={qubit.addr} key={qubit.key} {self.REASON_STR[is_decoh]}")
         self.node = node
         self.qubit = qubit
         self.is_decoh = is_decoh

--- a/mqns/network/protocol/event.py
+++ b/mqns/network/protocol/event.py
@@ -15,7 +15,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from typing import final, override
+from typing import ClassVar, final, override
 
 from mqns.entity.memory import MemoryQubit, QubitState
 from mqns.entity.node import QNode
@@ -25,28 +25,30 @@ from mqns.simulator import Event, Time
 
 
 @final
-class ManageActiveChannels(Event):
+class ManageActiveChannel(Event):
     """
-    Event sent by Forwarder to request LinkLayer to start/stop generating EPRs over a qchannel.
+    Event to instruct LinkLayer to start/stop generating EPRs over a quantum channel for a path_id.
     """
+
+    ACTION_STR: ClassVar = {True: "start", False: "stop"}
+    ROLE_STR: ClassVar = {True: "primary", False: "secondary"}
 
     def __init__(
         self,
         node: QNode,
-        neighbor: QNode,
         qchannel: QuantumChannel,
         *,
-        path_id: int | None = None,
+        path_id: int | None,
         start: bool,
+        is_primary: bool,
         t: Time,
-        name: str | None = None,
     ):
-        super().__init__(t, name)
+        super().__init__(t, f"{node.name}, {self.ACTION_STR[start]} {qchannel.name}, {self.ROLE_STR[is_primary]}")
         self.node = node
-        self.neighbor = neighbor
         self.qchannel = qchannel
         self.path_id = path_id
         self.start = start
+        self.is_primary = is_primary
 
     @override
     def invoke(self) -> None:
@@ -66,10 +68,9 @@ class LinkArchSuccessEvent(Event):
         epr: Entanglement,
         *,
         t: Time,
-        name: str | None = None,
         attempts: int,
     ):
-        super().__init__(t, name)
+        super().__init__(t, f"LinkArchSuccessEvent({node.name}, key={key}, epr={epr.name})")
         self.node = node
         self.key = key
         self.epr = epr
@@ -93,9 +94,8 @@ class QubitEntangledEvent(Event):
         qubit: MemoryQubit,
         *,
         t: Time,
-        name: str | None = None,
     ):
-        super().__init__(t, name)
+        super().__init__(t, f"{node.name}-{neighbor.name}, key={qubit.key}, addr={qubit.addr}")
         self.node = node
         self.neighbor = neighbor
         self.qubit = qubit
@@ -122,7 +122,7 @@ class QubitConsumeEvent(Event):
         t: Time,
         req_id: int,
     ):
-        super().__init__(t, f"EntanglementReadyEvent({qubit.addr}, {epr.name})")
+        super().__init__(t, f"{qubit.addr}, {epr.name}")
         self.node = node
         self.qubit = qubit
         self.epr = epr

--- a/mqns/network/protocol/link_layer.py
+++ b/mqns/network/protocol/link_layer.py
@@ -23,10 +23,17 @@ from mqns.entity.cchannel import ClassicCommandDispatcherMixin, ClassicPacket, c
 from mqns.entity.memory import MemoryQubit, QubitState
 from mqns.entity.node import Application, QNode
 from mqns.entity.qchannel import QuantumChannel
+from mqns.models.epr import Entanglement
 from mqns.network.network import TimingPhase, TimingPhaseEvent
-from mqns.network.protocol.event import LinkArchSuccessEvent, ManageActiveChannel, QubitEntangledEvent, QubitReleasedEvent
+from mqns.network.protocol.event import (
+    LinkArchNotifyDstEvent,
+    LinkArchNotifySrcEvent,
+    ManageActiveChannel,
+    QubitEntangledEvent,
+    QubitReleasedEvent,
+)
 from mqns.simulator import event_handler
-from mqns.utils import AutoIncrementIdentifier, json_encodable, log, rng
+from mqns.utils import AutoIncrementIdentifier, json_encodable, log, rng, unwrap, unwrap_cast
 
 _AUTOID = AutoIncrementIdentifier("llk_")
 """
@@ -340,8 +347,16 @@ class LinkLayer(ClassicCommandDispatcherMixin, Application[QNode]):
         if ap.insertion_count > 0:
             return
 
+        # If the path on a channel is being deactivated, reset qubits owned by LinkLayer.
+        addrs: list[int] = []
+        for mq, _ in self.memory.find(
+            lambda q, _: q.state in (QubitState.ACTIVE, QubitState.RESERVED) and q.path_id == path_id, qchannel=ch
+        ):
+            mq.state = QubitState.RAW
+            addrs.append(mq.addr)
+
         del ac.paths[path_id]
-        log.debug(f"{self}: removing path {path_id} in qchannel {ch.name}")
+        log.debug(f"{self}: removing path {path_id} in qchannel {ch.name}, reset-addrs={addrs}")
         if len(ac.paths) > 0:
             return
 
@@ -500,32 +515,33 @@ class LinkLayer(ClassicCommandDispatcherMixin, Application[QNode]):
         assert mq.key == key
         mq.state = QubitState.RESERVED
         log.debug(f"{self}: RESERVE_RES({pkt.src.name}:{path_id}, {key}) processed addr={mq.addr}")
-        self.generate_entanglement(ac.qchannel, ac.partner, mq)
+        self.generate_entanglement(ac, mq)
 
-    def generate_entanglement(self, qchannel: QuantumChannel, next_hop: QNode, qubit: MemoryQubit):
+    def generate_entanglement(self, ac: _ActiveChannel, mq: MemoryQubit) -> None:
         """
         Schedule a successful entanglement attempt using skip-ahead sampling.
 
         Args:
-            qchannel: The quantum channel over which entanglement is to be generated.
-            next_hop: The neighboring node with which the entanglement is attempted.
+            ac: ActiveChannel record of the quantum channel, where this node is primary.
             qubit: The memory qubit used for this attempt.
         """
-        key = qubit.key
-        assert key
+        qchannel = ac.qchannel
+        src = self.node
+        dst = ac.partner
+        key = unwrap(mq.key)
 
         # Calculate which attempt would succeed.
-        k = rng.geometric(qchannel.link_arch.success_prob)
+        k = self._calc_attempt(qchannel)
 
         # Calculate when would the k-th attempt (1-based) succeed.
         # TODO space out EPRs on a qchannel by attempt_interval or qchannel.bandwidth
-        epr, t_notify_a, t_notify_b = qchannel.link_arch.make_epr(k, self.simulator.tc, src=self.node, dst=next_hop, key=key)
+        epr, t_notify_a, t_notify_b = qchannel.link_arch.make_epr(k, self.simulator.tc, src=src, dst=dst, key=key)
 
         # If the network uses SYNC timing mode but the successful attempt would exceed the current EXTERNAL phase,
         # the EPR would not arrive in time, and therefore is not scheduled.
-        if not self.node.timing.is_external(max(t_notify_a, t_notify_b)):
+        if not src.timing.is_external(max(t_notify_a, t_notify_b)):
             log.debug(
-                f"{self}: skip prepare EPR {epr.name} key={key} dst={next_hop.name} attempts={k} "
+                f"{self}: skip prepare EPR {epr.name} key={key} dst={dst.name} attempts={k} "
                 f"notify-times={t_notify_a},{t_notify_b} reason=beyond-external-phase"
             )
             return
@@ -533,27 +549,38 @@ class LinkLayer(ClassicCommandDispatcherMixin, Application[QNode]):
         # If the network uses ASYNC timing mode or the successful attempt can complete within the current EXTERNAL phase,
         # schedule the EPR arrival on both nodes via LinkArchSuccessEvents.
         log.debug(
-            f"{self}: prepare EPR {epr.name} key={key} dst={next_hop.name} attempts={k} notify-times={t_notify_a},{t_notify_b}"
+            f"{self}: prepare EPR {epr.name} key={key} dst={dst.name} attempts={k} notify-times={t_notify_a},{t_notify_b}"
         )
 
-        self.simulator.add_event(LinkArchSuccessEvent(self.node, key, epr, t=t_notify_a, attempts=k))
-        self.simulator.add_event(LinkArchSuccessEvent(next_hop, key, epr, t=t_notify_b, attempts=k))
+        self.simulator.add_event(LinkArchNotifySrcEvent(key, epr, t=t_notify_a, attempts=k))
+        self.simulator.add_event(LinkArchNotifyDstEvent(key, epr, t=t_notify_b))
+
+    def _calc_attempt(self, qchannel: QuantumChannel) -> int:
+        return rng.geometric(qchannel.link_arch.success_prob)
 
     @event_handler
-    def handle_success_entangle(self, event: LinkArchSuccessEvent):
-        assert self.node.timing.is_external()
-
+    def _la_notify_src(self, event: LinkArchNotifySrcEvent):
+        self.cnt.increment_n_etg(event.attempts)
         epr = event.epr
-        partner, is_primary = (epr.dst, True) if epr.src == self.node else (epr.src, False)
-        assert partner is not None
-        if is_primary:
-            self.cnt.increment_n_etg(event.attempts)
+        self._la_notify(event.key, epr, "primary", "dst", unwrap_cast(epr.dst))
 
-        mq = self.memory.write(event.key, epr)
+    @event_handler
+    def _la_notify_dst(self, event: LinkArchNotifyDstEvent):
+        epr = event.epr
+        self._la_notify(event.key, epr, "secondary", "src", unwrap_cast(epr.src))
+
+    def _la_notify(self, key: str, epr: Entanglement, own_role: str, partner_role: str, partner: QNode) -> None:
+        assert self.node.timing.is_external()
+        try:
+            mq = self.memory.write(key, epr)
+        except LookupError:
+            # Path was deactivated and qubit was deallocated.
+            log.debug(f"{self}: EPR-notify-{own_role} {epr.name} ignored key={key} reason=qubit-not-found")
+            return
 
         log.debug(
-            f"{self}: got half-EPR {epr.name} key={event.key} {'dst' if is_primary else 'src'}={partner} "
-            f"addr={mq.addr} path={mq.path_id}"
+            f"{self}: EPR-notify-{own_role} {epr.name} delivered key={key} "
+            f"{partner_role}={partner} addr={mq.addr} path={mq.path_id}"
         )
         assert epr.decohere_time > self.simulator.tc
 
@@ -563,24 +590,27 @@ class LinkLayer(ClassicCommandDispatcherMixin, Application[QNode]):
     @event_handler
     def handle_release(self, event: QubitReleasedEvent) -> None:
         mq = event.qubit
-        log.debug(f"{self}: {event}")
         mq.state = QubitState.RAW
 
-        assert mq.qchannel is not None
-        partner = mq.qchannel.find_peer(self.node)
+        partner = unwrap(mq.qchannel).find_peer(self.node)
 
         ac = self.channels.get(partner.name)
         if ac is None:
+            log.debug(f"{self}: {event} ignored reason=no-active-channel")
             return
 
         ap = ac.paths.get(mq.path_id)
         if ap is None:
+            log.debug(f"{self}: {event} ignored reason=no-active-path")
             return
 
         if ac.is_primary:
+            log.debug(f"{self}: {event} processed role=primary")
             if event.is_decoh:
                 self.cnt.n_decoh += 1
             if self.node.timing.is_async():
                 self.start_reservation(ac, mq)
-        elif ap.ireq_queue and self.try_accept_reservation(ac, ap, ap.ireq_queue[0], hint=mq):
-            ap.ireq_queue.popleft()
+        else:
+            log.debug(f"{self}: {event} processed role=secondary")
+            if ap.ireq_queue and self.try_accept_reservation(ac, ap, ap.ireq_queue[0], hint=mq):
+                ap.ireq_queue.popleft()

--- a/mqns/network/protocol/link_layer.py
+++ b/mqns/network/protocol/link_layer.py
@@ -17,20 +17,14 @@
 
 from collections import deque
 from collections.abc import Iterable
-from dataclasses import dataclass
-from typing import Literal, TypedDict, cast, override
+from typing import Final, Literal, TypedDict, override
 
-from mqns.entity.cchannel import ClassicChannel, ClassicPacket, RecvClassicPacket
+from mqns.entity.cchannel import ClassicCommandDispatcherMixin, ClassicPacket, classic_cmd_handler
 from mqns.entity.memory import MemoryQubit, QubitState
 from mqns.entity.node import Application, QNode
 from mqns.entity.qchannel import QuantumChannel
 from mqns.network.network import TimingPhase, TimingPhaseEvent
-from mqns.network.protocol.event import (
-    LinkArchSuccessEvent,
-    ManageActiveChannels,
-    QubitEntangledEvent,
-    QubitReleasedEvent,
-)
+from mqns.network.protocol.event import LinkArchSuccessEvent, ManageActiveChannel, QubitEntangledEvent, QubitReleasedEvent
 from mqns.simulator import event_handler
 from mqns.utils import AutoIncrementIdentifier, json_encodable, log, rng
 
@@ -41,18 +35,96 @@ Automatically assigned ``ReservationRequest.key`` name.
 
 
 class ReserveMsg(TypedDict):
-    cmd: Literal["RESERVE_QUBIT", "RESERVE_QUBIT_OK"]
-    path_id: int | None
+    """
+    Message between LinkLayers to request and accept qubit reservation for entanglement generation.
+    """
+
+    cmd: Literal["RESERVE_REQ", "RESERVE_RES"]
+    """
+    RESERVE_REQ is sent from primary node to secondary node to request entanglement generation.
+    RESERVE_RES is sent from secondary node to primary node to accept entanglement generation.
+    """
     key: str
+    """
+    Reservation key that uniquely identifies this reservation and the resulting entanglement.
+    """
+    path_id: int | None
+    """
+    The path identifier assigned to the generated entanglement.
+    """
 
 
-@dataclass
-class ReservationRequest:
-    key: str
-    path_id: int | None
-    cchannel: ClassicChannel
-    from_node: QNode
-    qchannel: QuantumChannel
+class _ActivePath:
+    """
+    LinkLayer data structure related to an active path in an active quantum channel.
+    """
+
+    __slots__ = ("path_id", "insertion_count", "oreq_table", "ireq_queue")
+
+    path_id: Final[int | None]
+    """
+    Path identifier.
+
+    LinkLayer considers ``None`` as a valid path_id (rather than an absent value), because the forwarder's
+    multiplexing scheme may not need to allocate each qubit to a particular path_id.
+    """
+
+    insertion_count: int
+    """
+    How many times this channel+path_id combination has been activated.
+    It would take the same number of deactivation commands to deactivate the channel+path_id combination.
+    """
+
+    oreq_table: dict[str, int]
+    """
+    Table of outgoing RESERVE_REQ sent by this node for which a reply has not arrived.
+    This is only used on the primary node of the channel.
+    Key is reservation key.
+    Value is qubit address.
+    """
+
+    ireq_queue: deque[str]
+    """
+    Queue of incoming RESERVE_REQ received by this node that has not been fulfilled.
+    This is only used on the secondary node of the channel.
+    Element is reservation key.
+    """
+
+    def __init__(self, path_id: int | None):
+        self.path_id = path_id
+        self.insertion_count = 0
+        self.oreq_table = {}
+        self.ireq_queue = deque()
+
+
+class _ActiveChannel:
+    """
+    LinkLayer data structure related to an active quantum channel.
+    """
+
+    __slots__ = ("qchannel", "partner", "is_primary", "paths")
+
+    qchannel: Final[QuantumChannel]
+    """Quantum channel."""
+
+    partner: Final[QNode]
+    """Partner node."""
+
+    is_primary: Final[bool]
+    """Role of this node."""
+
+    paths: dict[int | None, _ActivePath]
+    """
+    Active paths.
+    Key is ``path_id``.
+    Value is ActivePath record.
+    """
+
+    def __init__(self, qchannel: QuantumChannel, partner: QNode, is_primary: bool):
+        self.qchannel = qchannel
+        self.partner = partner
+        self.is_primary = is_primary
+        self.paths = {}
 
 
 @json_encodable
@@ -94,7 +166,7 @@ class LinkLayerCounters:
         return f"etg={self.n_etg} attempts={self.n_attempts} decoh={self.n_decoh} decoh_ratio={self.decoh_ratio}"
 
 
-class LinkLayer(Application[QNode]):
+class LinkLayer(ClassicCommandDispatcherMixin, Application[QNode]):
     """
     Network function for creating elementary entanglements over qchannels.
     It equips a QNode and is activated from the forwarding function (e.g., ProactiveForwarder).
@@ -133,29 +205,10 @@ class LinkLayer(Application[QNode]):
         self.tau_0 = tau_0
         """Local operation delay in seconds."""
 
-        self.active_channels: dict[tuple[QuantumChannel, int | None], tuple[QNode, int]] = {}
+        self.channels: dict[str, _ActiveChannel] = {}
         """
-        Active quantum channels and paths where own node is the primary (on the left side).
-        Key is qchannel and optional path_id.
-        Value is [0] neighbor QNode [1] insertion count.
-
-        When qubits were assigned to qchannels but not allocated to specific path_ids,
-        such as in MuxSchemeDynamicEpr, path_id would be None, but LinkLayer would still
-        receive one ManageActiveChannels start event per qchannel+path combination.
-        The insertion count keeps track of how many start events were received
-        for the qchannel that are not yet canceled by corresponding stop events.
-
-        When qubits were allocated to specific path_ids, insertion count should always be 1.
-        """
-        self.pending_init_reservation: dict[str, tuple[QuantumChannel, QNode, MemoryQubit]] = {}
-        """
-        Table of pending reservations for which RESERVE_QUBIT is sent but RESERVE_QUBIT_OK has not arrived.
-        Key is reservation key.
-        Value is the qchannel, next hop QNode, local qubit.
-        """
-        self.fifo_reservation_req = deque[ReservationRequest]()
-        """
-        FIFO queue of reservation requests awaiting for memory qubits.
+        Active channel table.
+        Key is partner node name.
         """
 
         self.cnt = LinkLayerCounters()
@@ -176,7 +229,7 @@ class LinkLayer(Application[QNode]):
 
         Upon entering EXTERNAL phase:
 
-        1. Run all active channels from reservation step.
+        1. Start reservation for each active channel where this node is primary.
 
         Upon exiting EXTERNAL phase:
 
@@ -189,47 +242,61 @@ class LinkLayer(Application[QNode]):
         """
         match event.action:
             case TimingPhase.EXTERNAL, True:
-                for (qchannel, path_id), (neighbor, _) in self.active_channels.items():
-                    self.run_active_channel(qchannel, path_id, neighbor)
+                for ac in self.channels.values():
+                    if ac.is_primary:
+                        self.run_channel(ac)
             case TimingPhase.EXTERNAL, False:
-                self.pending_init_reservation.clear()
-                self.fifo_reservation_req.clear()
+                for ac in self.channels.values():
+                    for ap in ac.paths.values():
+                        ap.oreq_table.clear()
+                        ap.ireq_queue.clear()
             case TimingPhase.INTERNAL, False:
                 self.memory.clear()
 
     @event_handler
-    def RecvClassicPacketHandler(self, event: RecvClassicPacket) -> bool:
-        msg = event.packet.get()
-        if not (isinstance(msg, dict) and "cmd" in msg):
-            return False
-
-        match msg["cmd"]:
-            case "RESERVE_QUBIT":
-                self.handle_reserve_req(cast(ReserveMsg, msg), event.cchannel)
-                return True
-            case "RESERVE_QUBIT_OK":
-                self.handle_reserve_res(cast(ReserveMsg, msg))
-                return True
-            case _:
-                return False
-
-    @event_handler
-    def handle_manage_active_channels(self, event: ManageActiveChannels) -> bool:
-        """Handle ManageActiveChannels event from forwarder."""
+    def handle_manage_active_channels(self, event: ManageActiveChannel) -> None:
         if event.start:
-            self.add_active_channel(event.qchannel, event.path_id, event.neighbor)
+            self._activate_channel(event.qchannel, event.is_primary, event.path_id)
         else:
-            self.remove_active_channel(event.qchannel, event.path_id, event.neighbor)
-        return True
+            self._deactivate_channel(event.qchannel, event.path_id)
 
-    def add_active_channel(self, qchannel: QuantumChannel, path_id: int | None, neighbor: QNode):
-        key = (qchannel, path_id)
-        _, n = self.active_channels.get(key, (neighbor, 0))
-        n += 1
-        self.active_channels[key] = (neighbor, n)
+    def _activate_channel(self, ch: QuantumChannel, is_primary: bool, path_id: int | None) -> None:
+        """
+        Handle channel activation command from ``ManageActiveChannel`` event.
 
-        if n > 1:
-            assert path_id is None
+        Args:
+            ch: Quantum channel.
+            is_primary: Role of this node on this channel.
+            path_id: Act only on qubits allocated to a path.
+        """
+        partner = ch.find_peer(self.node)
+
+        ac = self.channels.get(partner.name)
+        if ac:
+            assert ac.is_primary is is_primary, f"{self}: inconsistent is_primary on {ch.name}"
+        else:
+            ac = _ActiveChannel(ch, partner, is_primary)
+            self.channels[partner.name] = ac
+
+            self._activate_channel_new(ac)
+
+        ap = ac.paths.get(path_id)
+        if not ap:
+            ap = _ActivePath(path_id)
+            ac.paths[path_id] = ap
+
+            addrs = list(q.addr for q, _ in self.memory.find(lambda *_: True, qchannel=ch))
+            log.debug(f"{self}: adding path {path_id} in qchannel {ch.name}, assigned qubits {addrs}")
+
+        ap.insertion_count += 1
+
+        if is_primary and self.node.timing.is_async():
+            self.run_channel(ac, ap)
+
+    def _activate_channel_new(self, ac: _ActiveChannel) -> None:
+        ch = ac.qchannel
+        if not ac.is_primary:
+            log.debug(f"{self}: activating qchannel {ch.name} as secondary with partner {ac.partner.name}")
             return
 
         # link_arch.set() may be called multiple times in several situations:
@@ -237,164 +304,203 @@ class LinkLayer(Application[QNode]):
         # - qchannel is activated from both sides due to shared paths in opposite directions.
         # Nevertheless, we assume every LinkLayer instance has the same parameters,
         # so that the parameters saved into LinkArch are the same every time.
-        qchannel.link_arch.set(
-            ch=qchannel,
+        ch.link_arch.set(
+            ch=ch,
             eta_s=self.eta_s,
             eta_d=self.eta_d,
             reset_time=self.reset_time,
             tau_0=self.tau_0,
             epr_type=self.node.network.epr_type,
             t0=self.simulator.tc,
-            store_decays=(self.memory.time_decay, neighbor.memory.time_decay),
+            store_decays=(self.memory.time_decay, ac.partner.memory.time_decay),
         )
 
-        epr_tpl, t_notify_a, t_notify_b = qchannel.link_arch.make_epr(
-            1, self.simulator.ts, src=self.node, dst=neighbor, key=None
-        )
+        epr_tpl, t_notify_a, t_notify_b = ch.link_arch.make_epr(1, self.simulator.ts, src=self.node, dst=ac.partner, key=None)
+
         log.debug(
-            f"{self}: add qchannel {qchannel} with {neighbor} on path {path_id}, "
-            f"link arch {qchannel.link_arch.name}, "
+            f"{self}: activating qchannel {ch.name} as primary with partner {ac.partner.name},"
+            f" link arch {ch.link_arch.name}, "
             f"EPR template {epr_tpl} t_notify_a={t_notify_a} t_notify_b={t_notify_b}"
         )
 
-        if self.node.timing.is_async():
-            self.run_active_channel(qchannel, path_id, neighbor)
-
-    def remove_active_channel(self, qchannel: QuantumChannel, path_id: int | None, neighbor: QNode):
-        key = (qchannel, path_id)
-        _, n = self.active_channels[key]
-        n -= 1
-
-        if n == 0:
-            del self.active_channels[key]
-            log.debug(f"{self}: remove qchannel {qchannel} with {neighbor} on path {path_id}")
-        else:
-            self.active_channels[key] = (neighbor, n)
-
-    def run_active_channel(self, qchannel: QuantumChannel, path_id: int | None, next_hop: QNode):
+    def _deactivate_channel(self, ch: QuantumChannel, path_id: int | None) -> None:
         """
-        Start EPR generation over the given quantum channel and the specified path_id.
+        Handle channel deactivation command from ``ManageActiveChannel`` event.
 
         Args:
-            qchannel: The quantum channel over which entanglement is to be attempted.
-            path_id: The path_id to restrict attempts to path-allocated qubits only.
-                    Needed in multipath where a channel may be activated while not all qubits have been allocated to paths.
-            next_hop: The neighboring node with which to initiate the negotiation.
-
-        Notes:
-            - Qubits assigned to memory are retrieved using the channel's name.
-            - Qubit reservations are spaced out in time using a fixed ``attempt_rate``.
-
+            ch: Quantum channel.
+            path_id: Act only on qubits allocated to a path.
         """
-        qubits = list(self.memory.find(lambda *_: True, qchannel=qchannel))
-        log.debug(f"{self}: {qchannel.name} has assigned qubits: {qubits}")
-        for qb, data in qubits:
-            if qb.path_id != path_id or qb.state is not QubitState.RAW:
-                continue
-            assert qb.key is None
-            assert data is None, f"{self}: qubit {qb} has data {data}"
-            self.start_reservation(next_hop, qchannel, qb)
+        partner = ch.find_peer(self.node)
+        ac = self.channels[partner.name]
+        assert ac.qchannel is ch
 
-    def start_reservation(self, next_hop: QNode, qchannel: QuantumChannel, qubit: MemoryQubit):
-        """
-        Start the exchange with neighbor node for reserving a qubit for entanglement
-        generation over a specified quantum channel. It performs the following steps:
-
-        1. Construct a random reservation key.
-        2. Mark the qubit as active using the reservation key.
-        3. Store reservation metadata in ``self.pending_init_reservation``.
-        4. Send a classical message to the next hop to request qubit reservation.
-
-        Args:
-            next_hop: The neighboring node with which the reservation is to be made.
-            qchannel: The quantum channel used for entanglement.
-            qubit: The memory qubit to reserve.
-
-        Raises:
-            Exception: If a reservation has already been initiated for the same key,
-                   or if no classical channel to the destination node is found.
-
-        Notes:
-            - The key uniquely identifies the reservation context.
-              Key format: ``<node1>_<node2>_[<path_id>]_<local_qubit_addr>``
-            - The reservation is communicated via a classical message using the ``RESERVE_QUBIT`` command.
-        """
-        key = _AUTOID()
-
-        qubit.state, qubit.key = QubitState.ACTIVE, key
-        self.pending_init_reservation[key] = (qchannel, next_hop, qubit)
-        log.debug(f"{self}: start reservation key={key} dst={next_hop} addr={qubit.addr} path={qubit.path_id}")
-
-        msg: ReserveMsg = {"cmd": "RESERVE_QUBIT", "path_id": qubit.path_id, "key": key}
-        self.node.send_cpacket(next_hop, ClassicPacket(msg, src=self.node, dest=next_hop))
-
-    def handle_reserve_req(self, msg: ReserveMsg, cchannel: ClassicChannel):
-        """
-        Handle ``RESERVE_QUBIT`` control message sent by the initiating node to request a memory qubit reservation.
-
-        1. If an available memory qubit is found, it is reserved (marked active using the given key).
-        2. A ``RESERVE_QUBIT_OK`` response is sent back to confirm the reservation.
-        3. If no available qubit is found, the request is enqueued for future retry (FIFO).
-        """
-        key = msg["key"]
-
-        if not self.node.timing.is_external():
-            log.debug(f"{self}: ignore reservation request key={key} reason=not-external-phase")
+        ap = ac.paths[path_id]
+        ap.insertion_count -= 1
+        if ap.insertion_count > 0:
             return
 
-        from_node = cchannel.find_peer(self.node)
-        assert type(from_node) is QNode
-        qchannel = self.node.get_qchannel(from_node)
-        req = ReservationRequest(key, msg["path_id"], cchannel, from_node, qchannel)
-        if not self.try_accept_reservation(req):
-            self.fifo_reservation_req.append(req)
+        del ac.paths[path_id]
+        log.debug(f"{self}: removing path {path_id} in qchannel {ch.name}")
+        if len(ac.paths) > 0:
+            return
 
-    def try_accept_reservation(self, req: ReservationRequest) -> bool:
+        del self.channels[partner.name]
+        log.debug(
+            f"{self}: deactivating qchannel {ch.name} as {ManageActiveChannel.ROLE_STR[ac.is_primary]} "
+            f"with partner {partner.name}"
+        )
+
+    def run_channel(self, ac: _ActiveChannel, ap: _ActivePath | None = None) -> None:
+        """
+        Start entanglement generation on qubits assigned to a channel.
+
+        Args:
+            ac: ActiveChannel record of the quantum channel, where this node is primary.
+            ap: If set, only consider qubits allocated to a specified path.
+        """
+        qubits = self.memory.find(
+            (lambda q, _: q.state is QubitState.RAW)
+            if ap is None
+            else (lambda q, _: q.state is QubitState.RAW and q.path_id == ap.path_id),
+            qchannel=ac.qchannel,
+        )
+        for q, v in qubits:
+            assert q.key is None
+            assert v is None
+            self.start_reservation(ac, q)
+
+    def start_reservation(self, ac: _ActiveChannel, mq: MemoryQubit):
+        """
+        Start entanglement generation on a qubit assigned to a channel.
+
+        Args:
+            ac: ActiveChannel record of the quantum channel, where this node is primary.
+            mq: The qubit, which must be in RAW state.
+        """
+        assert ac.is_primary
+
+        # Generate a unique reservation key to represent this entanglement generation protocol execution
+        # and the entanglement, which is valid until the entanglement is released.
+        mq.key = _AUTOID()
+        mq.state = QubitState.ACTIVE
+
+        # Remember the pending reservation in ActivePath record.
+        ap = ac.paths[mq.path_id]
+        ap.oreq_table[mq.key] = mq.addr
+        log.debug(
+            f"{self}: RESERVE_REQ({self.node.name}:{mq.path_id}, {mq.key}) sent addr={mq.addr} secondary={ac.partner.name}"
+        )
+
+        # Transmit RESERVE_REQ message to the secondary node.
+        msg = ReserveMsg(cmd="RESERVE_REQ", key=mq.key, path_id=mq.path_id)
+        self.node.send_cpacket(ac.partner, ClassicPacket(msg, src=self.node, dest=ac.partner))
+
+    @classic_cmd_handler("RESERVE_REQ")
+    def handle_reserve_req(self, pkt: ClassicPacket, msg: ReserveMsg):
+        """
+        Handle ``RESERVE_REQ`` message from the primary node.
+        """
+        key = msg["key"]
+        path_id = msg["path_id"]
+
+        if not self.node.timing.is_external():
+            log.debug(f"{self}: RESERVE_REQ({pkt.src.name}:{path_id}, {key}) ignored reason=not-external-phase")
+            return
+
+        ac = self.channels.get(pkt.src.name)
+        if ac is None:
+            log.debug(f"{self}: RESERVE_REQ({pkt.src.name}:{path_id}, {key}) ignored reason=no-active-channel")
+            return
+        assert not ac.is_primary
+
+        ap = ac.paths.get(path_id)
+        if ap is None:
+            log.debug(f"{self}: RESERVE_REQ({pkt.src.name}:{path_id}, {key}) ignored reason=no-active-path")
+            return
+
+        if len(ap.ireq_queue) > 0 or not self.try_accept_reservation(ac, ap, key):
+            # If the queue is non-empty, try_accept_reservation() would not have succeeded.
+            # If try_accept_reservation() was unsuccessful, enqueue the request.
+            ap.ireq_queue.append(key)
+
+    def try_accept_reservation(self, ac: _ActiveChannel, ap: _ActivePath, key: str, *, hint: MemoryQubit | None = None) -> bool:
         """
         Accept a reservation if a qubit is available.
 
-        Returns:
-            True if the reservation is accepted and ``RESERVE_QUBIT_OK`` is sent.
-            False if the reservation is not accepted.
+        Args:
+            ac: ActiveChannel record of the quantum channel, where this node is secondary.
+            ap: ActivePath record of the path to which the qubit is allocated.
+            key: Reservation key from a received RESERVE_RES message.
+            hint: If provided, it will be used, bypassing the search; it must be in RAW state.
 
-        Notes: Caller is responsible for managing ``fifo_reservation_req`` queue.
+        Returns:
+
+            * True if the request is accepted and ``RESERVE_RES`` is sent.
+              Caller is responsible for dequeuing the request if it was in a queue.
+            * False if the request is not accepted.
+              Caller is responsible for enqueuing the request.
         """
-        qubit, _ = next(
-            self.memory.find(
-                lambda q, _: (
-                    q.state is QubitState.RAW  # currently unoccupied and not part of an active reservation
-                    and q.path_id == req.path_id  # allocated to the path_id, if MuxScheme uses path_id
+        assert not ac.is_primary
+
+        if hint:
+            mq = hint
+            assert mq.state is QubitState.RAW
+            assert mq.path_id == ap.path_id
+        else:
+            mq, _ = next(
+                self.memory.find(
+                    lambda q, _: (
+                        q.state is QubitState.RAW  # currently unoccupied and not part of an active reservation
+                        and q.path_id == ap.path_id  # allocated to the path_id, if MuxScheme uses path_id
+                    ),
+                    qchannel=ac.qchannel,  # assigned to the quantum channel
                 ),
-                qchannel=req.qchannel,  # assigned to the quantum channel
-            ),
-            (None, None),
-        )
-        if qubit is None:
+                (None, None),
+            )
+
+        if mq is None:
             return False
 
-        log.debug(f"{self}: accept reservation key={req.key} src={req.from_node} addr={qubit.addr} path={qubit.path_id}")
-        qubit.state = QubitState.ACTIVE  # cannot go directly from RAW to RESERVED
-        qubit.state = QubitState.RESERVED
-        qubit.key = req.key
-        msg: ReserveMsg = {"cmd": "RESERVE_QUBIT_OK", "path_id": req.path_id, "key": req.key}
-        req.cchannel.send(ClassicPacket(msg, src=self.node, dest=req.from_node), next_hop=req.from_node)
+        log.debug(f"{self}: RESERVE_REQ({ac.partner.name}:{ap.path_id}, {key}) accepted addr={mq.addr}")
+        mq.state = QubitState.RESERVED
+        mq.key = key
+        msg = ReserveMsg(cmd="RESERVE_RES", key=key, path_id=ap.path_id)
+        self.node.send_cpacket(ac.partner, ClassicPacket(msg, src=self.node, dest=ac.partner))
         return True
 
-    def handle_reserve_res(self, msg: ReserveMsg):
+    @classic_cmd_handler("RESERVE_RES")
+    def handle_reserve_res(self, pkt: ClassicPacket, msg: ReserveMsg):
         """
-        Handle ``RESERVE_QUBIT_OK`` control messages received as a response to a reservation request.
-
-        1. Trigger the entanglement generation process using the reserved memory qubit.
+        Handle ``RESERVE_RES`` message from the secondary node.
         """
         key = msg["key"]
+        path_id = msg["path_id"]
+
         if not self.node.timing.is_external():
-            log.debug(f"{self}: ignore reservation response key={key} reason=not-external-phase")
+            log.debug(f"{self}: RESERVE_RES({pkt.src.name}:{path_id}, {key}) ignored reason=not-external-phase")
             return
 
-        (qchannel, next_hop, qubit) = self.pending_init_reservation.pop(key)
-        assert qubit.key == key
-        qubit.state = QubitState.RESERVED
-        self.generate_entanglement(qchannel, next_hop, qubit)
+        ac = self.channels.get(pkt.src.name)
+        if ac is None:
+            log.debug(f"{self}: RESERVE_RES({pkt.src.name}:{path_id}, {key}) ignored reason=no-active-channel")
+            return
+
+        ap = ac.paths.get(path_id)
+        if ap is None:
+            log.debug(f"{self}: RESERVE_RES({pkt.src.name}:{path_id}, {key}) ignored reason=no-active-path")
+            return
+
+        addr = ap.oreq_table.pop(key, None)
+        if addr is None:
+            log.debug(f"{self}: RESERVE_RES({pkt.src.name}:{path_id}, {key}) ignored reason=no-active-key")
+            return
+
+        mq, _ = self.memory.read(addr, must=True)
+        assert mq.key == key
+        mq.state = QubitState.RESERVED
+        log.debug(f"{self}: RESERVE_RES({pkt.src.name}:{path_id}, {key}) processed addr={mq.addr}")
+        self.generate_entanglement(ac.qchannel, ac.partner, mq)
 
     def generate_entanglement(self, qchannel: QuantumChannel, next_hop: QNode, qubit: MemoryQubit):
         """
@@ -419,14 +525,16 @@ class LinkLayer(Application[QNode]):
         # the EPR would not arrive in time, and therefore is not scheduled.
         if not self.node.timing.is_external(max(t_notify_a, t_notify_b)):
             log.debug(
-                f"{self}: skip prepare EPR {epr.name} key={key} dst={epr.dst} attempts={k} "
+                f"{self}: skip prepare EPR {epr.name} key={key} dst={next_hop.name} attempts={k} "
                 f"notify-times={t_notify_a},{t_notify_b} reason=beyond-external-phase"
             )
             return
 
         # If the network uses ASYNC timing mode or the successful attempt can complete within the current EXTERNAL phase,
         # schedule the EPR arrival on both nodes via LinkArchSuccessEvents.
-        log.debug(f"{self}: prepare EPR {epr.name} key={key} dst={epr.dst} attempts={k} notify-times={t_notify_a},{t_notify_b}")
+        log.debug(
+            f"{self}: prepare EPR {epr.name} key={key} dst={next_hop.name} attempts={k} notify-times={t_notify_a},{t_notify_b}"
+        )
 
         self.simulator.add_event(LinkArchSuccessEvent(self.node, key, epr, t=t_notify_a, attempts=k))
         self.simulator.add_event(LinkArchSuccessEvent(next_hop, key, epr, t=t_notify_b, attempts=k))
@@ -436,49 +544,43 @@ class LinkLayer(Application[QNode]):
         assert self.node.timing.is_external()
 
         epr = event.epr
-        neighbor, is_primary = (epr.dst, True) if epr.src == self.node else (epr.src, False)
-        assert neighbor is not None
+        partner, is_primary = (epr.dst, True) if epr.src == self.node else (epr.src, False)
+        assert partner is not None
         if is_primary:
             self.cnt.increment_n_etg(event.attempts)
 
-        qubit = self.memory.write(event.key, epr)
-        if qubit is None:
-            raise Exception(f"{self}: Failed to store EPR at key={event.key}")
+        mq = self.memory.write(event.key, epr)
 
         log.debug(
-            f"{self}: got half-EPR {epr.name} key={event.key} {'dst' if is_primary else 'src'}={neighbor} "
-            f"addr={qubit.addr} path={qubit.path_id}"
+            f"{self}: got half-EPR {epr.name} key={event.key} {'dst' if is_primary else 'src'}={partner} "
+            f"addr={mq.addr} path={mq.path_id}"
         )
         assert epr.decohere_time > self.simulator.tc
 
-        qubit.state = QubitState.ENTANGLED0
-        self.simulator.add_event(QubitEntangledEvent(self.node, neighbor, qubit, t=self.simulator.tc))
+        mq.state = QubitState.ENTANGLED0
+        self.simulator.add_event(QubitEntangledEvent(self.node, partner, mq, t=self.simulator.tc))
 
     @event_handler
-    def handle_release(self, event: QubitReleasedEvent) -> bool:
-        qubit = event.qubit
+    def handle_release(self, event: QubitReleasedEvent) -> None:
+        mq = event.qubit
         log.debug(f"{self}: {event}")
-        qubit.state = QubitState.RAW
+        mq.state = QubitState.RAW
 
-        assert qubit.qchannel is not None
-        ac = self.active_channels.get((qubit.qchannel, qubit.path_id))
+        assert mq.qchannel is not None
+        partner = mq.qchannel.find_peer(self.node)
 
-        if ac is None:  # secondary node
-            # If there is a pending reservation request, check if it can be accepted with the now vacated qubit.
-            if self.fifo_reservation_req and self.try_accept_reservation(self.fifo_reservation_req[0]):
-                # XXX If the released qubit is assigned to a different qchannel+path than the first reservation request,
-                #     try_accept_reservation() would not accept the reservation, resulting to unncessary choking.
-                # TODO Refactor fifo_reservation_req to consider qchannel+path.
-                #      Pass current qubit into try_accept_reservation() to reduce unnecesary searching.
-                self.fifo_reservation_req.popleft()
-            return True
+        ac = self.channels.get(partner.name)
+        if ac is None:
+            return
 
-        # primary node
-        if event.is_decoh:
-            self.cnt.n_decoh += 1
+        ap = ac.paths.get(mq.path_id)
+        if ap is None:
+            return
 
-        next_hop, _ = ac
-        if self.node.timing.is_async():
-            self.start_reservation(next_hop, qubit.qchannel, qubit)
-
-        return True
+        if ac.is_primary:
+            if event.is_decoh:
+                self.cnt.n_decoh += 1
+            if self.node.timing.is_async():
+                self.start_reservation(ac, mq)
+        elif ap.ireq_queue and self.try_accept_reservation(ac, ap, ap.ireq_queue[0], hint=mq):
+            ap.ireq_queue.popleft()

--- a/mqns/network/reactive/forwarder.py
+++ b/mqns/network/reactive/forwarder.py
@@ -19,7 +19,7 @@ from typing import override
 
 from mqns.network.fw import Forwarder
 from mqns.network.network import TimingPhase, TimingPhaseEvent
-from mqns.network.protocol.event import ManageActiveChannels
+from mqns.network.protocol.event import ManageActiveChannel
 from mqns.network.reactive.message import LinkStateEntry, LinkStateMsg
 from mqns.utils import log
 
@@ -46,18 +46,17 @@ class ReactiveForwarder(Forwarder):
         This may be called from install() or at the first EXTERNAL phase (for better coordination).
         """
         for ch in self.node.qchannels:
-            if self.node == ch.node_list[0]:  # self is the EPR initiator node for this channel
-                log.debug(f"{self}: activate qchannel {ch.name}")
-                self.simulator.add_event(
-                    ManageActiveChannels(
-                        self.node,
-                        ch.node_list[1],
-                        ch,
-                        path_id=None,
-                        start=True,
-                        t=self.simulator.tc,
-                    )
+            log.debug(f"{self}: activate qchannel {ch.name}")
+            self.simulator.add_event(
+                ManageActiveChannel(
+                    self.node,
+                    ch,
+                    path_id=None,
+                    start=True,
+                    is_primary=ch.node_list[0] is self.node,
+                    t=self.simulator.tc,
                 )
+            )
 
     @override
     def handle_sync_phase(self, event: TimingPhaseEvent):

--- a/tests/entity/test_memory.py
+++ b/tests/entity/test_memory.py
@@ -33,7 +33,7 @@ class TwoNodes:
     def make_epr(self, name: str) -> WernerStateEntanglement:
         return WernerStateEntanglement(
             name=name,
-            decohere_time=self.s.tc + self.m1.t_decohere,
+            decohere_time=self.s.tc + self.m1.t_cohere,
             fidelity_time=self.s.tc,
             src=self.n1,
             dst=self.n2,

--- a/tests/entity/test_memory.py
+++ b/tests/entity/test_memory.py
@@ -128,12 +128,25 @@ def test_memory_clear_and_deallocate():
     assert mem.count == 0
 
     # Test deallocate
-    addrs = mem.allocate(scenario.qc, 7, PathDirection.L)
-    assert len(addrs) == 1
-    addr = addrs[0]
-    mem.deallocate(addr)
+    addrs = mem.allocate(scenario.qc, 7, PathDirection.L, n=2)
+    assert len(addrs) == 2
+
+    q0, _ = mem.read(addrs[0], must=True)
+    q1, _ = mem.read(addrs[1], must=True)
+    assert q0.addr != q1.addr
+    assert q0.path_id == 7
+    assert q1.path_id == 7
+    q0.state = QubitState.ACTIVE
+
+    mem.deallocate(*addrs)
+    assert q0.path_id == 7
+    assert q1.path_id is None
+
+    q0.state = QubitState.RAW
+    assert q0.path_id is None
+
     with pytest.raises(LookupError):
-        mem.deallocate(999)  # invalid
+        mem.deallocate(999)  # out of range
 
 
 def test_qubit_reservation_behavior():

--- a/tests/fw/fw_common.py
+++ b/tests/fw/fw_common.py
@@ -321,7 +321,7 @@ _provide_entanglements_autoid = AutoIncrementIdentifier("Tpe_")
 
 
 def provide_entanglements(
-    *etgs: tuple[float, Forwarder, Forwarder] | tuple[Iterable[float], Iterable[Forwarder]],
+    *etgs: tuple[float | Iterable[float], Forwarder, Forwarder] | tuple[Iterable[float], Iterable[Forwarder]],
     transform_t: Callable[[float], float] = lambda t: t,
     fidelity=0.99,
 ):
@@ -377,7 +377,12 @@ def provide_entanglements(
 
     for etg in etgs:
         if len(etg) == 3:
-            sched_entangle(*etg)
+            times, src, dst = etg
+            if isinstance(times, int | float):
+                sched_entangle(times, src, dst)
+            else:
+                for t in times:
+                    sched_entangle(t, src, dst)
         else:
             times, fws = etg
             for t, (src, dst) in zip(times, itertools.pairwise(fws), strict=True):

--- a/tests/fw/fw_common.py
+++ b/tests/fw/fw_common.py
@@ -382,16 +382,3 @@ def provide_entanglements(
             times, fws = etg
             for t, (src, dst) in zip(times, itertools.pairwise(fws), strict=True):
                 sched_entangle(t, src, dst)
-
-
-def check_memory_released(net: QuantumNetwork) -> None:
-    """
-    Verify that all MemoryQubits on every node are in RAW or RELEASED state.
-    """
-    errors: list[str] = []
-    for node in net.nodes:
-        for qubit, data in node.memory.find(lambda *_: True):
-            if qubit.state not in (QubitState.RAW, QubitState.RELEASE):
-                errors.append(f"{node.name}:{qubit.addr} unexpected state {qubit.state}: {data}")
-    if len(errors) > 0:
-        raise AssertionError(errors)

--- a/tests/fw/fw_common.py
+++ b/tests/fw/fw_common.py
@@ -352,7 +352,7 @@ def provide_entanglements(
 
         ll_key = _provide_entanglements_autoid()
         epr = src.network.epr_type(
-            decohere_time=t_creation + min(src.memory.t_decohere, dst.memory.t_decohere),
+            decohere_time=t_creation + min(src.memory.t_cohere, dst.memory.t_cohere),
             fidelity_time=t_creation,
             src=src.node,
             dst=dst.node,

--- a/tests/fw/test_p_integ.py
+++ b/tests/fw/test_p_integ.py
@@ -37,14 +37,11 @@ def test_4_swap(epr_type: type[Entanglement], timing: TimingMode, swap: SwapSequ
     assert RequestCounters.of(net, rp).n_consumed >= 16
 
 
-def test_rect_uninstall_path():
-    """Test uninstall_path in rectangle topology."""
-    net, simulator = build_rect_network(swap_table_leak_tol=256, has_link_layer=True)
-    fwB = net.get_node("B").get_app(ProactiveForwarder)
-    fwC = net.get_node("C").get_app(ProactiveForwarder)
-    llA = net.get_node("A").get_app(LinkLayer)
-    llB = net.get_node("B").get_app(LinkLayer)
-    llC = net.get_node("C").get_app(LinkLayer)
+def test_rect2_uninstall_path():
+    """Test uninstall_path in 2x2 rectangle topology."""
+    net, simulator = build_rect_network(t_cohere=1.0, has_link_layer=True)
+    _, fwB, fwC, _ = (node.get_app(ProactiveForwarder) for node in net.nodes)
+    llA, llB, llC, _ = (node.get_app(LinkLayer) for node in net.nodes)
 
     counters: list[tuple[int, int, int, int, int]] = []
 

--- a/tests/fw/test_p_integ.py
+++ b/tests/fw/test_p_integ.py
@@ -4,6 +4,7 @@ Test suite for ProactiveForwarder integrated with LinkLayer.
 
 import pytest
 
+from mqns.entity.memory import QuantumMemory
 from mqns.entity.timer import Timer
 from mqns.models.epr import Entanglement, MixedStateEntanglement, WernerStateEntanglement
 from mqns.network.fw import RoutingPathSingle, RoutingPathStatic, SwapSequenceInput
@@ -74,3 +75,5 @@ def test_rect2_uninstall_path():
     # llA.cnt.n_attempts
     assert counters[0][4] == counters[1][4]
     assert counters[8][4] == counters[9][4]
+
+    QuantumMemory.check_leaks(net.nodes)

--- a/tests/fw/test_p_purif.py
+++ b/tests/fw/test_p_purif.py
@@ -2,14 +2,15 @@
 Test suite for ProactiveForwarder focused on purification.
 """
 
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Mapping, Sequence
 
 import pytest
 
-from mqns.entity.memory import QuantumMemory
+from mqns.entity.memory import MemoryQubit, PathDirection, QuantumMemory, QubitState
 from mqns.network.fw import RoutingPathStatic
 from mqns.network.proactive import ProactiveForwarder
 from mqns.network.protocol.consumer import RequestCounters
+from mqns.simulator import Time
 from mqns.utils import rng
 
 from .fw_common import (
@@ -76,21 +77,25 @@ def test_link_rounds(monkeypatch: pytest.MonkeyPatch, n_rounds: int, purif_succe
     assert RequestCounters.of(net, rp).n_consumed == n_eligible
 
 
-xfail_uninstall = pytest.mark.xfail(reason="UNINSTALL_PATH cleanup not implemented", strict=True)
+xfail_memory = pytest.mark.xfail(reason="UNINSTALL_PATH cleanup not implemented", raises=MemoryError, strict=True)
+_3u_purif = ([1.0000, 1.0010], []), -1, {"A-B": 1}, ([1.0025], [1.0020], [], [])
+_3u_purif_swap = ([1.0000, 1.0010], [1.0000]), *_3u_purif[1:-1], ([1.0025, 1.2035], [1.0020, 1.2030], [1.2030], [1.2035])
+_3u_cutoff = ([1.0000], []), 0.004, {}, ([1.0055], [1.0050], [], [])
+_3u_swap = ([1.0000], [1.0100]), -1, {}, ([1.2115], [1.2110], [1.2110], [1.2115])
 
 
 @pytest.mark.parametrize(
-    ("t_uninstall", "etg_sec", "cutoff", "purif"),
+    ("t_uninstall", "etg_sec", "cutoff", "purif", "t_raw"),
     [
         # 1. t=1.0010, A-B.0 arrives.
         # 2. t=1.0020, A-B.1 arrives, B sends PURIF_SOLICIT, which would arrive at 1.0025.
         # 3. t=1.0022, path is uninstalled.
-        pytest.param(1.0022, ([1.0000, 1.0010], []), -1, {"A-B": 1}, id="purif-solicit", marks=xfail_uninstall),
+        pytest.param(1.0022, *_3u_purif, id="purif-solicit", marks=xfail_memory),
         # 1. t=1.0010, A-B.0 arrives.
         # 2. t=1.0020, A-B.1 arrives, B sends PURIF_SOLICIT.
         # 3. t=1.0025, A receives PURIF_SOLICIT and sends PURIF_RESPONSE, which would arrive at 1.0030.
         # 4. t=1.0027, path is uninstalled.
-        pytest.param(1.0027, ([1.0000, 1.0010], []), -1, {"A-B": 1}, id="purif-response", marks=xfail_uninstall),
+        pytest.param(1.0027, *_3u_purif, id="purif-response", marks=xfail_memory),
         # 1. t=1.0010, A-B.0 arrives, B-C arrives.
         # 2. t=1.0020, A-B.1 arrives, B sends PURIF_SOLICIT.
         # 3. t=1.0025, A receives PURIF_SOLICIT and sends PURIF_RESPONSE.
@@ -98,55 +103,85 @@ xfail_uninstall = pytest.mark.xfail(reason="UNINSTALL_PATH cleanup not implement
         # 5. t=1.2030, B finishes swapping and sends SWAP_UPDATE.
         # 6. t=1.2035, A and C process SWAP_UPDATE message.
         # 7. t=1.2037, path is uninstalled.
-        pytest.param(1.2037, ([1.0000, 1.0010], [1.0000]), -1, {"A-B": 1}, id="purif-complete"),
+        pytest.param(1.2037, *_3u_purif_swap, id="purif-complete"),
         # 1. t=1.0010, A-B arrives, discard scheduled at 1.0050.
         # 2. t=1.0012, path is uninstalled.
-        pytest.param(1.0012, ([1.0000], []), 0.004, {}, id="cutoff-waiting"),
+        # 3. t=1.0050, B discards A-B and sends CUTOFF_DISCARD to A.
+        # 4. t=1.0055, A processes CUTOFF_DISCARD message.
+        pytest.param(1.0012, *_3u_cutoff, id="cutoff-waiting"),
         # 1. t=1.0010, A-B arrives, discard scheduled at 1.0050.
-        # 2. t=1.0050, B discards A-B and sends CUTOFF_DISCARD message to A, which would arrive at 1.0055.
+        # 2. t=1.0050, B discards A-B and sends CUTOFF_DISCARD to A.
         # 3. t=1.0052, path is uninstalled.
-        pytest.param(1.0052, ([1.0000], []), 0.004, {}, id="cutoff-inflight"),
+        # 4. t=1.0055, A processes CUTOFF_DISCARD message.
+        pytest.param(1.0052, *_3u_cutoff, id="cutoff-inflight"),
         # 1. t=1.0010, A-B arrives, discard scheduled at 1.0050.
-        # 2. t=1.0050, B discards A-B and sends CUTOFF_DISCARD message to A.
-        # 3. t=1.0055, A processes CUTOFF_DISCARD MESSAGE.
+        # 2. t=1.0050, B discards A-B and sends CUTOFF_DISCARD to A.
+        # 3. t=1.0055, A processes CUTOFF_DISCARD message.
         # 4. t=1.0057, path is uninstalled.
-        pytest.param(1.0057, ([1.0000], []), 0.004, {}, id="cutoff-complete"),
+        pytest.param(1.0057, *_3u_cutoff, id="cutoff-complete"),
         # 1. t=1.0010, A-B arrives.
-        # 2. t=1.0110, B-C arrives, B starts swapping, which would finish at 1.2110.
+        # 2. t=1.0110, B-C arrives, B starts swapping.
         # 3. t=1.1000, path is uninstalled.
-        pytest.param(1.1000, ([1.0000], [1.0100]), -1, {}, id="swap-waiting"),
+        # 4. t=1.2110, B aborts the swap and sends SWAP_UPDATE.
+        # 5. t=1.2115, A and C process SWAP_UPDATE message.
+        pytest.param(1.1000, *_3u_swap, id="swap-waiting"),
         # 1. t=1.0010, A-B arrives.
         # 2. t=1.0110, B-C arrives, B starts swapping.
-        # 3. t=1.2110, B finishes swapping and sends SWAP_UPDATE to A and C, which would arrive at 1.2115.
+        # 3. t=1.2110, B finishes swapping and sends SWAP_UPDATE.
         # 4. t=1.2112, path is uninstalled.
-        pytest.param(1.2112, ([1.0000], [1.0100]), -1, {}, id="swap-inflight"),
+        # 5. t=1.2115, A and C process SWAP_UPDATE message.
+        pytest.param(1.2112, *_3u_swap, id="swap-inflight"),
         # 1. t=1.0010, A-B arrives.
         # 2. t=1.0110, B-C arrives, B starts swapping.
-        # 3. t=1.2110, B finishes swapping and sends SWAP_UPDATE to A and C.
+        # 3. t=1.2110, B finishes swapping and sends SWAP_UPDATE.
         # 4. t=1.2115, A and C process SWAP_UPDATE message.
         # 4. t=1.2117, path is uninstalled.
-        pytest.param(1.2117, ([1.0000], [1.0100]), -1, {}, id="swap-complete"),
+        pytest.param(1.2117, *_3u_swap, id="swap-complete"),
     ],
 )
 def test_3_uninstall(
+    monkeypatch: pytest.MonkeyPatch,
     t_uninstall: float,
     etg_sec: tuple[Iterable[float], Iterable[float]],
     cutoff: float,
     purif: Mapping[str, int],
+    t_raw: tuple[Sequence[float], ...],
 ):
     """Test UNINSTALL_PATH cleanup during cut-off/swap/purify on 3-node topology."""
     net, simulator = build_linear_network(3, t_cohere=5.0, ch_capacity=2, fw={"p_swap": 1.0, "swap_delay": 0.2}, end_time=5.0)
+    chAB = net.get_qchannel("A", "B")
+    chBC = net.get_qchannel("B", "C")
     fwA, fwB, fwC = (node.get_app(ProactiveForwarder) for node in net.nodes)
 
-    install_path(net, RoutingPathStatic("ABC", swap_cutoff=[cutoff, -1], purif=purif), t_uninstall=t_uninstall)
+    install_path(net, RoutingPathStatic("ABC", path_id=0, swap_cutoff=[cutoff, -1], purif=purif), t_uninstall=t_uninstall)
     provide_entanglements(
         (etg_sec[0], fwA, fwB),
         (etg_sec[1], fwB, fwC),
     )
 
+    mq_reset_state_old = MemoryQubit.reset_state
+    reset_times = [list[Time]() for _ in range(4)]
+
+    def mq_reset_state_new(self: MemoryQubit, state: QubitState) -> None:
+        nonlocal chAB, chBC
+        if self.path_id == 0 and state is QubitState.RAW:
+            match self.path_direction:
+                case PathDirection.R if self.qchannel is chAB:
+                    reset_times[0].append(simulator.tc)
+                case PathDirection.L if self.qchannel is chAB:
+                    reset_times[1].append(simulator.tc)
+                case PathDirection.R if self.qchannel is chBC:
+                    reset_times[2].append(simulator.tc)
+                case PathDirection.L if self.qchannel is chBC:
+                    reset_times[3].append(simulator.tc)
+        mq_reset_state_old(self, state)
+
+    monkeypatch.setattr(MemoryQubit, "reset_state", mq_reset_state_new)
+
     simulator.run()
     print_node_counters(net)
     QuantumMemory.check_leaks(net.nodes, deallocated=True)
+    assert reset_times == list(list(simulator.time(sec=t) for t in mqt) for mqt in t_raw)
 
 
 def test_4_l2r(monkeypatch: pytest.MonkeyPatch):

--- a/tests/fw/test_p_purif.py
+++ b/tests/fw/test_p_purif.py
@@ -2,9 +2,12 @@
 Test suite for ProactiveForwarder focused on purification.
 """
 
+from collections.abc import Iterable, Mapping
+
 import pytest
 
-from mqns.network.fw import RoutingPathSingle
+from mqns.entity.memory import QuantumMemory
+from mqns.network.fw import RoutingPathStatic
 from mqns.network.proactive import ProactiveForwarder
 from mqns.network.protocol.consumer import RequestCounters
 from mqns.utils import rng
@@ -57,7 +60,7 @@ def test_link_rounds(monkeypatch: pytest.MonkeyPatch, n_rounds: int, purif_succe
     fwA = net.get_node("A").get_app(ProactiveForwarder)
     fwB = net.get_node("B").get_app(ProactiveForwarder)
 
-    rp = install_path(net, RoutingPathSingle("A", "B", swap=[0, 0], purif={"A-B": n_rounds}))
+    rp = install_path(net, RoutingPathStatic("AB", swap=[0, 0], purif={"A-B": n_rounds}))
     provide_entanglements(*((1.001 + i / 1000, fwA, fwB) for i in range(n_etg)))
     force_purify_outcome(monkeypatch, *(True if i > 0 else False for i in purif_success))
     simulator.run()
@@ -73,6 +76,79 @@ def test_link_rounds(monkeypatch: pytest.MonkeyPatch, n_rounds: int, purif_succe
     assert RequestCounters.of(net, rp).n_consumed == n_eligible
 
 
+xfail_uninstall = pytest.mark.xfail(reason="UNINSTALL_PATH cleanup not implemented", strict=True)
+
+
+@pytest.mark.parametrize(
+    ("t_uninstall", "etg_sec", "cutoff", "purif"),
+    [
+        # 1. t=1.0010, A-B.0 arrives.
+        # 2. t=1.0020, A-B.1 arrives, B sends PURIF_SOLICIT, which would arrive at 1.0025.
+        # 3. t=1.0022, path is uninstalled.
+        pytest.param(1.0022, ([1.0000, 1.0010], []), -1, {"A-B": 1}, id="purif-solicit", marks=xfail_uninstall),
+        # 1. t=1.0010, A-B.0 arrives.
+        # 2. t=1.0020, A-B.1 arrives, B sends PURIF_SOLICIT.
+        # 3. t=1.0025, A receives PURIF_SOLICIT and sends PURIF_RESPONSE, which would arrive at 1.0030.
+        # 4. t=1.0027, path is uninstalled.
+        pytest.param(1.0027, ([1.0000, 1.0010], []), -1, {"A-B": 1}, id="purif-response", marks=xfail_uninstall),
+        # 1. t=1.0010, A-B.0 arrives, B-C arrives.
+        # 2. t=1.0020, A-B.1 arrives, B sends PURIF_SOLICIT.
+        # 3. t=1.0025, A receives PURIF_SOLICIT and sends PURIF_RESPONSE.
+        # 4. t=1.0030, B receives PURIF_RESPONSE and starts swapping.
+        # 5. t=1.2030, B finishes swapping and sends SWAP_UPDATE.
+        # 6. t=1.2035, A and C process SWAP_UPDATE message.
+        # 7. t=1.2037, path is uninstalled.
+        pytest.param(1.2037, ([1.0000, 1.0010], [1.0000]), -1, {"A-B": 1}, id="purif-complete"),
+        # 1. t=1.0010, A-B arrives, discard scheduled at 1.0050.
+        # 2. t=1.0012, path is uninstalled.
+        pytest.param(1.0012, ([1.0000], []), 0.004, {}, id="cutoff-waiting", marks=xfail_uninstall),
+        # 1. t=1.0010, A-B arrives, discard scheduled at 1.0050.
+        # 2. t=1.0050, B discards A-B and sends CUTOFF_DISCARD message to A, which would arrive at 1.0055.
+        # 3. t=1.0052, path is uninstalled.
+        pytest.param(1.0052, ([1.0000], []), 0.004, {}, id="cutoff-inflight", marks=xfail_uninstall),
+        # 1. t=1.0010, A-B arrives, discard scheduled at 1.0050.
+        # 2. t=1.0050, B discards A-B and sends CUTOFF_DISCARD message to A.
+        # 3. t=1.0055, A processes CUTOFF_DISCARD MESSAGE.
+        # 4. t=1.0057, path is uninstalled.
+        pytest.param(1.0057, ([1.0000], []), 0.004, {}, id="cutoff-complete"),
+        # 1. t=1.0010, A-B arrives.
+        # 2. t=1.0110, B-C arrives, B starts swapping, which would finish at 1.2110.
+        # 3. t=1.1000, path is uninstalled.
+        pytest.param(1.1000, ([1.0000], [1.0100]), -1, {}, id="swap-waiting", marks=xfail_uninstall),
+        # 1. t=1.0010, A-B arrives.
+        # 2. t=1.0110, B-C arrives, B starts swapping.
+        # 3. t=1.2110, B finishes swapping and sends SWAP_UPDATE to A and C, which would arrive at 1.2115.
+        # 4. t=1.2112, path is uninstalled.
+        pytest.param(1.2112, ([1.0000], [1.0100]), -1, {}, id="swap-inflight", marks=xfail_uninstall),
+        # 1. t=1.0010, A-B arrives.
+        # 2. t=1.0110, B-C arrives, B starts swapping.
+        # 3. t=1.2110, B finishes swapping and sends SWAP_UPDATE to A and C.
+        # 4. t=1.2115, A and C process SWAP_UPDATE message.
+        # 4. t=1.2117, path is uninstalled.
+        pytest.param(1.2117, ([1.0000], [1.0100]), -1, {}, id="swap-complete"),
+    ],
+)
+def test_3_uninstall(
+    t_uninstall: float,
+    etg_sec: tuple[Iterable[float], Iterable[float]],
+    cutoff: float,
+    purif: Mapping[str, int],
+):
+    """Test UNINSTALL_PATH cleanup during cut-off/swap/purify on 3-node topology."""
+    net, simulator = build_linear_network(3, t_cohere=5.0, ch_capacity=2, fw={"p_swap": 1.0, "swap_delay": 0.2}, end_time=5.0)
+    fwA, fwB, fwC = (node.get_app(ProactiveForwarder) for node in net.nodes)
+
+    install_path(net, RoutingPathStatic("ABC", swap_cutoff=[cutoff, -1], purif=purif), t_uninstall=t_uninstall)
+    provide_entanglements(
+        (etg_sec[0], fwA, fwB),
+        (etg_sec[1], fwB, fwC),
+    )
+
+    simulator.run()
+    print_node_counters(net)
+    QuantumMemory.check_leaks(net.nodes, deallocated=True)
+
+
 def test_4_l2r(monkeypatch: pytest.MonkeyPatch):
     """Test multi-segment purification on 4-node topology with l2r swapping order."""
     net, simulator = build_linear_network(4, ch_capacity=8, fw={"p_swap": 1.0})
@@ -80,7 +156,7 @@ def test_4_l2r(monkeypatch: pytest.MonkeyPatch):
 
     rp = install_path(
         net,
-        RoutingPathSingle("A", "D", swap=[2, 0, 1, 2], purif={"A-B": 1, "B-C": 1, "C-D": 1, "A-C": 1, "A-D": 1}),
+        RoutingPathStatic("ABCD", swap=[2, 0, 1, 2], purif={"A-B": 1, "B-C": 1, "C-D": 1, "A-C": 1, "A-D": 1}),
     )
     provide_entanglements(
         (1.001, fwA, fwB),  # \

--- a/tests/fw/test_p_purif.py
+++ b/tests/fw/test_p_purif.py
@@ -101,11 +101,11 @@ xfail_uninstall = pytest.mark.xfail(reason="UNINSTALL_PATH cleanup not implement
         pytest.param(1.2037, ([1.0000, 1.0010], [1.0000]), -1, {"A-B": 1}, id="purif-complete"),
         # 1. t=1.0010, A-B arrives, discard scheduled at 1.0050.
         # 2. t=1.0012, path is uninstalled.
-        pytest.param(1.0012, ([1.0000], []), 0.004, {}, id="cutoff-waiting", marks=xfail_uninstall),
+        pytest.param(1.0012, ([1.0000], []), 0.004, {}, id="cutoff-waiting"),
         # 1. t=1.0010, A-B arrives, discard scheduled at 1.0050.
         # 2. t=1.0050, B discards A-B and sends CUTOFF_DISCARD message to A, which would arrive at 1.0055.
         # 3. t=1.0052, path is uninstalled.
-        pytest.param(1.0052, ([1.0000], []), 0.004, {}, id="cutoff-inflight", marks=xfail_uninstall),
+        pytest.param(1.0052, ([1.0000], []), 0.004, {}, id="cutoff-inflight"),
         # 1. t=1.0010, A-B arrives, discard scheduled at 1.0050.
         # 2. t=1.0050, B discards A-B and sends CUTOFF_DISCARD message to A.
         # 3. t=1.0055, A processes CUTOFF_DISCARD MESSAGE.
@@ -114,12 +114,12 @@ xfail_uninstall = pytest.mark.xfail(reason="UNINSTALL_PATH cleanup not implement
         # 1. t=1.0010, A-B arrives.
         # 2. t=1.0110, B-C arrives, B starts swapping, which would finish at 1.2110.
         # 3. t=1.1000, path is uninstalled.
-        pytest.param(1.1000, ([1.0000], [1.0100]), -1, {}, id="swap-waiting", marks=xfail_uninstall),
+        pytest.param(1.1000, ([1.0000], [1.0100]), -1, {}, id="swap-waiting"),
         # 1. t=1.0010, A-B arrives.
         # 2. t=1.0110, B-C arrives, B starts swapping.
         # 3. t=1.2110, B finishes swapping and sends SWAP_UPDATE to A and C, which would arrive at 1.2115.
         # 4. t=1.2112, path is uninstalled.
-        pytest.param(1.2112, ([1.0000], [1.0100]), -1, {}, id="swap-inflight", marks=xfail_uninstall),
+        pytest.param(1.2112, ([1.0000], [1.0100]), -1, {}, id="swap-inflight"),
         # 1. t=1.0010, A-B arrives.
         # 2. t=1.0110, B-C arrives, B starts swapping.
         # 3. t=1.2110, B finishes swapping and sends SWAP_UPDATE to A and C.

--- a/tests/fw/test_p_swap.py
+++ b/tests/fw/test_p_swap.py
@@ -7,6 +7,7 @@ from collections.abc import Sequence
 
 import pytest
 
+from mqns.entity.memory import QuantumMemory
 from mqns.entity.timer import Timer
 from mqns.models.delay import ConstantDelayModel
 from mqns.models.epr import Entanglement, MixedStateEntanglement
@@ -34,7 +35,6 @@ from .fw_common import (
     build_rect_network,
     build_tree_network,
     check_fw_counters,
-    check_memory_released,
     collect_cpacket_counts,
     install_path,
     print_node_counters,
@@ -287,7 +287,7 @@ def test_4_asap(ps3: int, etg_ms: tuple[int, int, int]):
             n_su_lower=(1, 0, 0, 1),
         )
         assert RequestCounters.of(net, rp).n_consumed == 0
-    check_memory_released(net)
+    QuantumMemory.check_leaks(net.nodes)
 
 
 @pytest.mark.parametrize(
@@ -385,7 +385,7 @@ def test_4_delayed(
     cpacket_cnt = collect_cpacket_counts(monkeypatch)
     simulator.run()
     print_node_counters(net)
-    check_memory_released(net)
+    QuantumMemory.check_leaks(net.nodes)
     print("cpacket_cnt", cpacket_cnt)
 
     assert fwB_n_swapped_values == [0, 0, 0, 0, 0, n_swap2, n_swap2, n_swap2]
@@ -445,7 +445,7 @@ def test_4_decohere(swap_delay: float, n_consumed: int):
         n_su_lower=(1, 0, 0, 1),
     )
     assert RequestCounters.of(net, rp).n_consumed == n_consumed
-    check_memory_released(net)
+    QuantumMemory.check_leaks(net.nodes)
 
 
 @pytest.mark.parametrize("ps3", [1, 0])
@@ -476,7 +476,7 @@ def test_5_asap(
         n_su_lower=(1, 0, 0, 0, 1),
     )
     assert RequestCounters.of(net, rp).n_consumed == n_consumed
-    check_memory_released(net)
+    QuantumMemory.check_leaks(net.nodes)
 
 
 @pytest.mark.parametrize(
@@ -569,7 +569,7 @@ def test_5_decohere(
     #     n_su_lower=(1, 0, 0, 0, 1),
     # )
     assert RequestCounters.of(net, rp).n_consumed == n_consumed
-    check_memory_released(net)
+    QuantumMemory.check_leaks(net.nodes)
     assert list(node.get_app(QubitReleaseReset).last_t for node in net.nodes[: len(t_release)]) == [
         simulator.time(sec=t) for t in t_release
     ]
@@ -742,7 +742,7 @@ def test_tree2_statistical(
     print_node_counters(net)
     if -1 in etg_ms:
         # For test cases without unused EPRs, swap conflict should release memory quickly.
-        check_memory_released(net)
+        QuantumMemory.check_leaks(net.nodes)
 
     assert RequestCounters.of(net, rp0).n_consumed == n_consumed[0]
     assert RequestCounters.of(net, rp1).n_consumed == n_consumed[1]

--- a/tests/protocol/test_link_layer.py
+++ b/tests/protocol/test_link_layer.py
@@ -11,7 +11,7 @@ from mqns.models.epr import (
     WernerStateEntanglement,
 )
 from mqns.network.network import QuantumNetwork, TimingModeSync
-from mqns.network.protocol.event import ManageActiveChannels, QubitEntangledEvent, QubitReleasedEvent
+from mqns.network.protocol.event import ManageActiveChannel, QubitEntangledEvent, QubitReleasedEvent
 from mqns.network.protocol.link_layer import LinkLayer, LinkLayerCounters
 from mqns.network.topology import ClassicTopology, CustomTopology, LinearTopology
 from mqns.simulator import Simulator, event_handler
@@ -55,16 +55,12 @@ class NetworkLayer(Application[QNode]):
         self.simulator.add_event(QubitReleasedEvent(self.node, event.qubit, is_decoh=True, t=event.t))
 
 
-def manage_active_channel(simulator: Simulator, t: float, src: NetworkLayer, dst: NetworkLayer, *, stop=False):
-    simulator.add_event(
-        ManageActiveChannels(
-            src.node,
-            dst.node,
-            src.node.get_qchannel(dst.node),
-            start=not stop,
-            t=simulator.time(sec=t),
-        )
-    )
+def manage_active_channel(t: float, src: NetworkLayer, dst: NetworkLayer, *, start=True):
+    simulator = src.simulator
+    ch = src.node.get_qchannel(dst.node)
+    time = simulator.time(sec=t)
+    simulator.add_event(ManageActiveChannel(src.node, ch, path_id=None, start=start, is_primary=True, t=time))
+    simulator.add_event(ManageActiveChannel(dst.node, ch, path_id=None, start=start, is_primary=False, t=time))
 
 
 @pytest.mark.parametrize(
@@ -88,12 +84,10 @@ def test_basic(epr_type: type[Entanglement]):
 
     s = Simulator(0.0, 20.0, install_to=(log, net))
 
-    ll1 = net.get_node("n1").get_app(LinkLayer)
-    ll2 = net.get_node("n2").get_app(LinkLayer)
-    nl1 = net.get_node("n1").get_app(NetworkLayer)
-    nl2 = net.get_node("n2").get_app(NetworkLayer)
-    manage_active_channel(s, 0.5, nl1, nl2)
-    manage_active_channel(s, 8.4, nl1, nl2, stop=True)
+    ll1, ll2 = (node.get_app(LinkLayer) for node in net.nodes)
+    nl1, nl2 = (node.get_app(NetworkLayer) for node in net.nodes)
+    manage_active_channel(0.5, nl1, nl2)
+    manage_active_channel(8.8, nl1, nl2, start=False)
     nl1.release_after = 2.9
     nl2.release_after = 3.2
 
@@ -103,29 +97,29 @@ def test_basic(epr_type: type[Entanglement]):
         print(ll.node.name, ll.cnt, nl.entangle, nl.decohere)
         assert len(nl.entangle) == 3
         assert len(nl.decohere) == 2
-        # t=0.5, n1 installs path
-        # t=0.5, n1 sends RESERVE_QUBIT
-        # t=0.6, n2 receives RESERVE_QUBIT and sends RESERVE_QUBIT_OK
-        # t=0.7, n1 receives RESERVE_QUBIT_OK
+        # t=0.5, path is installed with n1 as primary and n2 as secondary
+        # t=0.5, n1 sends RESERVE_REQ
+        # t=0.6, n2 receives RESERVE_REQ and sends RESERVE_RES
+        # t=0.7, n1 receives RESERVE_RES
         # t=0.9, entanglement established
         # t=0.7 is assumed time of entanglement creation
         assert nl.entangle[0] == pytest.approx((0.9, 0.7), abs=1e-3)
-        # t=3.8, n1 releases qubit and sends RESERVE_QUBIT
-        # t=3.9, n2 receives RESERVE_QUBIT but has no qubit available
-        # t=4.1, n2 releases qubit and sends RESERVE_QUBIT_OK
-        # t=4.2, n1 receives RESERVE_QUBIT_OK
+        # t=3.8, n1 releases qubit and sends RESERVE_REQ
+        # t=3.9, n2 receives RESERVE_REQ but has no qubit available
+        # t=4.1, n2 releases qubit and sends RESERVE_RES
+        # t=4.2, n1 receives RESERVE_RES
         # t=4.4, entanglement established
         # t=4.2 is assumed time of entanglement creation
         assert nl.entangle[1] == pytest.approx((4.4, 4.2), abs=1e-3)
         # t=8.3, qubits decohered 4.1 seconds since entanglement creation
         assert nl.decohere[0] == pytest.approx(8.3, abs=1e-3)
-        # t=8.3, n1 sends RESERVE_QUBIT
-        # t=8.4, n1 uninstalls path, but this does not affect ongoing reservation
-        # t=8.4, n2 receives RESERVE_QUBIT and sends RESERVE_QUBIT_OK
-        # t=8.5, n1 receives RESERVE_QUBIT_OK
+        # t=8.3, n1 sends RESERVE_REQ
+        # t=8.4, n2 receives RESERVE_REQ and sends RESERVE_RES
+        # t=8.5, n1 receives RESERVE_RES
         # t=8.7, entanglement established
         # t=8.5 is assumed time of entanglement creation
         assert nl.entangle[2] == pytest.approx((8.7, 8.5), abs=1e-3)
+        # t=8.8, path is uninstalled
         # t=12.6, qubits decohered 4.1 seconds since entanglement creation
         assert nl.decohere[1] == pytest.approx(12.6, abs=1e-3)
         # no more entanglements because the path has been uninstalled
@@ -155,11 +149,9 @@ def test_skip_ahead():
 
     simulator = Simulator(0.0, 10.0, install_to=(log, net))
 
-    ll1 = net.get_node("n1").get_app(LinkLayer)
-    ll2 = net.get_node("n2").get_app(LinkLayer)
-    nl1 = net.get_node("n1").get_app(NetworkLayer)
-    nl2 = net.get_node("n2").get_app(NetworkLayer)
-    manage_active_channel(simulator, 0.5, nl1, nl2)
+    ll1, ll2 = (node.get_app(LinkLayer) for node in net.nodes)
+    nl1, nl2 = (node.get_app(NetworkLayer) for node in net.nodes)
+    manage_active_channel(0.5, nl1, nl2)
 
     simulator.run()
 
@@ -197,15 +189,12 @@ def test_timing_mode_sync():
 
     simulator = Simulator(0.0, 10.0, install_to=(log, net))
 
-    nl0 = net.get_node("n0").get_app(NetworkLayer)
-    nl1 = net.get_node("n1").get_app(NetworkLayer)
-    nl2 = net.get_node("n2").get_app(NetworkLayer)
-    nl3 = net.get_node("n3").get_app(NetworkLayer)
-    manage_active_channel(simulator, 0.1, nl0, nl1)
-    manage_active_channel(simulator, 0.1, nl2, nl3)  # n=1, start entanglements
-    manage_active_channel(simulator, 1.1, nl2, nl3)  # n=2, no change
-    manage_active_channel(simulator, 4.1, nl2, nl3, stop=True)  # n=1, no change
-    manage_active_channel(simulator, 5.1, nl2, nl3, stop=True)  # n=0, stop entanglements
+    nl0, nl1, nl2, nl3 = (node.get_app(NetworkLayer) for node in net.nodes)
+    manage_active_channel(0.1, nl0, nl1)
+    manage_active_channel(0.1, nl2, nl3)  # insertion_count=1, start entanglements
+    manage_active_channel(1.1, nl2, nl3)  # insertion_count=2, no change
+    manage_active_channel(4.1, nl2, nl3, start=False)  # insertion_count=1, no change
+    manage_active_channel(5.9, nl2, nl3, start=False)  # insertion_count=0, stop entanglements
 
     simulator.run()
 

--- a/tests/protocol/test_link_layer.py
+++ b/tests/protocol/test_link_layer.py
@@ -35,7 +35,7 @@ class NetworkLayer(Application[QNode]):
     def handle_entangle(self, event: QubitEntangledEvent):
         mq, epr = self.memory.read(event.qubit.addr, has=self.epr_type)
         assert mq is event.qubit
-        t_create = epr.decohere_time - self.memory.t_decohere
+        t_create = epr.decohere_time - self.memory.t_cohere
         self.entangle.append((event.t.sec, t_create.sec))
 
         try:

--- a/tests/protocol/test_link_layer.py
+++ b/tests/protocol/test_link_layer.py
@@ -1,28 +1,25 @@
+from collections import deque
 from typing import override
 
 import pytest
 
-from mqns.entity.memory import MemoryDecohereEvent, QubitState
+from mqns.entity.memory import MemoryDecohereEvent, MemoryQubit, QuantumMemory, QubitState
 from mqns.entity.node import Application, QNode
-from mqns.entity.qchannel import LinkArchAlways, LinkArchDimBk
-from mqns.models.epr import (
-    Entanglement,
-    MixedStateEntanglement,
-    WernerStateEntanglement,
-)
+from mqns.entity.qchannel import LinkArchAlways, LinkArchDimBk, LinkArchSr
+from mqns.models.epr import Entanglement, MixedStateEntanglement, WernerStateEntanglement
 from mqns.network.network import QuantumNetwork, TimingModeSync
 from mqns.network.protocol.event import ManageActiveChannel, QubitEntangledEvent, QubitReleasedEvent
 from mqns.network.protocol.link_layer import LinkLayer, LinkLayerCounters
 from mqns.network.topology import ClassicTopology, CustomTopology, LinearTopology
-from mqns.simulator import Simulator, event_handler
+from mqns.simulator import Simulator, event_handler, func_to_event
 from mqns.utils import log
 
 
 class NetworkLayer(Application[QNode]):
     def __init__(self):
         super().__init__()
-        self.release_after: float | None = None
-        """If set, ``QubitReleasedEvent`` would be emitted after specified duration for the next entanglement."""
+        self.release_after = deque[float | None]()
+        """If non-empty, ``QubitReleasedEvent`` would be emitted after specified duration for the next entanglement."""
         self.entangle: list[tuple[float, float]] = []
         """Entanglement events, each entry contains entanglement time and EPR creation time."""
         self.decohere: list[float] = []
@@ -36,17 +33,22 @@ class NetworkLayer(Application[QNode]):
 
     @event_handler
     def handle_entangle(self, event: QubitEntangledEvent):
-        qubit, epr = self.memory.read(event.qubit.addr, has=self.epr_type)
-        assert qubit is event.qubit
+        mq, epr = self.memory.read(event.qubit.addr, has=self.epr_type)
+        assert mq is event.qubit
         t_create = epr.decohere_time - self.memory.t_decohere
         self.entangle.append((event.t.sec, t_create.sec))
 
-        if not isinstance(self.release_after, float):
+        try:
+            release_after = self.release_after.popleft()
+        except IndexError:
             return
-        self.memory.read(event.qubit.addr, remove=True)
-        event.qubit.state = QubitState.RELEASE
-        self.simulator.add_event(QubitReleasedEvent(self.node, event.qubit, t=event.t + self.release_after))
-        self.release_after = None
+        if release_after is not None:
+            self.simulator.add_event(func_to_event(event.t + release_after, self._release, mq))
+
+    def _release(self, mq: MemoryQubit):
+        self.memory.read(mq.addr, remove=True)
+        mq.state = QubitState.RELEASE
+        self.simulator.add_event(QubitReleasedEvent(self.node, mq, t=self.simulator.tc))
 
     @event_handler
     def handle_decohere(self, event: MemoryDecohereEvent):
@@ -63,13 +65,7 @@ def manage_active_channel(t: float, src: NetworkLayer, dst: NetworkLayer, *, sta
     simulator.add_event(ManageActiveChannel(dst.node, ch, path_id=None, start=start, is_primary=False, t=time))
 
 
-@pytest.mark.parametrize(
-    "epr_type",
-    [
-        WernerStateEntanglement,
-        MixedStateEntanglement,
-    ],
-)
+@pytest.mark.parametrize("epr_type", [WernerStateEntanglement, MixedStateEntanglement])
 def test_basic(epr_type: type[Entanglement]):
     topo = LinearTopology(
         nodes_number=2,
@@ -82,16 +78,16 @@ def test_basic(epr_type: type[Entanglement]):
     net.build_route()
     net.get_qchannel("n1", "n2").assign_memory_qubits(capacity=1)
 
-    s = Simulator(0.0, 20.0, install_to=(log, net))
+    simulator = Simulator(0.0, 20.0, install_to=(log, net))
 
     ll1, ll2 = (node.get_app(LinkLayer) for node in net.nodes)
     nl1, nl2 = (node.get_app(NetworkLayer) for node in net.nodes)
     manage_active_channel(0.5, nl1, nl2)
     manage_active_channel(8.8, nl1, nl2, start=False)
-    nl1.release_after = 2.9
-    nl2.release_after = 3.2
+    nl1.release_after.append(2.9)
+    nl2.release_after.append(3.2)
 
-    s.run()
+    simulator.run()
 
     for ll, nl in (ll1, nl1), (ll2, nl2):
         print(ll.node.name, ll.cnt, nl.entangle, nl.decohere)
@@ -134,6 +130,113 @@ def test_basic(epr_type: type[Entanglement]):
     assert ll_cnt_agg.n_decoh == 1
     assert ll_cnt_agg.decoh_ratio == pytest.approx(1 / 3, abs=1e-6)
 
+    QuantumMemory.check_leaks(net.nodes)
+
+
+@pytest.mark.parametrize(
+    ("uninstall_t", "qubits_state", "n_entangle"),
+    [
+        # don't uninstall, only check timeline states (expected qubits_state are ignored)
+        (9.9, (QubitState.CONSUME, QubitState.CONSUME), (3, 3)),
+        # uninstall when RESERVE_REQ is in-flight
+        (0.2, (QubitState.RAW, QubitState.RAW), (0, 0)),
+        # uninstall when RESERVE_RES is in-flight
+        (0.5, (QubitState.RAW, QubitState.RAW), (0, 0)),
+        # uninstall when LinkArch is waiting for t_notify_a
+        (0.8, (QubitState.RAW, QubitState.RAW), (0, 0)),
+        # uninstall when LinkArch is waiting for t_notify_b
+        (1.1, (QubitState.ENTANGLED1, QubitState.RAW), (1, 0)),
+        # uninstall when both qubits are owned by NetworkLayer
+        (1.5, (QubitState.ENTANGLED1, QubitState.ENTANGLED1), (1, 1)),
+        # uninstall when one qubit is owned by NetworkLayer
+        (4.3, (QubitState.RAW, QubitState.ENTANGLED1), (2, 2)),
+        (6.1, (QubitState.ENTANGLED1, QubitState.RAW), (3, 3)),
+    ],
+)
+def test_uninstall(uninstall_t: float, qubits_state: tuple[QubitState, QubitState], n_entangle: tuple[int, int]):
+    """
+    Verify proper cleanups when the path is uninstalled in various steps.
+    """
+    topo = LinearTopology(
+        nodes_number=2,
+        nodes_apps=[NetworkLayer(), LinkLayer()],
+        qchannel_args={"delay": 0.3, "link_arch": LinkArchAlways(LinkArchSr())},
+        cchannel_args={"delay": 0.3},
+        memory_args={"t_cohere": 2.0},
+    )
+    net = QuantumNetwork(topo, classic_topo=ClassicTopology.Follow)
+    net.build_route()
+    net.get_qchannel("n1", "n2").assign_memory_qubits(capacity=1)
+
+    simulator = Simulator(0.0, 6.5, install_to=(log, net))
+
+    nl1, nl2 = (node.get_app(NetworkLayer) for node in net.nodes)
+    manage_active_channel(0.1, nl1, nl2)
+    manage_active_channel(uninstall_t, nl1, nl2, start=False)
+
+    def assert_states(expected: tuple[QubitState, QubitState]) -> None:
+        mq1 = nl1.memory.read(0, must=True)
+        mq2 = nl2.memory.read(0, must=True)
+        actual = mq1[0].state, mq2[0].state
+        assert actual == expected
+
+    def check_states(t: float, expected0: QubitState, expected1: QubitState) -> None:
+        if t > uninstall_t:
+            return
+        event = func_to_event(simulator.time(sec=t), assert_states, (expected0, expected1))
+        event.priority = 10000
+        simulator.add_event(event)
+
+    check_states(uninstall_t, *qubits_state)
+
+    # t=0.1, path is installed with n1 as primary and n2 as secondary
+    # t=0.1, n1 sets qubit state to ACTIVE, sends RESERVE_REQ
+    check_states(0.1, QubitState.ACTIVE, QubitState.RAW)
+    # t=0.4, n2 receives RESERVE_REQ, sets qubit state to RESERVED, sends RESERVE_RES
+    check_states(0.4, QubitState.ACTIVE, QubitState.RESERVED)
+    # t=0.7, n1 receives RESERVE_RES, sets qubit state to RESERVED; n2 emits photon
+    check_states(0.7, QubitState.RESERVED, QubitState.RESERVED)
+    # t=1.0, n1 absorbs photon, sends S-R heralding, sets qubit state to ENTANGLED
+    check_states(1.0, QubitState.ENTANGLED1, QubitState.RESERVED)
+    # t=1.3, n2 receives S-R heralding, sets qubit state to ENTANGLED
+    check_states(1.3, QubitState.ENTANGLED1, QubitState.ENTANGLED1)
+    nl1.release_after.append(None)
+    nl2.release_after.append(None)
+    # t=2.7, EPR decoheres, qubit states are set to RELEASE then RAW
+    # t=2.7, n1 sets qubit state to ACTIVE, sends RESERVE_REQ
+    check_states(2.7, QubitState.ACTIVE, QubitState.RAW)
+    # t=3.0, n2 receives RESERVE_REQ, sets qubit state to RESERVED, sends RESERVE_RES
+    check_states(3.0, QubitState.ACTIVE, QubitState.RESERVED)
+    # t=3.3, n1 receives RESERVE_RES, sets qubit state to RESERVED; n2 emits photon
+    check_states(3.3, QubitState.RESERVED, QubitState.RESERVED)
+    # t=3.6, n1 absorbs photon, sends S-R heralding, sets qubit state to ENTANGLED
+    check_states(3.6, QubitState.ENTANGLED1, QubitState.RESERVED)
+    # t=3.9, n2 receives S-R heralding, sets qubit state to ENTANGLED
+    check_states(3.9, QubitState.ENTANGLED1, QubitState.ENTANGLED1)
+    nl1.release_after.append(4.2 - 3.6)
+    # t=4.2, n1 sets qubit state to RELEASE then RAW then ACTIVE, sends RESERVE_REQ
+    check_states(4.2, QubitState.ACTIVE, QubitState.ENTANGLED1)
+    # t=4.4, n2 receives RESERVE_REQ but has no available qubit
+    nl2.release_after.append(4.7 - 3.9)
+    # t=4.7, n2 sets qubit state to RELEASE then RAW then RESERVED, sends RESERVE_RES
+    check_states(4.7, QubitState.ACTIVE, QubitState.RESERVED)
+    # t=5.0, n1 receives RESERVE_RES, sets qubit state to RESERVED; n2 emits photon
+    check_states(5.0, QubitState.RESERVED, QubitState.RESERVED)
+    # t=5.3, n1 absorbs photon, sends S-R heralding, sets qubit state to ENTANGLED
+    check_states(5.3, QubitState.ENTANGLED1, QubitState.RESERVED)
+    # t=5.6, n2 receives S-R heralding, sets qubit state to ENTANGLED
+    check_states(5.6, QubitState.ENTANGLED1, QubitState.ENTANGLED1)
+    nl2.release_after.append(6.0 - 5.6)
+    # t=6.0, n2 sets qubit state to RELEASE then RAW but has no pending request
+    check_states(6.0, QubitState.ENTANGLED1, QubitState.RAW)
+    nl1.release_after.append(6.4 - 5.3)
+    # t=6.4, n1 sets qubit state to RELEASE then RAW then ACTIVE, sends RESERVE_REQ
+    # t=6.5, scenario ends
+
+    simulator.run()
+
+    assert (len(nl1.entangle), len(nl2.entangle)) == n_entangle
+
 
 def test_skip_ahead():
     topo = LinearTopology(
@@ -159,7 +262,7 @@ def test_skip_ahead():
         print(ll.node.name, ll.cnt, nl.entangle, nl.decohere)
 
     assert len(nl1.entangle) == len(nl2.entangle) > 0
-    for t1, t2 in zip(nl1.entangle, nl2.entangle):
+    for t1, t2 in zip(nl1.entangle, nl2.entangle, strict=True):
         assert t1 == pytest.approx(t2, abs=1e-3)
 
     ll_cnt_agg = LinkLayerCounters.aggregate(net.nodes)
@@ -187,7 +290,7 @@ def test_timing_mode_sync():
     net = QuantumNetwork(topo, classic_topo=ClassicTopology.Follow, timing=TimingModeSync(t_ext=0.6, t_int=0.4))
     net.build_route()
 
-    simulator = Simulator(0.0, 10.0, install_to=(log, net))
+    simulator = Simulator(0.0, 6.1, install_to=(log, net))
 
     nl0, nl1, nl2, nl3 = (node.get_app(NetworkLayer) for node in net.nodes)
     manage_active_channel(0.1, nl0, nl1)
@@ -217,3 +320,4 @@ def test_timing_mode_sync():
         # All qubits are cleared at the start of each EXTERNAL phase, before memory decoherence occurs.
         # Decoherence events are not emitted for cleared qubits.
         assert len(nl.decohere) == 0
+    QuantumMemory.check_leaks([nl2.node, nl3.node])


### PR DESCRIPTION
refs #124

## LinkLayer queuing

LinkLayer is substantially refactored.
The node-wide `fifo_reservation_req` and `pending_init_reservation` structures are removed and replaced with more precise data structures arranged by ActiveChannel - ActivePath hierarchy.
This was an old TODO item:
https://github.com/usnistgov/mqns/blob/66a982a2a3b4e79f3c4705aea4bffd37220da21c/mqns/network/protocol/link_layer.py#L467-L473
With this change, the end-to-end rate has increased 1.2x ~ 3x for `multi_request_single_path.py` example.

To support the above change, the **LinkLayer API** has changed: both the primary and secondary forwarder must activate the channel in LinkLayer.
Previously, only the primary forwarder needs to do so.

## UNINSTALL_PATH cleanups

The UNINSTALL_PATH command can now properly deallocate MemoryQubits used by the path.

Qubits owned by LinkLayer (in ACTIVE or RESERVED states) are deallocated immediately:

1. When UNINSTALL_PATH command arrives, the forwarder immediately informs the LinkLayer to stop entanglement generation.
2. If a qubit has not completed reservation, the reservation attempt is abandoned, and any in-flight reservation messages would be ignored.
3. If a qubit pair is waiting for the successful k-th attempt, the "link arch success" event is canceled.
   This is slightly unrealistic because a physical network can only cancel at integral `attempt_duration` but cannot cancel "half an attempt".
   However, the difference is small enough.
4. If a qubit pair is during heralding (t_notify hasn't arrived), the qubits are immediately reset, and any in-flight heralding messages would be ignored.
   Note: Heralding messages aren't implemented, they are simply `t_notify` timers.
5. If a qubit pair is partially delivered (e.g. in Sender-Receiver link arch, fwA has been notified, fwB hasn't), only the qubit still owned by LinkLayer-B is reset, and fwB won't be notified.

Qubits owned by Forwarder are deallocated when they next reach RAW state:

1. When UNINSTALL_PATH command arrives, the forwarder immediately marks the FIB entry as *inactive* but does not delete the FIB entry.
2. Local swap have accelerated abort:
   * Starting a local swap linked to an inactive FIB entry results in swap abort without waiting for swap delay.
   * Finishing a local swap linked to an inactive FIB entry results in swap abort.
3. SWAP_UPDATE message processing and wait-time budget cutoffs are processed normally.
4. Purification is not fixed yet, with relevant tests marked as "expected failure"; this is deferred to purification refactoring.
5. The FIB entry is eventually deleted after `4 * t_cohere`, long after all qubits allocated to the path have decohered.

Compared to an immediate resetting to RAW, this approach would slightly delay MemoryQubit release, but the delay is much less than LinkLayer controlled qubits because there won't be k attempts.
This approach avoids the complexity of preparing every possible interaction for the possibility of deleted FIB entry.
