### PR TITLE
protocol+fw: allow paths in both directions to share a channel

### DIFF
--- a/examples/multi_request_single_path.py
+++ b/examples/multi_request_single_path.py
@@ -168,7 +168,7 @@ def plot(results: dict[str, list[list[PathStats]]], *, save_plt: str):
 STRATEGIES: dict[str, MuxScheme] = {
     "Statistical Mux.": MuxSchemeStatistical(coordinated_decisions=False),
     "Random Alloc.": MuxSchemeDynamicEpr(),
-    "Swap-weighted Alloc.": MuxSchemeDynamicEpr(select_path=MuxSchemeDynamicEpr.SelectPath_swap_weighted),
+    "Swap-weighted Alloc.": MuxSchemeDynamicEpr(select_path="swap_weighted"),
 }
 T_COHERE_VALUES = [5e-3, 10e-3, 20e-3]
 

--- a/examples/multiplexing.py
+++ b/examples/multiplexing.py
@@ -107,13 +107,8 @@ SCENARIOS: list[Scenario] = [
 ]
 
 STRATEGIES: dict[str, MuxScheme] = {
-    "Statistical": MuxSchemeStatistical(
-        select_swap_qubit=MuxSchemeStatistical.SelectSwapQubit_random,
-        coordinated_decisions=True,
-    ),
-    "Buffer-Space": MuxSchemeBufferSpace(
-        select_swap_qubit=MuxSchemeBufferSpace.SelectSwapQubit_random,
-    ),
+    "Statistical": MuxSchemeStatistical(select_swap_qubit="random", coordinated_decisions=True),
+    "Buffer-Space": MuxSchemeBufferSpace(select_swap_qubit="random"),
 }
 
 

--- a/examples/s2uc.py
+++ b/examples/s2uc.py
@@ -184,7 +184,7 @@ def run_simulation(seed: int, args: Args, duration: float, w: tuple[float, float
             swap_delay=340e-6,
             swap_error="PERFECT",  # no error applied by the swap gates
             swap_error_at="f",  # memory decoherence continues during swap
-            mux=MuxSchemeBufferSpace(select_swap_qubit=getattr(MuxSchemeBufferSpace, f"SelectSwapQubit_{args.ssq}")),
+            mux=MuxSchemeBufferSpace(select_swap_qubit=args.ssq),
         )
         .request(
             "S-D",

--- a/examples/template_routing.py
+++ b/examples/template_routing.py
@@ -159,12 +159,12 @@ class Scenario:
 
 def _mux_statistical() -> MuxScheme:
     # select_swap_qubit: Function to select a qubit to swap with, default is first.
-    return MuxSchemeStatistical(select_swap_qubit=MuxSchemeStatistical.SelectSwapQubit_random)
+    return MuxSchemeStatistical(select_swap_qubit="random")
 
 
 def _mux_buffer_space() -> MuxScheme:
     # select_swap_qubit: Function to select a qubit to swap with, default is first.
-    return MuxSchemeBufferSpace(select_swap_qubit=MuxSchemeBufferSpace.SelectSwapQubit_random)
+    return MuxSchemeBufferSpace(select_swap_qubit="random")
 
 
 # Multiplexing vector for buffer-space mux. It's per-hop list of (tx_qubits, rx_qubits) allocations.

--- a/mqns/entity/memory/memory_qubit.py
+++ b/mqns/entity/memory/memory_qubit.py
@@ -153,12 +153,12 @@ class MemoryQubit:
 
     This is set by ``Forwarder`` upon entanglement and when completing a swap rank sequentially.
     It is invalid during parallel swap within a rank.
-
-    Note: this is a ``list`` instead of a ``set``, to ensure deterministic simulation.
     """
     epr_path_ids: list[int] | None = None
     """
     Which paths are compatible with the currently stored entanglement.
+
+    Note: this is a ``list`` instead of a ``set``, to ensure deterministic simulation.
     """
     purif_rounds = 0
     """Number of purification rounds completed by the EPR stored on this qubit."""

--- a/mqns/models/epr/entanglement.py
+++ b/mqns/models/epr/entanglement.py
@@ -154,6 +154,19 @@ class Entanglement(QuantumModel):
     def fidelity(self, value: float):
         pass
 
+    def flip_direction(self) -> None:
+        """
+        Reverse the direction between src and dst.
+        """
+        self.src, self.dst = self.dst, self.src
+        self.mem_keys = self.mem_keys[1], self.mem_keys[0]
+        self.store_decays = self.store_decays[1], self.store_decays[0]
+        if self.orig_eprs:
+            self.orig_eprs.reverse()
+            for oe in self.orig_eprs:
+                oe.flip_direction()
+        self.consumed_sides = ((self.consumed_sides & 0b01) << 1) | ((self.consumed_sides & 0b10) >> 1)
+
     def apply_store_decays(self, now: Time) -> None:
         """
         Apply memory time-based decays for both qubits in this EPR.

--- a/mqns/models/epr/entanglement.py
+++ b/mqns/models/epr/entanglement.py
@@ -64,6 +64,9 @@ class EntanglementInitKwargs(TypedDict, total=False):
 class Entanglement(QuantumModel):
     """Base entanglement model."""
 
+    name: str
+    """Descriptive name."""
+
     is_decohered: bool = False
     """
     Whether the entanglement has decohered.
@@ -71,12 +74,34 @@ class Entanglement(QuantumModel):
     This reflects the hidden physical state.
     It must not be used to guide decision prior to measurement.
     """
+    decohere_time: Time
+    """
+    EPR decoherence time point, when it would be removed from memory.
 
-    ch_index: int = -1
+    * Upon creating a memory-memory EPR, this is assigned according to memory ``t_cohere``.
+        If the two qubits are stored in memories with different dephasing times, the shorter value is used.
+    * Upon swapping, the oldest decoherence time point is used.
+    * Upon purification, the decoherence time point is unchanged.
+    * Some operations are unavailable if this is ``Time.SENTINEL``.
     """
-    Index of elementary entanglement in a path, smaller indices are on the left side.
-    Negative means this is not an elementary entanglement.
+    fidelity_time: Time
     """
+    Fidelity update time point, reflecting when fidelity values are last updated.
+
+    * Upon creating a memory-memory EPR, this is assigned according to the EPR creation time.
+    * This may be updated to the current time at any time, while ``store_decays`` is applied to the EPR.
+    * Some operations are unavailable if this is ``Time.SENTINEL``.
+    """
+
+    src: "QNode|None"
+    """Left node that holds one of the entangled qubits."""
+    dst: "QNode|None"
+    """Right node that holds one of the entangled qubits."""
+    mem_keys: tuple[str, str]
+    """MemoryQubit reservation keys at src and dst."""
+    store_decays: tuple[TimeDecayFunc, TimeDecayFunc]
+    """Memory time-based decay functions at src and dst."""
+
     orig_eprs: list[Self] | None = None
     """Elementary entanglements that swapped into this entanglement."""
     affectionated_path_id: int = -1
@@ -103,37 +128,17 @@ class Entanglement(QuantumModel):
         """
         name = kwargs.get("name")
         self.name = _AUTOID() if name is None else name
-        """Descriptive name."""
 
         self.decohere_time = kwargs.get("decohere_time", Time.SENTINEL)
-        """
-        EPR decoherence time point, when it would be removed from memory.
-
-        * Upon creating a memory-memory EPR, this is assigned according to memory ``t_cohere``.
-          If the two qubits are stored in memories with different dephasing times, the shorter value is used.
-        * Upon swapping, the oldest decoherence time point is used.
-        * Upon purification, the decoherence time point is unchanged.
-        * Some operations are unavailable if this is ``Time.SENTINEL``.
-        """
         self.fidelity_time = kwargs.get("fidelity_time", Time.SENTINEL)
-        """
-        Fidelity update time point, reflecting when fidelity values are last updated.
-
-        * Upon creating a memory-memory EPR, this is assigned according to the EPR creation time.
-        * This may be updated to the current time at any time, while ``store_decays`` is applied to the EPR.
-        * Some operations are unavailable if this is ``Time.SENTINEL``.
-        """
 
         self.src = kwargs.get("src")
-        """Left node that holds one of the entangled qubits."""
         self.dst = kwargs.get("dst")
-        """Right node that holds one of the entangled qubits."""
         key0, key1 = kwargs.get("mem_keys", (None, None))
         self.mem_keys = key0 or "", key1 or ""
         """MemoryQubit reservation keys at src and dst."""
         decay0, decay1 = kwargs.get("store_decays", (None, None))
         self.store_decays = decay0 or time_decay_nop, decay1 or time_decay_nop
-        """Memory time-based decay functions at src and dst."""
 
     @property
     @abstractmethod
@@ -356,11 +361,8 @@ def _describe(epr: Entanglement) -> Iterable[str]:
     if epr.src and epr.dst:
         yield f"src={epr.src.name}"
         yield f"dst={epr.dst.name}"
-        if epr.ch_index >= 0:
-            yield f"ch_index={epr.ch_index}"
-        elif epr.orig_eprs:
-            orig_eprs = ",".join(e.name for e in epr.orig_eprs)
-            yield f"orig_eprs=[{orig_eprs}]"
+        if epr.orig_eprs:
+            yield f"orig_eprs=[{','.join(e.name for e in epr.orig_eprs)}]"
 
     if epr.affectionated_path_id >= 0:
         yield f"affectionated_path_id={epr.affectionated_path_id}"

--- a/mqns/network/fw/__init__.py
+++ b/mqns/network/fw/__init__.py
@@ -17,12 +17,7 @@ from mqns.network.fw.routing import (
     RoutingPathSingle,
     RoutingPathStatic,
 )
-from mqns.network.fw.select import (
-    MemoryEprIterator,
-    MemoryEprTuple,
-    SelectPurifQubit,
-    select_purif_qubit_random,
-)
+from mqns.network.fw.select import MemoryEprIterator, MemoryEprTuple
 from mqns.network.fw.swap_sequence import SwapPolicy, SwapSequenceInput, parse_swap_sequence
 
 __all__ = [
@@ -52,8 +47,6 @@ __all__ = [
     "RoutingPathMulti",
     "RoutingPathSingle",
     "RoutingPathStatic",
-    "select_purif_qubit_random",
-    "SelectPurifQubit",
     "SwapPolicy",
     "SwapSequence",
     "SwapSequenceInput",
@@ -65,7 +58,6 @@ for name in __all__:
         "MemoryEprTuple",
         "MultiplexingVector",
         "MultiplexingVectorInput",
-        "SelectPurifQubit",
         "SwapPolicy",
         "SwapSequence",
         "SwapSequenceInput",

--- a/mqns/network/fw/cutoff.py
+++ b/mqns/network/fw/cutoff.py
@@ -6,6 +6,7 @@ from mqns.network.fw.fib import FibEntry
 from mqns.network.fw.fw_module import ForwarderModule, fw_signaling_cmd_handler
 from mqns.network.fw.message import CutoffDiscardMsg
 from mqns.simulator import Event, Time
+from mqns.utils import unwrap_cast
 
 if TYPE_CHECKING:
     from mqns.network.fw.forwarder import Forwarder
@@ -37,12 +38,18 @@ class CutoffScheme(ForwarderModule, ABC):
         """
         fw = self.fw
 
+        o_key = unwrap_cast(qubit.key)
+
         # Find EPR partner.
         assert qubit.partner
         partner, p_key = qubit.partner
         self.log_debug(
-            "local cutoff discard key=%s addr=%s round=%s partner=%s:%s", qubit.key, qubit.addr, round, partner.name, p_key
+            "local cutoff discard key=%s addr=%s round=%s partner=%s:%s", o_key, qubit.addr, round, partner.name, p_key
         )
+
+        # Inform SwapProc.
+        if round == -1:
+            fw.swap.handle_decohere(o_key)
 
         # Discard primary qubit.
         fw.cnt.increment_n_cutoff(round, True)
@@ -68,6 +75,10 @@ class CutoffScheme(ForwarderModule, ABC):
         fw = self.fw
         o_key = msg["key"]
         round = msg["round"]
+
+        # Inform SwapProc.
+        if round == -1:
+            fw.swap.handle_decohere(o_key)
 
         # Find qubit.
         qm_tuple = fw.memory.read(o_key, remove=True)

--- a/mqns/network/fw/fib.py
+++ b/mqns/network/fw/fib.py
@@ -226,17 +226,19 @@ class FibSwapGroup:
         """
         return self.r_neigh if self.r_most else self.nodes[self.own_idx + 1]
 
+    def repr_route(self) -> str:
+        return "".join(
+            [
+                self.l_neigh,
+                "<" if self.dir in ("l", "b") else "~",
+                "-".join(f"[{n}]" if i == self.own_idx else n for (i, n) in enumerate(self.nodes)),
+                ">" if self.dir in ("b", "r") else "~",
+                self.r_neigh,
+            ]
+        )
+
     def __repr__(self) -> str:
-        tokens = [
-            "FibSwapGroup(",
-            self.l_neigh,
-            "<" if self.dir in ("l", "b") else "~",
-            "-".join(f"[{n}]" if i == self.own_idx else n for (i, n) in enumerate(self.nodes)),
-            ">" if self.dir in ("b", "r") else "~",
-            self.r_neigh,
-            f", rank={self.rank})",
-        ]
-        return "".join(tokens)
+        return f"FibSwapGroup({self.repr_route()}, rank={self.rank})"
 
 
 class FibRequestGroup:

--- a/mqns/network/fw/forwarder.py
+++ b/mqns/network/fw/forwarder.py
@@ -383,7 +383,7 @@ class Forwarder(ClassicCommandDispatcherMixin, Application[QNode]):
         assert self.node.timing.is_async(), f"unexpected {event} in SYNC timing mode, (t_ext+t_int) too high"
         self.release_qubit(event.qubit, is_decoh=True)
 
-    def release_qubit(self, qubit: MemoryQubit, *, need_remove=False, is_decoh=False, is_cutoff=False):
+    def release_qubit(self, qubit: MemoryQubit, *, need_remove=False, is_decoh=False):
         """
         Release a qubit.
 
@@ -391,13 +391,12 @@ class Forwarder(ClassicCommandDispatcherMixin, Application[QNode]):
             need_remove: Whether to remove the data associated with the qubit.
                          This should be set to True unless .read(remove=True) is already performed.
             is_decoh: Whether the release was caused by MemoryDecohereEvent.
-            is_cutoff: Whether the release was caused by CutoffScheme.
         """
         if need_remove:
             self.memory.read(qubit.addr, remove=True)
 
-        if is_decoh or is_cutoff:
-            self.swap.handle_decohere(qubit)
+        if is_decoh:
+            self.swap.handle_decohere(unwrap_cast(qubit.key))
 
         qubit.state = QubitState.RELEASE
         event = QubitReleasedEvent(self.node, qubit, is_decoh=is_decoh, t=self.simulator.tc)

--- a/mqns/network/fw/forwarder.py
+++ b/mqns/network/fw/forwarder.py
@@ -314,7 +314,7 @@ class Forwarder(ClassicCommandDispatcherMixin, Application[QNode]):
 
         self.purif.start(qubit, found[0], fib_entry, partner)
 
-    def qubit_is_eligible(self, qubit: MemoryQubit, fib_entry: FibEntry | None):
+    def qubit_is_eligible(self, mq0: MemoryQubit, fib_entry: FibEntry | None):
         """
         Handle a qubit entering ELIGIBLE state.
 
@@ -330,32 +330,31 @@ class Forwarder(ClassicCommandDispatcherMixin, Application[QNode]):
             qubit: The qubit that became eligible.
             fib_entry: FIB entry (not available with MuxSchemeStatistical).
         """
-        assert qubit.state is QubitState.ELIGIBLE, f"unexpected state {qubit.state}"
+        assert mq0.state is QubitState.ELIGIBLE, f"unexpected state {mq0.state}"
         self.cnt.n_eligible += 1
-        qubit.purif_rounds = 0
-        qubit.eligible_time = self.simulator.tc
+        mq0.purif_rounds = 0
+        mq0.eligible_time = self.simulator.tc
 
         if not self.node.timing.is_internal():
             self.log_debug("INT phase is over -> stop swaps")
             return
 
-        _, epr = self.memory.read(qubit.addr, has=self.epr_type)
-        if self._try_consume(qubit, epr, fib_entry):
+        _, epr0 = self.memory.read(mq0.addr, has=self.epr_type)
+        if self._try_consume(mq0, epr0, fib_entry):
             return
 
-        swap_candidates = self.memory.find(
-            lambda q, _: (
-                q.state is QubitState.ELIGIBLE  # in ELIGIBLE state
-                and q.qchannel is not qubit.qchannel  # assigned to a different channel
-            ),
-            has=self.epr_type,
-        )
-        if swap_candidate := self.mux.find_swap_candidate(qubit, epr, fib_entry, swap_candidates):
-            mq1, fib_entry = swap_candidate
-            self.cutoff.before_swap(qubit, mq1, fib_entry)
-            self.swap.start(qubit, mq1, fib_entry)
+        swap_decision = self.mux.find_swap_with(mq0, epr0, fib_entry)
+        if swap_decision:
+            mq1, fib_entry = swap_decision
+            self.cutoff.before_swap(mq0, mq1, fib_entry)
+            if fib_entry.route.index(unwrap_cast(mq0.partner)[0].name) < fib_entry.route.index(
+                unwrap_cast(mq1.partner)[0].name
+            ):
+                self.swap.start(mq0, mq1, fib_entry)
+            else:
+                self.swap.start(mq1, mq0, fib_entry)
         else:
-            self.cutoff.before_store_eligible(qubit, PathDirection.L if epr.dst is self.node else PathDirection.R, fib_entry)
+            self.cutoff.before_store_eligible(mq0, PathDirection.L if epr0.dst is self.node else PathDirection.R, fib_entry)
 
     def _try_consume(self, qubit: MemoryQubit, epr: Entanglement, fib_entry: FibEntry | None) -> bool:
         """

--- a/mqns/network/fw/forwarder.py
+++ b/mqns/network/fw/forwarder.py
@@ -217,7 +217,7 @@ class Forwarder(ClassicCommandDispatcherMixin, Application[QNode]):
 
         The actual processing is handled by the multiplexing scheme.
 
-        If a SwapUpdate was received before processing this event and buffered in ``self.waiting_su``,
+        If a SwapUpdate was received before processing this event and buffered in ``self.swap.waiting_su``,
         it is re-processed at this time.
 
         Args:

--- a/mqns/network/fw/forwarder.py
+++ b/mqns/network/fw/forwarder.py
@@ -16,7 +16,7 @@
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import copy
-from typing import Literal, TypedDict, Unpack, override
+from typing import Callable, Literal, TypedDict, Unpack, override
 
 from mqns.entity.cchannel import ClassicCommandDispatcherMixin
 from mqns.entity.memory import MemoryDecohereEvent, MemoryQubit, PathDirection, QubitState
@@ -31,7 +31,7 @@ from mqns.network.fw.fw_purif import ForwarderPurifProc
 from mqns.network.fw.fw_swap import ForwarderSwapProc
 from mqns.network.fw.mux import MuxScheme
 from mqns.network.fw.mux_buffer_space import MuxSchemeBufferSpace
-from mqns.network.fw.select import SelectPurifQubit, call_select_purif_qubit
+from mqns.network.fw.select import MemoryEprTuple, call_select
 from mqns.network.network import TimingPhase, sync_phase_handler
 from mqns.network.protocol.event import QubitConsumeEvent, QubitEntangledEvent, QubitReleasedEvent
 from mqns.simulator import event_handler
@@ -51,7 +51,7 @@ class ForwarderInitKwargs(TypedDict, total=False):
     """EPR age cut-off scheme, default is wait-time."""
     mux: MuxScheme | None
     """Path multiplexing scheme, default is buffer-space."""
-    select_purif_qubit: SelectPurifQubit
+    select_purif_qubit: Callable[[list[MemoryEprTuple], MemoryQubit, FibEntry, QNode], MemoryEprTuple] | None
     """Qubit selection among purification candidates, default is picking first candidate."""
 
 
@@ -307,7 +307,7 @@ class Forwarder(ClassicCommandDispatcherMixin, Application[QNode]):
             ),
             has=self.epr_type,
         )
-        found = call_select_purif_qubit(self._select_purif_qubit, qubit, fib_entry, partner, candidates)
+        found = call_select(candidates, self._select_purif_qubit, qubit, fib_entry, partner)
         if not found:
             self.log_debug("no candidate EPR for segment %s purif round %s", segment_name, 1 + qubit.purif_rounds)
             return

--- a/mqns/network/fw/forwarder.py
+++ b/mqns/network/fw/forwarder.py
@@ -245,7 +245,7 @@ class Forwarder(ClassicCommandDispatcherMixin, Application[QNode]):
         _, epr = self.memory.read(mq.addr, has=self.epr_type)
         assert not epr.orig_eprs, f"{mq} is not elementary entanglement"
         fib_entry = self.mux.qubit_is_entangled(mq, epr, event.neighbor)
-        self.log_debug("ENTANGLED %s fib_entry=%s | %s", mq, fib_entry, epr)
+        self.log_debug("ENTANGLED %s path_id=%s | %s", mq, fib_entry.path_id if fib_entry else None, epr)
 
         match mq.state:
             case QubitState.PURIF:

--- a/mqns/network/fw/fw_nb.py
+++ b/mqns/network/fw/fw_nb.py
@@ -26,13 +26,13 @@ class ForwarderNorthbound(ForwarderModule):
         self._fib_erase_delay = self.simulator.time(time_slot=4 * self.memory.t_cohere.time_slot)
 
     @fw_control_cmd_handler("INSTALL_PATH")
-    def handle_install_path(self, msg: InstallPathMsg):
+    def handle_install_path(self, msg: InstallPathMsg) -> None:
         """Process an INSTALL_PATH control command."""
         path_id = msg["path_id"]
         instructions = msg["instructions"]
         self.mux.validate_path_instructions(instructions)
 
-        # populate FIB
+        # Insert FIB entry.
         route = instructions["route"]
         if "swap_cutoff" in instructions:
             swap_cutoff = [None if t < 0 else self.simulator.time(time_slot=t) for t in instructions["swap_cutoff"]]
@@ -49,47 +49,43 @@ class ForwarderNorthbound(ForwarderModule):
         )
         self.fib.insert_or_replace(fib_entry)
 
-        # identify left/right neighbors
-        # associate path with qchannel and allocate qubits
-        if ch_l := self._find_adj(fib_entry, -1):
-            self.mux.install_path_adj(instructions, fib_entry, PathDirection.L, ch_l)
-        if ch_r := self._find_adj(fib_entry, +1):
-            self.mux.install_path_adj(instructions, fib_entry, PathDirection.R, ch_r)
+        # Identify left/right channels, allocate qubits and process LinkLayer changes.
+        if ch := self._find_adj(fib_entry, -1):
+            self.mux.install_path_adj(instructions, fib_entry, PathDirection.L, ch)
+            self.install_path_adj(fib_entry, PathDirection.L, ch)
+        if ch := self._find_adj(fib_entry, +1):
+            self.mux.install_path_adj(instructions, fib_entry, PathDirection.R, ch)
+            self.install_path_adj(fib_entry, PathDirection.R, ch)
 
-        # call subclass specialization
-        self.handle_path_change(
-            path_id=path_id,
-            uninstall=False,
-            fib_entry=fib_entry,
-            ch_l=ch_l,
-            ch_r=ch_r,
-        )
+    @abstractmethod
+    def install_path_adj(self, fib_entry: FibEntry, dir: PathDirection, ch: QuantumChannel) -> None:
+        """
+        Process LinkLayer changes for an adjacency after a path has been installed.
+        """
 
     @fw_control_cmd_handler("UNINSTALL_PATH")
-    def handle_uninstall_path(self, msg: UninstallPathMsg):
+    def handle_uninstall_path(self, msg: UninstallPathMsg) -> None:
         """Process an UNINSTALL_PATH control command."""
         path_id = msg["path_id"]
 
-        # retrieve and erase FIB entry
+        # Retrieve and erase FIB entry.
         fib_entry = self.fib.get(path_id)
         fib_entry.active_until = self.simulator.tc
         self.simulator.add_event(func_to_event(fib_entry.active_until + self._fib_erase_delay, self.fib.erase, path_id))
 
-        # identify left/right neighbors
-        # disassociate path with qchannel and deallocate qubits
-        if ch_l := self._find_adj(fib_entry, -1):
-            self.mux.uninstall_path_adj(fib_entry, PathDirection.L, ch_l)
-        if ch_r := self._find_adj(fib_entry, +1):
-            self.mux.uninstall_path_adj(fib_entry, PathDirection.R, ch_r)
+        # Identify left/right channels, deallocate qubits and process LinkLayer changes.
+        if ch := self._find_adj(fib_entry, -1):
+            self.mux.uninstall_path_adj(fib_entry, PathDirection.L, ch)
+            self.uninstall_path_adj(fib_entry, PathDirection.L, ch)
+        if ch := self._find_adj(fib_entry, +1):
+            self.mux.uninstall_path_adj(fib_entry, PathDirection.R, ch)
+            self.uninstall_path_adj(fib_entry, PathDirection.R, ch)
 
-        # call subclass specialization
-        self.handle_path_change(
-            path_id=path_id,
-            uninstall=True,
-            fib_entry=fib_entry,
-            ch_l=ch_l,
-            ch_r=ch_r,
-        )
+    @abstractmethod
+    def uninstall_path_adj(self, fib_entry: FibEntry, dir: PathDirection, ch: QuantumChannel) -> None:
+        """
+        Process LinkLayer changes for an adjacency after a path has been installed.
+        """
 
     def _find_adj(self, fib_entry: FibEntry, route_offset: int) -> QuantumChannel | None:
         neigh_idx = fib_entry.own_idx + route_offset
@@ -97,24 +93,3 @@ class ForwarderNorthbound(ForwarderModule):
             return None
         neigh = self.network.get_node(fib_entry.route[neigh_idx])
         return self.node.get_qchannel(neigh)
-
-    @abstractmethod
-    def handle_path_change(
-        self,
-        *,
-        path_id: int,
-        uninstall: bool,
-        fib_entry: FibEntry,
-        ch_l: QuantumChannel | None,
-        ch_r: QuantumChannel | None,
-    ):
-        """
-        Process LinkLayer changes after a path has been installed or uninstalled.
-
-        Args:
-            path_id: Path identifier.
-            uninstall: Whether this is an uninstall command.
-            fib_entry: FIB entry.
-            ch_l: Quantum channel toward left, if exists.
-            ch_r: Quantum channel toward right, if exists.
-        """

--- a/mqns/network/fw/fw_swap.py
+++ b/mqns/network/fw/fw_swap.py
@@ -1,4 +1,4 @@
-from collections.abc import Iterable, MutableSequence, Sequence
+from collections.abc import Iterable, Sequence
 from typing import TYPE_CHECKING, ClassVar, NamedTuple, cast, override
 
 from mqns.entity.memory import MemoryQubit, QubitState
@@ -54,6 +54,21 @@ class _SwapHerald(NamedTuple):
     """Destination node name."""
     paths: Sequence[int]
     """Possible path IDs for classical signaling, must be non-empty."""
+
+
+class _SwapParsedUpdate(NamedTuple):
+    """SWAP_UPDATE parsed in own node context."""
+
+    fib_entry: FibEntry
+    expiry: int
+    q_paths: Sequence[int]
+
+    swapper: str
+    swapper_rank: int
+
+    o_key: str
+    partner: str
+    p_key: str
 
 
 class _SwapTask:
@@ -170,7 +185,7 @@ class _SwapTask:
 
         return self._check_triggers()
 
-    def notify_remote_swap(self, su: SwapUpdateMsg) -> list[_SwapHerald]:
+    def notify_remote_swap(self, su: _SwapParsedUpdate) -> list[_SwapHerald]:
         """
         Save heralded swap outcome.
 
@@ -180,29 +195,27 @@ class _SwapTask:
         Returns:
             Heralding instructions, if any.
         """
-        expiry = su["expiry"]
-        self._update_expiry(expiry)
+        self._update_expiry(su.expiry)
 
         sg = self.sg
-        swapper = su["o_node"]
-        if swapper == sg.l_adj:  # Message came from left peer.
+        if su.swapper == sg.l_adj:  # Message came from left peer.
             self.l_complete = True
-            self.lb_key = su["l_key"]
-            self.la_key = su["r_key"]
-            self.q_paths = _intersect_path_ids(self.q_paths, su["q_paths"])
-            if expiry == 0:
+            self.lb_key = su.p_key
+            self.la_key = su.o_key
+            self.q_paths = _intersect_path_ids(self.q_paths, su.q_paths)
+            if su.expiry == 0:
                 # Left peer does not need to hear about the failure they just told us.
                 self.l_sent = True
-        elif swapper == sg.r_adj:  # Message came from right peer.
+        elif su.swapper == sg.r_adj:  # Message came from right peer.
             self.r_complete = True
-            self.rb_key = su["r_key"]
-            self.ra_key = su["l_key"]
-            self.q_paths = _intersect_path_ids(self.q_paths, su["q_paths"])
-            if expiry == 0:
+            self.rb_key = su.p_key
+            self.ra_key = su.o_key
+            self.q_paths = _intersect_path_ids(self.q_paths, su.q_paths)
+            if su.expiry == 0:
                 # Right peer does not need to hear about the failure they just told us.
                 self.r_sent = True
         else:
-            raise RuntimeError(f"SwapGroup({sg.nodes},{sg.own_idx}) received swap outcome from unexpected node {swapper}")
+            raise RuntimeError(f"SwapGroup({sg.nodes},{sg.own_idx}) received swap outcome from unexpected node {su.swapper}")
 
         self._pivot_sg()
         return self._check_triggers()
@@ -223,12 +236,19 @@ class _SwapTask:
             return
 
         fib_entry = self.proc.fib.get(self.q_paths[0])
-        assert fib_entry.sg
-        self.sg = fib_entry.sg
+        sg = unwrap(fib_entry.sg)
+        if sg.l_adj == self.sg.r_adj or sg.r_adj == self.sg.l_adj:
+            self.l_complete, self.r_complete = self.r_complete, self.l_complete
+            self.lc_paths, self.rc_paths = self.rc_paths, self.lc_paths
+            self.l_sent, self.r_sent = self.r_sent, self.l_sent
+            self.la_key, self.ra_key = self.ra_key, self.la_key
+            self.lb_key, self.rb_key = self.rb_key, self.lb_key
+        self.sg = sg
 
     def _check_triggers(self) -> list[_SwapHerald]:
         sg = self.sg
         heralds: list[_SwapHerald] = []
+        spoiled = self.expiry == 0 or not self.q_paths
 
         if (
             not self.l_sent  # leftward herald is allowed at most once
@@ -243,10 +263,13 @@ class _SwapTask:
                 )
             )
         ):
-            su = self._make_base_su()
-            su.update(
-                l_node=sg.l_adj,
-                l_key=self.lb_key if sg.l_most else self.la_key,
+            su = self._make_su(
+                [
+                    sg.l_adj,
+                    self.lb_key if sg.l_most else self.la_key,
+                    self.UNKNOWN if spoiled else sg.r_neigh,
+                    self.UNKNOWN if spoiled else self.rb_key,
+                ]
             )
             heralds.append(_SwapHerald(su, sg.l_adj, unwrap_cast(self.lc_paths)))
             self.l_sent = True
@@ -254,27 +277,26 @@ class _SwapTask:
         if not self.r_sent and (
             self.o_started if self.expiry == 0 else (self.l_complete and self.o_complete and sg.dir in ("r", "b"))
         ):
-            su = self._make_base_su()
-            su.update(
-                r_node=sg.r_adj,
-                r_key=self.rb_key if sg.r_most else self.ra_key,
+            su = self._make_su(
+                [
+                    sg.r_adj,
+                    self.rb_key if sg.r_most else self.ra_key,
+                    self.UNKNOWN if spoiled else sg.l_neigh,
+                    self.UNKNOWN if spoiled else self.lb_key,
+                ]
             )
             heralds.append(_SwapHerald(su, sg.r_adj, unwrap_cast(self.rc_paths)))
             self.r_sent = True
 
         return heralds
 
-    def _make_base_su(self) -> SwapUpdateMsg:
+    def _make_su(self, ends: list[str]) -> SwapUpdateMsg:
         sg = self.sg
-        spoiled = self.expiry == 0 or not self.q_paths
         return SwapUpdateMsg(
             cmd="SWAP_UPDATE",
             path_id=-1,
-            o_node=sg.own_node,
-            l_node=self.UNKNOWN if spoiled else sg.l_neigh,
-            r_node=self.UNKNOWN if spoiled else sg.r_neigh,
-            l_key=self.UNKNOWN if spoiled else self.lb_key,
-            r_key=self.UNKNOWN if spoiled else self.rb_key,
+            swapper=sg.own_node,
+            ends=ends,
             expiry=unwrap_cast(self.expiry),
             # .q_paths is set in .begin_local_swap(), which is a prerequisite of .o_started and .o_complete
             q_paths=unwrap_cast(self.q_paths),
@@ -337,7 +359,7 @@ class ForwarderSwapProc(ForwarderModule):
         self.error_at_finish = error_at_finish
         """Whether to apply memory errors at swap finish time instead of swap start time."""
 
-        self.waiting_su: dict[str, tuple[SwapUpdateMsg, FibEntry]] = {}
+        self.waiting_su: dict[str, _SwapParsedUpdate] = {}
         """
         SwapUpdates received prior to QubitEntangledEvent.
 
@@ -433,20 +455,25 @@ class ForwarderSwapProc(ForwarderModule):
         Start swapping between two memory qubits.
 
         Args:
-            mq0: First qubit, must be in ELIGIBLE state.
-            mq1: Second qubit, must be in ELIGIBLE state and come from a different qchannel.
+            mq0: Left qubit.
+            mq1: Right qubit.
             fib_entry: FIB entry.
         """
         assert mq0.addr != mq1.addr
         assert mq0.qchannel is not mq1.qchannel
 
-        # Retrieve both qubits and determine directions.
-        arms = self._s_get_arms(mq0, mq1)
+        # Retrieve both qubits.
+        arms = [_SwapArm.new(mq0), _SwapArm.new(mq1)]
 
         # Record local swap start in SwapTask.
         task, task_from = self._s_get_task(fib_entry, arms)
         task.begin_local_swap(*arms)
         task_saved = self._s_put_task(task, arms)
+
+        # Set SWAPPING state, so that forwarder cannot start another swapping on the same qubit.
+        # The ALLOWED_STATE_TRANSITIONS matrix verifies existing state is ELIGIBLE.
+        mq0.state = QubitState.SWAPPING
+        mq1.state = QubitState.SWAPPING
 
         # Schedule swap completion event.
         # If the FIB entry is being uninstalled, swap delay is bypassed and local swap is deemed failed.
@@ -455,37 +482,10 @@ class ForwarderSwapProc(ForwarderModule):
             finish_time = now + self.delay.calculate()
         else:
             finish_time = now
-        self.simulator.add_event(
-            func_to_event(finish_time, self._s_finish, arms, fib_entry, finish_time if self.error_at_finish else now, task)
-        )
+        error_time = finish_time if self.error_at_finish else now
+        self.simulator.add_event(func_to_event(finish_time, self._s_finish, arms, fib_entry, error_time, task))
 
         self.log_debug("SWAP_START %s retrieved-from=%s saved-at=%s finish-time=%s", task, task_from, task_saved, finish_time)
-
-    def _s_get_arms(self, mq0: MemoryQubit, mq1: MemoryQubit) -> Sequence[_SwapArm]:
-        arms: MutableSequence[_SwapArm | None] = [None, None]
-
-        for mq in mq0, mq1:
-            # Retrieve qubit.
-            _, epr = self.memory.read(mq.addr, has=self.epr_type)
-
-            # Set SWAPPING state, so that forwarder cannot start another swapping on the same qubit.
-            # The ALLOWED_STATE_TRANSITIONS matrix verifies existing state is ELIGIBLE.
-            mq.state = QubitState.SWAPPING
-
-            # Determine direction.
-            if epr.dst is self.node:
-                idx = 0
-            elif epr.src is self.node:
-                idx = 1
-            else:
-                raise RuntimeError(f"{self}: node not in {epr} stored at {mq}")
-
-            # Save to destination array.
-            # Ensure each arm has a different direction.
-            assert arms[idx] is None
-            arms[idx] = _SwapArm.new(mq)
-
-        return cast(Sequence[_SwapArm], arms)
 
     def _s_get_task(
         self, fib_entry: FibEntry, arms: Sequence[_SwapArm], task_via_event: _SwapTask | None = None
@@ -517,7 +517,7 @@ class ForwarderSwapProc(ForwarderModule):
         """
         Complete swapping between two memory qubits.
 
-        This is scheduled by ``.start()`` after Bell-State Analyzer delay.
+        This is scheduled by ``.start()`` after ``swap_delay``.
         """
 
         # Retrieve physical EPRs.
@@ -561,9 +561,19 @@ class ForwarderSwapProc(ForwarderModule):
         if len(phy_eprs) != 2:
             return None, "SWAP_ABORT", False
 
+        epr0, epr1 = phy_eprs
+        flip0 = 0
+        flip1 = 0
+        if epr0.dst is not self.node:
+            flip0 = 1
+            epr0.flip_direction()
+        if epr1.src is not self.node:
+            flip1 = 1
+            epr1.flip_direction()
+
         # Attempt the physical swap.
         # Memory error model is applied as of the specified time point.
-        new_epr, local_success = Entanglement.swap(*phy_eprs, now=error_t, ps=self.ps, error=self.error)
+        new_epr, local_success = Entanglement.swap(epr0, epr1, now=error_t, ps=self.ps, error=self.error)
 
         # Update physical swap counters.
         if local_success:
@@ -574,7 +584,7 @@ class ForwarderSwapProc(ForwarderModule):
         # Deposit physical swap result.
         self._s_physical_deposit(new_epr)
 
-        return new_epr, "SWAP_SUCC" if local_success else "SWAP_FAIL", local_success
+        return new_epr, f"SWAP_{'SUCC' if local_success else 'FAIL'}_{flip0}{flip1}", local_success
 
     def _s_physical_deposit(self, new_epr: Entanglement) -> None:
         if new_epr.is_decohered:
@@ -599,110 +609,130 @@ class ForwarderSwapProc(ForwarderModule):
         before D is notified. This cannot be resolved with ``Event.priority`` mechanism because R and D may be
         notified at different times depending on the link architecture.
         """
-        su_args = self.waiting_su.pop(unwrap(qubit.key), None)
+        su = self.waiting_su.pop(unwrap(qubit.key), None)
         if (
             qubit.state is not QubitState.RELEASE  # qubit was released due to uninstalled path
-            and su_args
+            and su
         ):
-            self.handle_update(*su_args)
+            self.handle_update(su)
 
     @fw_signaling_cmd_handler("SWAP_UPDATE")
     def receive_update(self, msg: SwapUpdateMsg, fib_entry: FibEntry) -> None:
-        self.handle_update(msg, fib_entry)
-
-    def handle_update(self, msg: SwapUpdateMsg, fib_entry: FibEntry) -> None:
         """
-        Process an SWAP_UPDATE signaling message.
+        Receive an SWAP_UPDATE signaling message.
 
         Args:
             msg: The SWAP_UPDATE message.
             fib_entry: FIB entry associated with path_id in the message.
         """
+        ends = msg["ends"]
+        if ends[0] == self.node.name:
+            _, o_key, partner, p_key = ends
+        elif ends[2] == self.node.name:
+            partner, p_key, _, o_key = ends
+        else:
+            raise ValueError(f"SWAP_UPDATE does not address node {self.node.name} | {msg}")
+
+        swapper = msg["swapper"]
+        q_paths = msg["q_paths"]
+        if partner not in fib_entry.route and q_paths:
+            for path_id in q_paths:
+                fe = self.fib.get(path_id)
+                if swapper in fe.route and partner in fe.route:
+                    fib_entry = fe
+                    break
+        _, swapper_rank = fib_entry.find_index_and_swap_rank(swapper)
+
+        self.handle_update(
+            _SwapParsedUpdate(
+                fib_entry=fib_entry,
+                expiry=msg["expiry"],
+                q_paths=q_paths,
+                swapper=swapper,
+                swapper_rank=swapper_rank,
+                o_key=o_key,
+                partner=partner,
+                p_key=p_key,
+            )
+        )
+
+    def handle_update(self, su: _SwapParsedUpdate) -> None:
+        """
+        Process a received or dequeued SWAP_UPDATE signaling message.
+        """
         if not self.node.timing.is_internal():
             self.log_debug("INT phase is over -> stop swaps")
             return
 
-        swapper_idx, swapper_rank = fib_entry.find_index_and_swap_rank(msg["o_node"])
-        if swapper_idx < fib_entry.own_idx:
-            # Own node is to the right of the swapper, so that swapper's r_key is in own memory.
-            o_key = msg["r_key"]
-        else:
-            o_key = msg["l_key"]
-
         # Defer after LinkArchSuccessEvent and QubitEntangledEvent for the qubit are processed.
-        if (qubit_pair := self.memory.read(o_key)) and qubit_pair[0].state in (QubitState.RESERVED, QubitState.ENTANGLED0):
-            self.waiting_su[o_key] = (msg, fib_entry)
+        if (qubit_pair := self.memory.read(su.o_key)) and qubit_pair[0].state in (QubitState.RESERVED, QubitState.ENTANGLED0):
+            self.waiting_su[su.o_key] = su
             return
 
         # If the swapper has a lower rank, it indicates the completion of a lower-ranked swap task.
         # Save its outcome into memory, so that this node can start purification and own-rank swapping,
-        if swapper_rank < fib_entry.own_swap_rank:
-            self._u_lower(msg, fib_entry, qubit_pair, o_key, swapper_idx, swapper_rank)
+        if su.swapper_rank < su.fib_entry.own_swap_rank:
+            self._u_lower(su, qubit_pair)
             return
 
         # If the swapper has the same rank, it is part of the swap task that is potentially parallel.
         # qubit_pair would be None, if own node has already swapped.
-        assert swapper_rank == fib_entry.own_swap_rank
-        self._u_same(msg, fib_entry, qubit_pair, o_key)
+        assert su.swapper_rank == su.fib_entry.own_swap_rank
+        self._u_same(su, qubit_pair)
 
     def _u_lower(
         self,
-        msg: SwapUpdateMsg,
-        fib_entry: FibEntry,
+        su: _SwapParsedUpdate,
         qubit_pair: tuple[MemoryQubit, QuantumModel | None] | None,
-        qubit_key: str,
-        swapper_idx: int,
-        swapper_rank: int,
     ) -> None:
         """Process SWAP_UPDATE sent from a lower-ranked node."""
 
         # Retrieve qubit and new physical EPR.
         qubit = qubit_pair[0] if qubit_pair else None
-        new_phy = self.remote_swapped.pop(qubit_key, None)
+        new_phy = self.remote_swapped.pop(su.o_key, None)
 
         # If the lower-ranked swap failed, had conflict path, or the new EPR has decohered, release the qubit.
-        q_paths = msg["q_paths"]
-        expiry = msg["expiry"]
-        if not q_paths or expiry <= self.simulator.tc.time_slot:
+        if not su.q_paths or su.expiry <= self.simulator.tc.time_slot:
             if qubit:
-                if expiry == 0:
+                if su.expiry == 0:
                     self.fw_cnt.n_su_lower[3] += 1
-                    self.log_debug("releasing qubit %s reason=lower-swap-failure key=%s | %s", qubit.addr, qubit_key, new_phy)
-                elif not q_paths:
+                    self.log_debug("releasing qubit %s reason=lower-swap-failure key=%s | %s", qubit.addr, su.o_key, new_phy)
+                elif not su.q_paths:
                     self.fw_cnt.n_su_lower[4] += 1
-                    self.log_debug("releasing qubit %s reason=lower-swap-conflict key=%s | %s", qubit.addr, qubit_key, new_phy)
+                    self.log_debug("releasing qubit %s reason=lower-swap-conflict key=%s | %s", qubit.addr, su.o_key, new_phy)
                 else:
                     self.fw_cnt.n_su_lower[2] += 1
                     self.log_debug(
                         "releasing qubit %s reason=lower-expiry expiry=%s key=%s | %s",
                         qubit.addr,
-                        self.simulator.time(time_slot=expiry),
-                        qubit_key,
+                        self.simulator.time(time_slot=su.expiry),
+                        su.o_key,
                         new_phy,
                     )
                 self.fw.release_qubit(qubit, need_remove=True)
             else:
                 self.fw_cnt.n_su_lower[1] += 1
-                self.log_debug("qubit decohered during SWAP_UPDATE transmission key=%s | %s", qubit_key, new_phy)
+                self.log_debug("qubit decohered during SWAP_UPDATE transmission key=%s | %s", su.o_key, new_phy)
             return
-        assert qubit, f"qubit not found for {qubit_key}"
-        assert new_phy, f"new_phy not found for {qubit_key}"
+        assert qubit, f"qubit not found for {su.o_key}"
+        assert new_phy, f"new_phy not found for {su.o_key}"
 
         # Verify that the new physical EPR matches the heralded EPR segment.
         # This logic only supports ASAP parallel swap at the lowest rank.
         # Having parallel swap at any higher rank would break the assertion, because the physical EPR
         # may have been swapped by a peer when own node processes SWAP_UPDATE.
-        if swapper_idx < fib_entry.own_idx:
-            assert (partner := unwrap_cast(new_phy.src)).name == msg["l_node"]
-            assert new_phy.dst is self.node
-            p_key = msg["l_key"]
+        if new_phy.src is self.node:
+            partner = unwrap_cast(new_phy.dst)
+        elif new_phy.dst is self.node:
+            partner = unwrap_cast(new_phy.src)
         else:
-            assert (partner := unwrap_cast(new_phy.dst)).name == msg["r_node"]
-            assert new_phy.src is self.node
-            p_key = msg["r_key"]
+            raise ValueError(f"new_phy does not match node {self.node.name} | {new_phy}")
+        assert partner.name == su.partner
+
+        assert su.partner in su.fib_entry.route
 
         # Store new EPR.
-        qubit.partner = partner, p_key
+        qubit.partner = partner, su.p_key
         self.memory.write(qubit.addr, new_phy, replace=True)
 
         self.fw_cnt.n_su_lower[0] += 1
@@ -710,33 +740,31 @@ class ForwarderSwapProc(ForwarderModule):
             "segment %s-%s swap completed for rank %s",
             unwrap_cast(new_phy.src).name,
             unwrap_cast(new_phy.dst).name,
-            swapper_rank,
+            su.swapper_rank,
         )
 
         # Progress toward purification and this-rank swap.
         qubit.purif_rounds = 0
         qubit.state = QubitState.PURIF
-        self.fw.qubit_is_purif(qubit, fib_entry, partner)
+        self.fw.qubit_is_purif(qubit, su.fib_entry, partner)
 
     def _u_same(
         self,
-        msg: SwapUpdateMsg,
-        fib_entry: FibEntry,
+        su: _SwapParsedUpdate,
         qubit_pair: tuple[MemoryQubit, QuantumModel | None] | None,
-        qubit_key: str,
     ) -> None:
         """Process SWAP_UPDATE sent from a same-ranked node."""
 
         # Retrieve SwapTask.
-        task, task_from = self._u_get_task(fib_entry, qubit_key)
+        task, task_from = self._u_get_task(su.fib_entry, su.o_key)
 
         # If qubit does not exist, it means own node had swap failure previously and already notified both sides,
         # but the remote swap occurred while the outgoing SWAP_UPDATE is still in flight.
         if not task.o_complete and qubit_pair is None:
             self.fw_cnt.n_su_same[1] += 1
             deleted_from = None
-            if self.remote_swapped.pop(qubit_key, None):
-                deleted_from = f"remote_swapped[{qubit_key}]"
+            if self.remote_swapped.pop(su.o_key, None):
+                deleted_from = f"remote_swapped[{su.o_key}]"
             self.log_debug(
                 "SWAP_UPDATE_SAME %s retrieved-from=%s DROPPED reason=previous-swap-failure deleted-from=%s",
                 task,
@@ -747,15 +775,15 @@ class ForwarderSwapProc(ForwarderModule):
             return
 
         # Record heralded swap outcome in SwapTask, and then send heralding if allowed.
-        heralds = task.notify_remote_swap(msg)
+        heralds = task.notify_remote_swap(su)
         task_saved = None
         if not task.o_complete:
-            self.task_by_qubit[qubit_key] = task
-            task_saved = f"task_by_qubit[{qubit_key}]"
+            self.task_by_qubit[su.o_key] = task
+            task_saved = f"task_by_qubit[{su.o_key}]"
             self.sched_expire_task(task)
 
             # Expose the narrowed q_paths to qubit selection algorithm.
-            mq, _ = self.memory.read(qubit_key, must=True)
+            mq, _ = self.memory.read(su.o_key, must=True)
             mq.epr_path_ids = task.q_paths
 
         self.fw_cnt.n_su_same[0] += 1

--- a/mqns/network/fw/fw_swap.py
+++ b/mqns/network/fw/fw_swap.py
@@ -10,9 +10,8 @@ from mqns.models.error import ErrorModel
 from mqns.network.fw.fib import FibEntry, FibSwapGroup
 from mqns.network.fw.fw_module import ForwarderModule, fw_signaling_cmd_handler
 from mqns.network.fw.message import SwapUpdateMsg
-from mqns.network.fw.mux import MuxScheme
 from mqns.simulator import Event, Time, func_to_event
-from mqns.utils import unwrap_cast
+from mqns.utils import unwrap, unwrap_cast
 
 if TYPE_CHECKING:
     from mqns.network.fw.forwarder import Forwarder
@@ -24,12 +23,7 @@ def _intersect_path_ids(a: Iterable[int] | None, b: Iterable[int]) -> list[int]:
     return sorted(i for i in a if i in b)
 
 
-def _qubit_key(mq: MemoryQubit) -> str:
-    assert mq.key, f"missing reservation key in {mq}"
-    return mq.key
-
-
-class SwapArm(NamedTuple):
+class _SwapArm(NamedTuple):
     mq: MemoryQubit
     """Local qubit entangled with partner."""
     o_key: str
@@ -37,11 +31,17 @@ class SwapArm(NamedTuple):
     p_key: str
     """Partner qubit reservation key."""
 
+    @staticmethod
+    def new(mq: MemoryQubit) -> "_SwapArm":
+        o_key = unwrap(mq.key)
+        p_key = o_key if mq.partner is None else mq.partner[1]
+        return _SwapArm(mq, o_key, p_key)
+
     def __repr__(self) -> str:
         return f"SwapArm(qubit={self.mq.addr}, o-key={self.o_key}, p-key={self.p_key})"
 
 
-class SwapHerald(NamedTuple):
+class _SwapHerald(NamedTuple):
     """Heralding instruction."""
 
     su: SwapUpdateMsg
@@ -56,7 +56,7 @@ class SwapHerald(NamedTuple):
     """Possible path IDs for classical signaling, must be non-empty."""
 
 
-class SwapTask:
+class _SwapTask:
     """
     Track the logical progress of a swap process within a swap group.
 
@@ -112,10 +112,9 @@ class SwapTask:
 
     def __init__(self, proc: "ForwarderSwapProc", fib_entry: FibEntry):
         self.proc = proc
-        assert fib_entry.sg
-        self.sg = fib_entry.sg
+        self.sg = unwrap(fib_entry.sg)
 
-    def begin_local_swap(self, la: SwapArm, ra: SwapArm) -> None:
+    def begin_local_swap(self, la: _SwapArm, ra: _SwapArm) -> None:
         """
         Record start of local swap.
 
@@ -148,7 +147,7 @@ class SwapTask:
         if self.sg.r_most:
             self.rb_key = self.ra_key
 
-    def end_local_swap(self, expiry: int) -> list[SwapHerald]:
+    def end_local_swap(self, expiry: int) -> list[_SwapHerald]:
         """
         Save local swap outcome.
 
@@ -156,8 +155,7 @@ class SwapTask:
             expiry: Zero on swap failure, otherwise time slot for swapped EPR expiration time.
 
         Returns:
-            [0]: Instruction to herald left node, if allowed.
-            [1]: Instruction to herald right node, if allowed.
+            Heralding instructions, if any.
         """
         assert self.o_started, "{self}: end_local_swap without start_local_swap"
 
@@ -172,7 +170,7 @@ class SwapTask:
 
         return self._check_triggers()
 
-    def notify_remote_swap(self, su: SwapUpdateMsg) -> list[SwapHerald]:
+    def notify_remote_swap(self, su: SwapUpdateMsg) -> list[_SwapHerald]:
         """
         Save heralded swap outcome.
 
@@ -180,8 +178,7 @@ class SwapTask:
             su: SWAP_UPDATE message.
 
         Returns:
-            [0]: Instruction to herald left node, if allowed.
-            [1]: Instruction to herald right node, if allowed.
+            Heralding instructions, if any.
         """
         expiry = su["expiry"]
         self._update_expiry(expiry)
@@ -229,9 +226,9 @@ class SwapTask:
         assert fib_entry.sg
         self.sg = fib_entry.sg
 
-    def _check_triggers(self) -> list[SwapHerald]:
+    def _check_triggers(self) -> list[_SwapHerald]:
         sg = self.sg
-        heralds: list[SwapHerald] = []
+        heralds: list[_SwapHerald] = []
 
         if (
             not self.l_sent  # leftward herald is allowed at most once
@@ -251,7 +248,7 @@ class SwapTask:
                 l_node=sg.l_adj,
                 l_key=self.lb_key if sg.l_most else self.la_key,
             )
-            heralds.append(SwapHerald(su, sg.l_adj, unwrap_cast(self.lc_paths)))
+            heralds.append(_SwapHerald(su, sg.l_adj, unwrap_cast(self.lc_paths)))
             self.l_sent = True
 
         if not self.r_sent and (
@@ -262,7 +259,7 @@ class SwapTask:
                 r_node=sg.r_adj,
                 r_key=self.rb_key if sg.r_most else self.ra_key,
             )
-            heralds.append(SwapHerald(su, sg.r_adj, unwrap_cast(self.rc_paths)))
+            heralds.append(_SwapHerald(su, sg.r_adj, unwrap_cast(self.rc_paths)))
             self.r_sent = True
 
         return heralds
@@ -285,7 +282,7 @@ class SwapTask:
 
     def __repr__(self) -> str:
         return (
-            f"SwapTask(path_id={self.sg.path_id}, group={self.sg.nodes}, "
+            f"SwapTask(path_id={self.sg.path_id}, group={self.sg.repr_route()}, "
             f"c-paths={self.lc_paths}:{self.rc_paths}, q-paths={self.q_paths}, "
             f"complete={self.l_complete and 'l' or '_'}"
             f"{self.o_complete and 'o' or (self.o_started and 'O' or '_')}"
@@ -295,8 +292,8 @@ class SwapTask:
         )
 
 
-class SwapTaskExpireEvent(Event):
-    def __init__(self, task: SwapTask, *, t: Time):
+class _SwapTaskExpireEvent(Event):
+    def __init__(self, task: _SwapTask, *, t: Time):
         super().__init__(t)
         self.task = task
 
@@ -329,8 +326,6 @@ class ForwarderSwapProc(ForwarderModule):
     This has no effect if set to a negative number or the simulation is continuous.
     """
 
-    mux: MuxScheme
-
     def __init__(self, *, ps: float, delay: DelayModel, error: ErrorModel, error_at_finish: bool):
         self.ps = ps
         """Probability of successful entanglement swapping."""
@@ -358,7 +353,7 @@ class ForwarderSwapProc(ForwarderModule):
         * Value: Physical EPR object.
         """
 
-        self.task_by_qubit: dict[str, SwapTask] = {}
+        self.task_by_qubit: dict[str, _SwapTask] = {}
         """
         SwapTask associated with a memory qubit.
 
@@ -368,7 +363,6 @@ class ForwarderSwapProc(ForwarderModule):
 
     def install(self, fw: "Forwarder"):
         super().install(fw)
-        self.mux = fw.mux
 
         if not self.simulator.is_continuous:
             event = func_to_event(self.simulator.te, self.check_table_leak)
@@ -414,7 +408,7 @@ class ForwarderSwapProc(ForwarderModule):
             deleted_from.append(f"task_by_qubit[{key}]")
         self.log_debug("DECOHERE key=%s deleted-from=%s", mq.key, deleted_from)
 
-    def _heralds(self, heralds: list[SwapHerald]) -> None:
+    def _heralds(self, heralds: list[_SwapHerald]) -> None:
         """
         Send heralding messages.
         """
@@ -465,14 +459,12 @@ class ForwarderSwapProc(ForwarderModule):
 
         self.log_debug("SWAP_START %s retrieved-from=%s saved-at=%s finish-time=%s", task, task_from, task_saved, finish_time)
 
-    def _s_get_arms(self, mq0: MemoryQubit, mq1: MemoryQubit) -> Sequence[SwapArm]:
-        arms: MutableSequence[SwapArm | None] = [None, None]
+    def _s_get_arms(self, mq0: MemoryQubit, mq1: MemoryQubit) -> Sequence[_SwapArm]:
+        arms: MutableSequence[_SwapArm | None] = [None, None]
 
         for mq in mq0, mq1:
             # Retrieve qubit.
             _, epr = self.memory.read(mq.addr, has=self.epr_type)
-            o_key = _qubit_key(mq)
-            p_key = o_key if mq.partner is None else mq.partner[1]
 
             # Set SWAPPING state, so that forwarder cannot start another swapping on the same qubit.
             # The ALLOWED_STATE_TRANSITIONS matrix verifies existing state is ELIGIBLE.
@@ -489,14 +481,14 @@ class ForwarderSwapProc(ForwarderModule):
             # Save to destination array.
             # Ensure each arm has a different direction.
             assert arms[idx] is None
-            arms[idx] = SwapArm(mq, o_key, p_key)
+            arms[idx] = _SwapArm.new(mq)
 
-        return cast(Sequence[SwapArm], arms)
+        return cast(Sequence[_SwapArm], arms)
 
     def _s_get_task(
-        self, fib_entry: FibEntry, arms: Sequence[SwapArm], task_via_event: SwapTask | None = None
-    ) -> tuple[SwapTask, str]:
-        task: SwapTask | None = None
+        self, fib_entry: FibEntry, arms: Sequence[_SwapArm], task_via_event: _SwapTask | None = None
+    ) -> tuple[_SwapTask, str]:
+        task: _SwapTask | None = None
         task_from: list[str] = []
         for arm in arms:
             if t := self.task_by_qubit.pop(arm.o_key, None):
@@ -507,9 +499,9 @@ class ForwarderSwapProc(ForwarderModule):
 
         if task_via_event:
             return task_via_event, "event"
-        return SwapTask(self, fib_entry), "constructor"
+        return _SwapTask(self, fib_entry), "constructor"
 
-    def _s_put_task(self, task: SwapTask, arms: Sequence[SwapArm]) -> list[str]:
+    def _s_put_task(self, task: _SwapTask, arms: Sequence[_SwapArm]) -> list[str]:
         task_saved: list[str] = []
         for i, dir_complete in enumerate((task.l_complete, task.r_complete)):
             if dir_complete:
@@ -519,7 +511,7 @@ class ForwarderSwapProc(ForwarderModule):
             task_saved.append(f"task_by_qubit[{arm.o_key}]")
         return task_saved
 
-    def _s_finish(self, arms: Sequence[SwapArm], fib_entry: FibEntry, error_t: Time, task_via_event: SwapTask):
+    def _s_finish(self, arms: Sequence[_SwapArm], fib_entry: FibEntry, error_t: Time, task_via_event: _SwapTask):
         """
         Complete swapping between two memory qubits.
 
@@ -527,11 +519,10 @@ class ForwarderSwapProc(ForwarderModule):
         """
 
         # Retrieve physical EPRs.
-        # Save ch_index metadata field onto elementary EPR.
         local_expiry: list[int] = []
-        alive_arms: list[SwapArm] = []
+        alive_arms: list[_SwapArm] = []
         phy_eprs: list[Entanglement] = []
-        for i, arm in enumerate(arms):
+        for arm in arms:
             if arm.mq.state is not QubitState.SWAPPING or arm.mq.key != arm.o_key:
                 # Elementary EPR decohered and potentially replaced.
                 continue
@@ -539,8 +530,6 @@ class ForwarderSwapProc(ForwarderModule):
             _, epr = self.memory.read(arm.mq.addr, has=self.epr_type, remove=True)
             local_expiry.append(epr.decohere_time.time_slot)
             phy = self.remote_swapped.pop(arm.o_key, epr)
-            if not phy.orig_eprs:
-                phy.ch_index = fib_entry.own_idx - 1 + i
             phy_eprs.append(phy)
 
         # If the FIB entry is being uninstalled, local swap is deemed failed.
@@ -608,7 +597,7 @@ class ForwarderSwapProc(ForwarderModule):
         before D is notified. This cannot be resolved with ``Event.priority`` mechanism because R and D may be
         notified at different times depending on the link architecture.
         """
-        su_args = self.waiting_su.pop(_qubit_key(qubit), None)
+        su_args = self.waiting_su.pop(unwrap(qubit.key), None)
         if (
             qubit.state is not QubitState.RELEASE  # qubit was released due to uninstalled path
             and su_args
@@ -771,24 +760,24 @@ class ForwarderSwapProc(ForwarderModule):
         self.log_debug("SWAP_UPDATE_SAME %s retrieved-from=%s saved-at=%s", task, task_from, task_saved)
         self._heralds(heralds)
 
-    def _u_get_task(self, fib_entry: FibEntry, qubit_key: str) -> tuple[SwapTask, str]:
+    def _u_get_task(self, fib_entry: FibEntry, qubit_key: str) -> tuple[_SwapTask, str]:
         if t := self.task_by_qubit.pop(qubit_key, None):
             return t, f"task_by_qubit[qubit_key:={qubit_key}]"
-        return SwapTask(self, fib_entry), "constructor"
+        return _SwapTask(self, fib_entry), "constructor"
 
-    def sched_expire_task(self, task: SwapTask) -> None:
+    def sched_expire_task(self, task: _SwapTask) -> None:
         if task.has_expire_event:
             return
         task.has_expire_event = True
         t = self.simulator.tc if not task.expiry else self.simulator.time(time_slot=task.expiry)
         t += self.memory.t_cohere  # delay deletion so that incoming messages can be replied to
-        self.simulator.add_event(SwapTaskExpireEvent(task, t=t))
+        self.simulator.add_event(_SwapTaskExpireEvent(task, t=t))
 
-    def _expire_task(self, event: SwapTaskExpireEvent):
+    def _expire_task(self, event: _SwapTaskExpireEvent):
         task = event.task
         deleted_from: list[str] = []
         for key in task.la_key, task.ra_key:
-            if key != SwapTask.UNKNOWN and self.task_by_qubit.pop(key, None):
+            if key != _SwapTask.UNKNOWN and self.task_by_qubit.pop(key, None):
                 deleted_from.append(key)
         if deleted_from:
             self.log_debug("TASK_EXPIRE %s deleted-from=%s", task, deleted_from)

--- a/mqns/network/fw/fw_swap.py
+++ b/mqns/network/fw/fw_swap.py
@@ -395,18 +395,20 @@ class ForwarderSwapProc(ForwarderModule):
         self.remote_swapped.clear()
         self.task_by_qubit.clear()
 
-    def handle_decohere(self, mq: MemoryQubit) -> None:
+    def handle_decohere(self, key: str) -> None:
         """
-        Called by forwarder before releasing a qubit due to decoherence or CutOffScheme.
+        Cleanup state when releasing a qubit due to decoherence or CutOffScheme.
+
+        Args:
+            key: Qubit key.
         """
-        key = unwrap_cast(mq.key)
         deleted_from: list[str] = []
         if epr := self.remote_swapped.pop(key, None):
             epr.is_decohered = True
             deleted_from.append(f"remote_swapped[{key}]")
         if self.task_by_qubit.pop(key, None):
             deleted_from.append(f"task_by_qubit[{key}]")
-        self.log_debug("DECOHERE key=%s deleted-from=%s", mq.key, deleted_from)
+        self.log_debug("DECOHERE key=%s deleted-from=%s", key, deleted_from)
 
     def _heralds(self, heralds: list[_SwapHerald]) -> None:
         """

--- a/mqns/network/fw/message.py
+++ b/mqns/network/fw/message.py
@@ -152,29 +152,18 @@ class SwapUpdateMsg(TypedDict):
     path_id: int
     """FIB entry path ID to guide classical forwarding of this message."""
 
-    o_node: str
+    swapper: str
     """
     Node that performed the swap.
     This would be the sender of this message.
     """
-    l_node: str
-    """
-    Leftmost node of the swapped EPR.
-    This would be either the recipient of this message or its opposite partner.
-    """
-    r_node: str
-    """
-    Rightmost node of the swapped EPR.
-    This would be either the recipient of this message or its opposite partner.
-    """
 
-    l_key: str
+    ends: list[str]
     """
-    Qubit reservation key at ``l_node``.
-    """
-    r_key: str
-    """
-    Qubit reservation key at ``r_node``.
+    Left and right ends of the swapped EPR.
+
+    * [0] and [2] are the two node names, one of which would be the recipient of this message.
+    * [1] and [3] are the corresponding qubit reservation keys.
     """
 
     expiry: int
@@ -183,4 +172,4 @@ class SwapUpdateMsg(TypedDict):
     If positive, time slot of qubit decoherence based on heralded knowledge.
     """
     q_paths: list[int]
-    """Possible path IDs for the entanglement between ``l_node`` and ``r_node``."""
+    """Possible path IDs for the entanglement between left and right ends."""

--- a/mqns/network/fw/mux.py
+++ b/mqns/network/fw/mux.py
@@ -58,11 +58,13 @@ class MuxScheme(ForwarderModule, ABC):
         Handle a qubit entering ENTANGLED state, i.e. having an elementary entanglement.
 
         Pre-conditions:
+
         * The network is in ASYNC timing mode or INTERNAL phase.
         * ``mq.epr_path_ids`` is populated and non-empty.
         * ``epr`` is an elementary entanglement.
 
         Post-condition and return value:
+
         * ``mq.state is PURIF``: forwarder starts purification; FIB entry is required.
         * ``mq.state is ELIGIBLE``: forwarder starts swapping; FIB entry is optional.
         """

--- a/mqns/network/fw/mux.py
+++ b/mqns/network/fw/mux.py
@@ -1,13 +1,12 @@
 from abc import ABC, abstractmethod
 
-from mqns.entity.memory import MemoryQubit, PathDirection
+from mqns.entity.memory import MemoryQubit, PathDirection, QubitState
 from mqns.entity.node import QNode
 from mqns.entity.qchannel import QuantumChannel
 from mqns.models.epr import Entanglement
 from mqns.network.fw.fib import FibEntry
 from mqns.network.fw.fw_module import ForwarderModule
 from mqns.network.fw.message import PathInstructions
-from mqns.network.fw.select import MemoryEprIterator
 
 
 class MuxScheme(ForwarderModule, ABC):
@@ -70,24 +69,29 @@ class MuxScheme(ForwarderModule, ABC):
         """
 
     @abstractmethod
-    def find_swap_candidate(
+    def find_swap_with(
         self,
         mq0: MemoryQubit,
         epr0: Entanglement,
         fib_entry: FibEntry | None,
-        input: MemoryEprIterator,
     ) -> tuple[MemoryQubit, FibEntry] | None:
         """
-        Find another qubit to swap with an ELIGIBLE qubit.
+        Choose another qubit to swap with a qubit entering ELIGIBLE state and ready to swap.
 
         Args:
-            input: Candidates iterator. They are in ELIGIBLE state and assigned to a different channel.
-            mq0: A qubit in ELIGIBLE state.
-            epr: The EPR associated with this qubit. This is not an end-to-end entanglement.
-            fib_entry: FIB entry passed to ``fw.qubit_is_eligible()``.
+            mq0: The qubit entering ELIGIBLE state.
+            epr0: The entanglement stored in the qubit.
+            fib_entry: FIB entry found by ``MuxScheme.qubit_is_entangled`` or used in last round of purification.
 
         Returns:
-            None: No candidate, do not swap.
-            [0]: Another qubit in ELIGIBLE state.
-            [1]: FIB entry for ``fw.do_swapping()``.
+            None: Do not swap.
+            [0]: The other qubit, which must be in ELIGIBLE state.
+            [1]: FIB entry to guide ``ForwarderSwapProc``.
         """
+
+    @staticmethod
+    def qubits_swappable(mq0: MemoryQubit, mq1: MemoryQubit) -> bool:
+        """
+        Determine whether ``mq1`` in memory can swap with ``mq0``.
+        """
+        return mq1.state is QubitState.ELIGIBLE and mq1.qchannel is not mq0.qchannel

--- a/mqns/network/fw/mux.py
+++ b/mqns/network/fw/mux.py
@@ -18,13 +18,7 @@ class MuxScheme(ForwarderModule, ABC):
         """Validate install_path instructions are compatible."""
 
     @abstractmethod
-    def install_path_adj(
-        self,
-        instructions: PathInstructions,
-        fib_entry: FibEntry,
-        direction: PathDirection,
-        qchannel: QuantumChannel,
-    ) -> None:
+    def install_path_adj(self, inst: PathInstructions, fib_entry: FibEntry, dir: PathDirection, ch: QuantumChannel) -> None:
         """
         Store information about adjacent quantum channel and allocate resources.
 
@@ -36,12 +30,7 @@ class MuxScheme(ForwarderModule, ABC):
         """
 
     @abstractmethod
-    def uninstall_path_adj(
-        self,
-        fib_entry: FibEntry,
-        direction: PathDirection,
-        qchannel: QuantumChannel,
-    ) -> None:
+    def uninstall_path_adj(self, fib_entry: FibEntry, dir: PathDirection, ch: QuantumChannel) -> None:
         """
         Erase information about adjacent quantum channel and deallocate resources.
 

--- a/mqns/network/fw/mux_buffer_space.py
+++ b/mqns/network/fw/mux_buffer_space.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import TYPE_CHECKING, Protocol, override
+from typing import TYPE_CHECKING, Literal, Protocol, override
 
 from mqns.entity.memory import MemoryQubit, PathDirection, QubitState
 from mqns.entity.node import QNode
@@ -12,6 +12,7 @@ from mqns.network.fw.select import (
     MemoryEprIterator,
     MemoryEprTuple,
     call_select,
+    parse_select,
     select_random,
     select_swap_qubit_newest,
     select_swap_qubit_oldest,
@@ -46,6 +47,8 @@ class MuxSchemeFibBase(MuxScheme):
             """
             ...
 
+    type SelectSwapQubitInput = SelectSwapQubit | Literal["random", "oldest", "newest"] | None
+
     SelectSwapQubit_random: SelectSwapQubit = select_random
     """
     Select a random qubit among the candidates, following uniform distribution.
@@ -59,9 +62,9 @@ class MuxSchemeFibBase(MuxScheme):
     Select the qubit that becomes ELIGIBLE in this forwarder the latest, i.e. Last-In-First-Out (LIFO).
     """
 
-    def __init__(self, select_swap_qubit: SelectSwapQubit | None):
+    def __init__(self, select_swap_qubit: SelectSwapQubitInput):
         super().__init__()
-        self._select_swap_qubit = select_swap_qubit
+        self._select_swap_qubit = parse_select(type(self), "SelectSwapQubit_", select_swap_qubit)
 
     @override
     def find_swap_candidate(
@@ -85,7 +88,7 @@ class MuxSchemeBufferSpace(MuxSchemeFibBase):
     def __init__(
         self,
         *,
-        select_swap_qubit: MuxSchemeFibBase.SelectSwapQubit | None = None,
+        select_swap_qubit: MuxSchemeFibBase.SelectSwapQubitInput = None,
     ):
         """
         Args:

--- a/mqns/network/fw/mux_buffer_space.py
+++ b/mqns/network/fw/mux_buffer_space.py
@@ -139,7 +139,7 @@ class MuxSchemeBufferSpace(MuxSchemeFibBase):
 
     @override
     def list_qubit_epr_path_ids(self, mq: MemoryQubit) -> list[int]:
-        if mq.path_id is None:
+        if mq.path_id is None:  # path has been uninstalled
             return []
         return [mq.path_id]
 

--- a/mqns/network/fw/mux_buffer_space.py
+++ b/mqns/network/fw/mux_buffer_space.py
@@ -1,4 +1,3 @@
-from abc import abstractmethod
 from typing import TYPE_CHECKING, Literal, Protocol, override
 
 from mqns.entity.memory import MemoryQubit, PathDirection, QubitState
@@ -66,18 +65,12 @@ class MuxSchemeFibBase(MuxScheme):
         super().__init__()
         self._select_swap_qubit = parse_select(type(self), "SelectSwapQubit_", select_swap_qubit)
 
-    @override
-    def find_swap_candidate(
-        self, mq0: MemoryQubit, epr0: Entanglement, fib_entry: FibEntry | None, input: MemoryEprIterator
+    def select_swap_candidate(
+        self, mq0: MemoryQubit, epr0: Entanglement, fib_entry: FibEntry, candidates: MemoryEprIterator
     ) -> tuple[MemoryQubit, FibEntry] | None:
         assert fib_entry
-        mt1 = call_select(
-            self.list_swap_candidates(mq0, fib_entry, input), self._select_swap_qubit, self.fw, (mq0, epr0), fib_entry
-        )
+        mt1 = call_select(candidates, self._select_swap_qubit, self.fw, (mq0, epr0), fib_entry)
         return None if mt1 is None else (mt1[0], fib_entry)
-
-    @abstractmethod
-    def list_swap_candidates(self, mq0: MemoryQubit, fib_entry: FibEntry, input: MemoryEprIterator) -> MemoryEprIterator: ...
 
 
 class MuxSchemeBufferSpace(MuxSchemeFibBase):
@@ -153,10 +146,23 @@ class MuxSchemeBufferSpace(MuxSchemeFibBase):
         return self.fib.get(unwrap_cast(mq.path_id))
 
     @override
-    def list_swap_candidates(self, mq0: MemoryQubit, fib_entry: FibEntry, input: MemoryEprIterator):
-        return (
-            (q, v)
-            for (q, v) in input
-            if q.path_id == fib_entry.path_id  # allocated to the same path_id
-            and q.path_direction is not mq0.path_direction  # in the opposite path direction
+    def find_swap_with(
+        self,
+        mq0: MemoryQubit,
+        epr0: Entanglement,
+        fib_entry: FibEntry | None,
+    ) -> tuple[MemoryQubit, FibEntry] | None:
+        assert fib_entry
+        return self.select_swap_candidate(
+            mq0,
+            epr0,
+            fib_entry,
+            self.memory.find(
+                lambda q, _: (
+                    self.qubits_swappable(mq0, q)  # basic condition met
+                    and q.path_id == mq0.path_id  # allocated to the same path_id
+                    and q.path_direction is not mq0.path_direction  # in the opposite path direction
+                ),
+                has=self.epr_type,
+            ),
         )

--- a/mqns/network/fw/mux_buffer_space.py
+++ b/mqns/network/fw/mux_buffer_space.py
@@ -99,16 +99,10 @@ class MuxSchemeBufferSpace(MuxSchemeFibBase):
         assert "m_v" in instructions
 
     @override
-    def install_path_adj(
-        self,
-        instructions: PathInstructions,
-        fib_entry: FibEntry,
-        direction: PathDirection,
-        qchannel: QuantumChannel,
-    ) -> None:
-        assert "m_v" in instructions
-        mv = instructions["m_v"]
-        mv_offset, ch_side = (-1, 1) if direction == PathDirection.L else (0, 0)
+    def install_path_adj(self, inst: PathInstructions, fib_entry: FibEntry, dir: PathDirection, ch: QuantumChannel) -> None:
+        assert "m_v" in inst
+        mv = inst["m_v"]
+        mv_offset, ch_side = (-1, 1) if dir == PathDirection.L else (0, 0)
         mv_index = fib_entry.own_idx + mv_offset
         mv_element = mv[mv_index]
 
@@ -117,24 +111,24 @@ class MuxSchemeBufferSpace(MuxSchemeFibBase):
             qubit, _ = next(self.memory.find(lambda q, _: q.key == mv_element), (None, None))
             if qubit is None:
                 raise ValueError(f"m_v[{mv_index}] refers to non-existent qubit {mv_element}")
-            qubit.path_id, qubit.path_direction = fib_entry.path_id, direction
+            qubit.path_id, qubit.path_direction = fib_entry.path_id, dir
             addrs = [qubit.addr]
         else:
             # allocate memory qubit(s) assigned to the channel (typically used in proactive forwarding)
             n_qubits = mv_element[ch_side]
             addrs = self.memory.allocate(
-                qchannel,
+                ch,
                 fib_entry.path_id,
-                direction,
+                dir,
                 n="all" if n_qubits == 0 else n_qubits,
             )
-        self.fw.log_debug("allocating %s qubits: %s", direction, addrs)
+        self.fw.log_debug("allocating %s qubits: %s", dir, addrs)
 
     @override
-    def uninstall_path_adj(self, fib_entry: FibEntry, direction: PathDirection, qchannel: QuantumChannel) -> None:
-        qubits = self.memory.find(lambda q, _: q.path_id == fib_entry.path_id, qchannel=qchannel)
+    def uninstall_path_adj(self, fib_entry: FibEntry, dir: PathDirection, ch: QuantumChannel) -> None:
+        qubits = self.memory.find(lambda q, _: q.path_id == fib_entry.path_id, qchannel=ch)
         addrs = [q[0].addr for q in qubits]
-        self.fw.log_debug("deallocating %s qubits: %s", direction, addrs)
+        self.fw.log_debug("deallocating %s qubits: %s", dir, addrs)
         # If some qubits are currently ACTIVE or RESERVED IN LinkLayer, deallocation would occur
         # when they next reach RAW state.
         self.memory.deallocate(*addrs)

--- a/mqns/network/fw/mux_dynamic_epr.py
+++ b/mqns/network/fw/mux_dynamic_epr.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable
-from typing import override
+from typing import Literal, override
 
 import numpy as np
 
@@ -9,16 +9,16 @@ from mqns.models.epr import Entanglement
 from mqns.network.fw.fib import Fib, FibEntry
 from mqns.network.fw.mux_buffer_space import MuxSchemeFibBase
 from mqns.network.fw.mux_statistical import MuxSchemeDynamicBase
-from mqns.network.fw.select import MemoryEprIterator
+from mqns.network.fw.select import MemoryEprIterator, call_select, parse_select
 from mqns.utils import rng, unwrap_cast
 
 
-def _select_path_random(epr: Entanglement, fib: Fib, path_ids: list[int]) -> int:
+def _select_path_random(path_ids: list[int], epr: Entanglement, fib: Fib) -> int:
     _ = epr, fib
     return rng.choice(path_ids)
 
 
-def _select_path_swap_weighted(epr: Entanglement, fib: Fib, path_ids: list[int]) -> FibEntry:
+def _select_path_swap_weighted(path_ids: list[int], epr: Entanglement, fib: Fib) -> FibEntry:
     _ = epr
     entries = [fib.get(pid) for pid in path_ids]
     # fewer swaps (shorter route) means higher weight
@@ -32,7 +32,7 @@ class MuxSchemeDynamicEpr(MuxSchemeFibBase, MuxSchemeDynamicBase):
     Dynamic EPR Allocation multiplexing scheme.
     """
 
-    type SelectPath = Callable[[Entanglement, Fib, list[int]], int | FibEntry]
+    type SelectPath = Callable[[list[int], Entanglement, Fib], int | FibEntry]
     """
     Path selection strategy.
     Function to select a path for an elementary entanglement.
@@ -59,8 +59,8 @@ class MuxSchemeDynamicEpr(MuxSchemeFibBase, MuxSchemeDynamicBase):
     def __init__(
         self,
         *,
-        select_swap_qubit: MuxSchemeFibBase.SelectSwapQubit | None = None,
-        select_path: SelectPath = SelectPath_random,
+        select_swap_qubit: MuxSchemeFibBase.SelectSwapQubitInput | None = None,
+        select_path: SelectPath | Literal["random", "swap_weighted"] = SelectPath_random,
     ):
         """
         Args:
@@ -68,7 +68,7 @@ class MuxSchemeDynamicEpr(MuxSchemeFibBase, MuxSchemeDynamicBase):
             select_path: Function to select a path for an entangled qubit, default is random.
         """
         super().__init__(select_swap_qubit)
-        self._select_path = select_path
+        self._select_path = parse_select(type(self), "SelectPath_", select_path)
 
     @override
     def qubit_is_entangled(self, mq: MemoryQubit, epr: Entanglement, neighbor: QNode) -> FibEntry | None:
@@ -81,8 +81,8 @@ class MuxSchemeDynamicEpr(MuxSchemeFibBase, MuxSchemeDynamicBase):
             # The necessary information could be carried in the reservation message.
             # For ease of implementation, this choice is made at either primary or secondary node,
             # whichever receives the EPR notification earlier.
-            selected_path = self._select_path(epr, self.fib, unwrap_cast(mq.epr_path_ids))
-            fib_entry = selected_path if type(selected_path) is FibEntry else self.fib.get(selected_path)
+            selected_path = call_select(unwrap_cast(mq.epr_path_ids), self._select_path, epr, self.fib)
+            fib_entry = selected_path if type(selected_path) is FibEntry else self.fib.get(unwrap_cast(selected_path))
             epr.affectionated_path_id = fib_entry.path_id
         else:
             fib_entry = self.fib.get(epr.affectionated_path_id)

--- a/mqns/network/fw/mux_dynamic_epr.py
+++ b/mqns/network/fw/mux_dynamic_epr.py
@@ -9,7 +9,7 @@ from mqns.models.epr import Entanglement
 from mqns.network.fw.fib import Fib, FibEntry
 from mqns.network.fw.mux_buffer_space import MuxSchemeFibBase
 from mqns.network.fw.mux_statistical import MuxSchemeDynamicBase
-from mqns.network.fw.select import MemoryEprIterator, call_select, parse_select
+from mqns.network.fw.select import call_select, parse_select
 from mqns.utils import rng, unwrap_cast
 
 
@@ -92,6 +92,22 @@ class MuxSchemeDynamicEpr(MuxSchemeFibBase, MuxSchemeDynamicBase):
         return fib_entry
 
     @override
-    def list_swap_candidates(self, mq0: MemoryQubit, fib_entry: FibEntry, input: MemoryEprIterator):
-        _ = mq0
-        return ((q, v) for (q, v) in input if fib_entry.path_id in unwrap_cast(q.epr_path_ids))
+    def find_swap_with(
+        self,
+        mq0: MemoryQubit,
+        epr0: Entanglement,
+        fib_entry: FibEntry | None,
+    ) -> tuple[MemoryQubit, FibEntry] | None:
+        assert fib_entry
+        return self.select_swap_candidate(
+            mq0,
+            epr0,
+            fib_entry,
+            self.memory.find(
+                lambda q, _: (
+                    self.qubits_swappable(mq0, q)  # basic condition met
+                    and fib_entry.path_id in unwrap_cast(q.epr_path_ids)  # has compatible path_id
+                ),
+                has=self.epr_type,
+            ),
+        )

--- a/mqns/network/fw/mux_statistical.py
+++ b/mqns/network/fw/mux_statistical.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from collections.abc import Callable
-from typing import TYPE_CHECKING, override
+from typing import TYPE_CHECKING, Literal, override
 
 from mqns.entity.memory import MemoryQubit, PathDirection, QubitState
 from mqns.entity.node import QNode
@@ -13,6 +13,7 @@ from mqns.network.fw.select import (
     MemoryEprIterator,
     MemoryEprTuple,
     call_select,
+    parse_select,
     select_random,
     select_swap_qubit_newest,
     select_swap_qubit_oldest,
@@ -80,9 +81,9 @@ class MuxSchemeStatistical(MuxSchemeDynamicBase):
     def __init__(
         self,
         *,
-        select_swap_qubit: SelectSwapQubit | None = None,
+        select_swap_qubit: SelectSwapQubit | Literal["random", "oldest", "newest"] | None = None,
         coordinated_decisions=False,
-        select_path: SelectPath | None = None,
+        select_path: SelectPath | Literal["random"] | None = None,
     ):
         """
         Args:
@@ -97,9 +98,9 @@ class MuxSchemeStatistical(MuxSchemeDynamicBase):
                 This has no effect unless coordinated_decisions is True.
         """
         super().__init__()
-        self._select_swap_qubit = select_swap_qubit
+        self._select_swap_qubit = parse_select(type(self), "SelectSwapQubit_", select_swap_qubit)
         self.coordinated_decisions = coordinated_decisions
-        self._select_path = select_path
+        self._select_path = parse_select(type(self), "SelectPath_", select_path)
 
     @override
     def validate_path_instructions(self, instructions: PathInstructions):

--- a/mqns/network/fw/mux_statistical.py
+++ b/mqns/network/fw/mux_statistical.py
@@ -35,28 +35,17 @@ class MuxSchemeDynamicBase(MuxScheme):
         assert "m_v" not in instructions
 
     @override
-    def install_path_adj(
-        self,
-        instructions: PathInstructions,
-        fib_entry: FibEntry,
-        direction: PathDirection,
-        qchannel: QuantumChannel,
-    ) -> None:
-        _ = instructions, direction
-        self.qchannel_paths_map[qchannel.name].append(fib_entry.path_id)
+    def install_path_adj(self, inst: PathInstructions, fib_entry: FibEntry, dir: PathDirection, ch: QuantumChannel) -> None:
+        _ = inst, dir
+        self.qchannel_paths_map[ch.name].append(fib_entry.path_id)
 
     @override
-    def uninstall_path_adj(
-        self,
-        fib_entry: FibEntry,
-        direction: PathDirection,
-        qchannel: QuantumChannel,
-    ) -> None:
-        _ = direction
-        paths = self.qchannel_paths_map[qchannel.name]
+    def uninstall_path_adj(self, fib_entry: FibEntry, dir: PathDirection, ch: QuantumChannel) -> None:
+        _ = dir
+        paths = self.qchannel_paths_map[ch.name]
         paths.remove(fib_entry.path_id)
         if len(paths) == 0:
-            del self.qchannel_paths_map[qchannel.name]
+            del self.qchannel_paths_map[ch.name]
 
     @override
     def qubit_has_path_id(self) -> bool:

--- a/mqns/network/fw/mux_statistical.py
+++ b/mqns/network/fw/mux_statistical.py
@@ -10,7 +10,6 @@ from mqns.network.fw.fib import FibEntry
 from mqns.network.fw.message import PathInstructions, validate_path_instructions
 from mqns.network.fw.mux import MuxScheme
 from mqns.network.fw.select import (
-    MemoryEprIterator,
     MemoryEprTuple,
     call_select,
     parse_select,
@@ -138,25 +137,31 @@ class MuxSchemeStatistical(MuxSchemeDynamicBase):
         return None
 
     @override
-    def find_swap_candidate(
-        self, mq0: MemoryQubit, epr0: Entanglement, fib_entry: FibEntry | None, input: MemoryEprIterator
+    def find_swap_with(
+        self,
+        mq0: MemoryQubit,
+        epr0: Entanglement,
+        fib_entry: FibEntry | None,
     ) -> tuple[MemoryQubit, FibEntry] | None:
         mq0_path_ids = set(unwrap_cast(mq0.epr_path_ids))
+
+        candidates = self.memory.find(
+            lambda q, v: (
+                self.qubits_swappable(mq0, q)  # basic condition met
+                and not mq0_path_ids.isdisjoint(unwrap_cast(q.epr_path_ids))  # has overlapping epr_path_ids
+                and (
+                    not self.coordinated_decisions  # uncoordinated
+                    or v.affectionated_path_id < 0  # no existing decision
+                    or v.affectionated_path_id in mq0_path_ids  # compatible decisions
+                )
+            ),
+            has=self.epr_type,
+        )
 
         # Find another qubit to swap with.
         # The qubit must have overlapping epr_path_ids so that there would be one or more viable paths.
         # In coordinated_decision mode, the physical path_id (written by parallel swapping) must also match.
-        mt1 = call_select(
-            (
-                (q, v)
-                for (q, v) in input
-                if not mq0_path_ids.isdisjoint(unwrap_cast(q.epr_path_ids))  # has overlapping epr_path_ids
-                and (not self.coordinated_decisions or v.affectionated_path_id < 0 or v.affectionated_path_id in mq0_path_ids)
-            ),
-            self._select_swap_qubit,
-            self.fw,
-            (mq0, epr0),
-        )
+        mt1 = call_select(candidates, self._select_swap_qubit, self.fw, (mq0, epr0))
         if mt1 is None:
             return None
         mq1, epr1 = mt1

--- a/mqns/network/fw/select.py
+++ b/mqns/network/fw/select.py
@@ -1,11 +1,28 @@
 from collections.abc import Callable, Iterable, Iterator
-from typing import Any
+from typing import Any, Never, cast
 
 from mqns.entity.memory import MemoryQubit
-from mqns.entity.node import QNode
 from mqns.models.epr import Entanglement
-from mqns.network.fw import FibEntry
 from mqns.utils import rng
+
+
+def parse_select[F: Callable, N: None | Never](cls: type, prefix: str, input: F | str | N) -> F | N:
+    """
+    Parse candidate selection function from string keyword.
+
+    Args:
+        cls: Class where predefined candidate selection functions are defined.
+        prefix: Prefix of predefined candidate selection functions on ``cls``.
+        input: Input parameter; its string possibilities should be constrained with ``typing.Literal``.
+
+    Returns:
+        Predefined or custom candidate selection function.
+    """
+    if callable(input) or input is None:
+        return input
+    f = getattr(cls, f"{prefix}{input}")
+    assert callable(f)
+    return cast(F, f)
 
 
 def call_select[T, R](candidates: Iterable[T], fn: Callable[..., R] | None, *args: Any) -> T | R | None:
@@ -14,7 +31,7 @@ def call_select[T, R](candidates: Iterable[T], fn: Callable[..., R] | None, *arg
 
     Args:
         candidates: Iterator of candidates.
-        fn: Selection function or None, ``fn(*args, candidates: list[T])``.
+        fn: Selection function or None, ``fn(candidates: list[T], *args)``.
 
     Returns:
         Chosen candidate or ``None`` for empty input.
@@ -38,43 +55,6 @@ def select_random[T](candidates: list[T], *_: Any) -> T:
 
 type MemoryEprTuple = tuple[MemoryQubit, Entanglement]
 type MemoryEprIterator = Iterator[MemoryEprTuple]
-
-type SelectPurifQubit = (
-    Callable[
-        [MemoryQubit, FibEntry, QNode, list[MemoryEprTuple]],
-        MemoryEprTuple,
-    ]
-    | None
-)
-"""
-Qubit selection among purification candidates.
-None means selecting the first candidate.
-"""
-
-
-def call_select_purif_qubit(
-    fn: SelectPurifQubit,
-    qubit: MemoryQubit,
-    fib_entry: FibEntry,
-    partner: QNode,
-    candidates: MemoryEprIterator,
-) -> MemoryEprTuple | None:
-    if fn is None:
-        return next(candidates, None)
-    l = list(candidates)
-    if len(l) == 0:
-        return None
-    return fn(qubit, fib_entry, partner, l)
-
-
-def select_purif_qubit_random(
-    qubit: MemoryQubit,
-    fib_entry: FibEntry,
-    partner: QNode,
-    candidates: list[MemoryEprTuple],
-) -> MemoryEprTuple:
-    _ = qubit, fib_entry, partner
-    return candidates[rng.choice(len(candidates))]
 
 
 def select_swap_qubit_oldest(candidates: list[MemoryEprTuple], *_) -> MemoryEprTuple:

--- a/mqns/network/proactive/forwarder.py
+++ b/mqns/network/proactive/forwarder.py
@@ -17,46 +17,39 @@
 
 from typing import Unpack, override
 
+from mqns.entity.memory import PathDirection
 from mqns.entity.qchannel import QuantumChannel
-from mqns.network.fw import Forwarder, ForwarderInitKwargs, ForwarderNorthbound
-from mqns.network.protocol.event import ManageActiveChannel
+from mqns.network.fw import FibEntry, Forwarder, ForwarderInitKwargs, ForwarderNorthbound
+from mqns.network.protocol.event import PathActivateEvent, PathDeactivateEvent
 
 
 class ProactiveForwarderNorthbound(ForwarderNorthbound):
     @override
-    def handle_path_change(
-        self,
-        *,
-        path_id: int,
-        uninstall: bool,
-        ch_l: QuantumChannel | None,
-        ch_r: QuantumChannel | None,
-        **_,
-    ):
-        """
-        Process LinkLayer changes after a path has been installed or uninstalled.
-
-        If a path has been installed and it has a right neighbor:
-
-        1. Notify LinkLayer to start elementary EPR generation toward the right neighbor.
-
-        If a path has been uninstalled and it has a right neighbor:
-
-        1. Notify LinkLayer to stop elementary EPR generation toward the right neighbor.
-        """
-        for i, ch in enumerate((ch_l, ch_r)):
-            if ch is None:
-                continue
-            self.simulator.add_event(
-                ManageActiveChannel(
-                    self.node,
-                    ch,
-                    path_id=path_id if self.mux.qubit_has_path_id() else None,
-                    start=not uninstall,
-                    is_primary=i == 1,
-                    t=self.simulator.tc,
-                )
+    def install_path_adj(self, fib_entry: FibEntry, dir: PathDirection, ch: QuantumChannel) -> None:
+        self.simulator.add_event(
+            PathActivateEvent(
+                self.node,
+                ch,
+                self._ll_path_id(fib_entry),
+                t=self.simulator.tc,
+                is_primary=dir is PathDirection.R,
             )
+        )
+
+    @override
+    def uninstall_path_adj(self, fib_entry: FibEntry, dir: PathDirection, ch: QuantumChannel) -> None:
+        _ = dir
+        self.simulator.add_event(
+            PathDeactivateEvent(
+                self.node,
+                ch,
+                self._ll_path_id(fib_entry),
+                t=self.simulator.tc,
+            )
+        )
+
+    def _ll_path_id(self, fib_entry: FibEntry) -> int | None:
+        return fib_entry.path_id if self.mux.qubit_has_path_id() else None
 
 
 class ProactiveForwarder(Forwarder):

--- a/mqns/network/protocol/event.py
+++ b/mqns/network/protocol/event.py
@@ -15,40 +15,62 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from typing import ClassVar, cast, final, override
+from typing import ClassVar, final, override
 
 from mqns.entity.memory import MemoryQubit, QubitState
 from mqns.entity.node import QNode
 from mqns.entity.qchannel import QuantumChannel
 from mqns.models.epr import Entanglement
 from mqns.simulator import Event, Time
+from mqns.utils import unwrap_cast
 
 
 @final
-class ManageActiveChannel(Event):
+class PathActivateEvent(Event):
     """
-    Event to instruct LinkLayer to start/stop generating EPRs over a quantum channel for a path_id.
+    Instruct LinkLayer to start entanglement generation on a channel for a path.
     """
 
-    ACTION_STR: ClassVar = {True: "start", False: "stop"}
     ROLE_STR: ClassVar = {True: "primary", False: "secondary"}
 
     def __init__(
         self,
         node: QNode,
         qchannel: QuantumChannel,
-        *,
         path_id: int | None,
-        start: bool,
-        is_primary: bool,
+        *,
         t: Time,
+        is_primary: bool,
     ):
-        super().__init__(t, f"{node.name}, {self.ACTION_STR[start]} {qchannel.name}, {self.ROLE_STR[is_primary]}")
+        super().__init__(t, f"ch={qchannel.name}, node={node.name}, role={self.ROLE_STR[is_primary]}")
         self.node = node
         self.qchannel = qchannel
         self.path_id = path_id
-        self.start = start
         self.is_primary = is_primary
+
+    @override
+    def invoke(self) -> None:
+        self.node.handle(self)
+
+
+@final
+class PathDeactivateEvent(Event):
+    """
+    Instruct LinkLayer to stop entanglement generation on a channel for a path.
+    """
+
+    def __init__(
+        self,
+        node: QNode,
+        qchannel: QuantumChannel,
+        path_id: int | None,
+        *,
+        t: Time,
+    ):
+        super().__init__(t, f"ch={qchannel.name}, node={node.name}")
+        self.node = node
+        self.qchannel = qchannel
+        self.path_id = path_id
 
     @override
     def invoke(self) -> None:
@@ -62,14 +84,14 @@ class LinkArchNotifySrcEvent(Event):
     """
 
     def __init__(self, key: str, epr: Entanglement, *, t: Time, attempts: int):
-        super().__init__(t, f"{cast(QNode, epr.src).name}, key={key}, epr={epr.name}")
+        super().__init__(t, f"{unwrap_cast(epr.src).name}, key={key}, epr={epr.name}")
         self.key = key
         self.epr = epr
         self.attempts = attempts
 
     @override
     def invoke(self) -> None:
-        cast(QNode, self.epr.src).handle(self)
+        unwrap_cast(self.epr.src).handle(self)
 
 
 @final
@@ -79,13 +101,13 @@ class LinkArchNotifyDstEvent(Event):
     """
 
     def __init__(self, key: str, epr: Entanglement, *, t: Time):
-        super().__init__(t, f"{cast(QNode, epr.dst).name}, key={key}, epr={epr.name}")
+        super().__init__(t, f"{unwrap_cast(epr.dst).name}, key={key}, epr={epr.name}")
         self.key = key
         self.epr = epr
 
     @override
     def invoke(self) -> None:
-        cast(QNode, self.epr.dst).handle(self)
+        unwrap_cast(self.epr.dst).handle(self)
 
 
 @final

--- a/mqns/network/protocol/event.py
+++ b/mqns/network/protocol/event.py
@@ -31,7 +31,7 @@ class PathActivateEvent(Event):
     Instruct LinkLayer to start entanglement generation on a channel for a path.
     """
 
-    ROLE_STR: ClassVar = {True: "primary", False: "secondary"}
+    ROLE_STR: ClassVar = {True: "pri", False: "2nd"}
 
     def __init__(
         self,
@@ -42,6 +42,15 @@ class PathActivateEvent(Event):
         t: Time,
         is_primary: bool,
     ):
+        """
+        Args:
+            node: Node where LinkLayer is installed.
+            qchannel: Quantum channel for entanglement generation.
+            path_id: Only consider qubits allocated to this path_id.
+                If ``None``, only consider unallocated qubits.
+            is_primary: Role of this LinkLayer instance.
+                This is ignored if the same channel is already activated.
+        """
         super().__init__(t, f"ch={qchannel.name}, node={node.name}, role={self.ROLE_STR[is_primary]}")
         self.node = node
         self.qchannel = qchannel
@@ -67,6 +76,13 @@ class PathDeactivateEvent(Event):
         *,
         t: Time,
     ):
+        """
+        Args:
+            node: Node where LinkLayer is installed.
+            qchannel: Quantum channel for entanglement generation.
+            path_id: Only consider qubits allocated to this path_id.
+                If ``None``, only consider unallocated qubits.
+        """
         super().__init__(t, f"ch={qchannel.name}, node={node.name}")
         self.node = node
         self.qchannel = qchannel

--- a/mqns/network/protocol/event.py
+++ b/mqns/network/protocol/event.py
@@ -77,37 +77,38 @@ class PathDeactivateEvent(Event):
         self.node.handle(self)
 
 
+class _LinkArchNotifyBaseEvent(Event):
+    def __init__(self, t: Time, node: QNode, partner: QNode, key: str, epr: Entanglement):
+        super().__init__(t, f"{node.name}, key={key}, epr={epr.name}")
+        self.node = node
+        self.partner = partner
+        self.key = key
+        self.epr = epr
+
+    @override
+    def invoke(self) -> None:
+        self.node.handle(self)
+
+
 @final
-class LinkArchNotifySrcEvent(Event):
+class LinkArchNotifyPriEvent(_LinkArchNotifyBaseEvent):
     """
     Event in LinkLayer to notify the primary node about successful entanglement in link architecture.
     """
 
     def __init__(self, key: str, epr: Entanglement, *, t: Time, attempts: int):
-        super().__init__(t, f"{unwrap_cast(epr.src).name}, key={key}, epr={epr.name}")
-        self.key = key
-        self.epr = epr
+        super().__init__(t, unwrap_cast(epr.src), unwrap_cast(epr.dst), key, epr)
         self.attempts = attempts
-
-    @override
-    def invoke(self) -> None:
-        unwrap_cast(self.epr.src).handle(self)
 
 
 @final
-class LinkArchNotifyDstEvent(Event):
+class LinkArchNotify2ndEvent(_LinkArchNotifyBaseEvent):
     """
     Event in LinkLayer to notify the secondary node about successful entanglement in link architecture.
     """
 
     def __init__(self, key: str, epr: Entanglement, *, t: Time):
-        super().__init__(t, f"{unwrap_cast(epr.dst).name}, key={key}, epr={epr.name}")
-        self.key = key
-        self.epr = epr
-
-    @override
-    def invoke(self) -> None:
-        unwrap_cast(self.epr.dst).handle(self)
+        super().__init__(t, unwrap_cast(epr.dst), unwrap_cast(epr.src), key, epr)
 
 
 @final

--- a/mqns/network/protocol/link_layer.py
+++ b/mqns/network/protocol/link_layer.py
@@ -17,7 +17,7 @@
 
 from collections import deque
 from collections.abc import Iterable
-from typing import Final, Literal, TypedDict, override
+from typing import Final, Literal, TypedDict, final, override
 
 from mqns.entity.cchannel import ClassicCommandDispatcherMixin, ClassicPacket, classic_cmd_handler
 from mqns.entity.memory import MemoryQubit, QubitState
@@ -61,6 +61,7 @@ class ReserveMsg(TypedDict):
     """
 
 
+@final
 class _ActivePath:
     """
     LinkLayer data structure related to an active path in an active quantum channel.
@@ -73,7 +74,7 @@ class _ActivePath:
     Path identifier.
 
     LinkLayer considers ``None`` as a valid path_id (rather than an absent value), because the forwarder's
-    multiplexing scheme may not need to allocate each qubit to a particular path_id.
+    multiplexing scheme may not need to allocate each qubit to an integer path_id.
     """
 
     insertion_count: int
@@ -85,7 +86,7 @@ class _ActivePath:
     oreq_table: dict[str, int]
     """
     Table of outgoing RESERVE_REQ sent by this node for which a reply has not arrived.
-    This is only used on the primary node of the channel.
+    This field only exists on the primary node of the channel.
     Key is reservation key.
     Value is qubit address.
     """
@@ -93,17 +94,20 @@ class _ActivePath:
     ireq_queue: deque[str]
     """
     Queue of incoming RESERVE_REQ received by this node that has not been fulfilled.
-    This is only used on the secondary node of the channel.
+    This field only exists on the secondary node of the channel.
     Element is reservation key.
     """
 
-    def __init__(self, path_id: int | None):
+    def __init__(self, path_id: int | None, is_primary: bool):
         self.path_id = path_id
         self.insertion_count = 0
-        self.oreq_table = {}
-        self.ireq_queue = deque()
+        if is_primary:
+            self.oreq_table = {}
+        else:
+            self.ireq_queue = deque()
 
 
+@final
 class _ActiveChannel:
     """
     LinkLayer data structure related to an active quantum channel.
@@ -245,11 +249,14 @@ class LinkLayer(ClassicCommandDispatcherMixin, Application[QNode]):
         In SYNC timing mode, exit EXTERNAL phase.
         """
         for ac in self.channels.values():
-            for ap in ac.paths.values():
+            if ac.is_primary:
                 # Clear incomplete reservations.
-                ap.oreq_table.clear()
+                for ap in ac.paths.values():
+                    ap.oreq_table.clear()
+            else:
                 # Clear unsatisfied reservation requests.
-                ap.ireq_queue.clear()
+                for ap in ac.paths.values():
+                    ap.ireq_queue.clear()
 
     @sync_phase_handler(TimingPhase.INTERNAL, False)
     def sync_internal_exit(self) -> None:
@@ -268,34 +275,38 @@ class LinkLayer(ClassicCommandDispatcherMixin, Application[QNode]):
         ch = event.qchannel
         partner = ch.find_peer(self.node)
         path_id = event.path_id
-        is_primary = event.is_primary
 
         ac = self.channels.get(partner.name)
-        if ac:
-            assert ac.is_primary is is_primary, f"{self}: inconsistent is_primary on {ch.name}"
-        else:
-            ac = _ActiveChannel(ch, partner, is_primary)
+        if not ac:
+            ac = _ActiveChannel(ch, partner, event.is_primary)
             self.channels[partner.name] = ac
 
-            self._path_activate_new(ac)
+            self._path_activate_channel(ac)
 
         ap = ac.paths.get(path_id)
         if not ap:
-            ap = _ActivePath(path_id)
+            ap = _ActivePath(path_id, ac.is_primary)
             ac.paths[path_id] = ap
 
             addrs = list(q.addr for q, _ in self.memory.find(lambda *_: True, qchannel=ch))
-            self.log_debug("adding path %s in qchannel %s, assigned qubits %s", path_id, ch.name, addrs)
+            self.log_debug(
+                "PATH_ACTIVATE_%s %s path=%s partner=%s has-addrs=%s",
+                PathActivateEvent.ROLE_STR[ac.is_primary],
+                ch.name,
+                path_id,
+                partner.name,
+                addrs,
+            )
 
         ap.insertion_count += 1
 
-        if is_primary and self.node.timing.is_async():
+        if ac.is_primary and self.node.timing.is_async():
             self.run_channel(ac, ap)
 
-    def _path_activate_new(self, ac: _ActiveChannel) -> None:
+    def _path_activate_channel(self, ac: _ActiveChannel) -> None:
         ch = ac.qchannel
         if not ac.is_primary:
-            self.log_debug("activating qchannel %s as secondary with partner %s", ch.name, ac.partner.name)
+            self.log_debug("CHANNEL_ACTIVATE_2nd %s partner=%s", ch.name, ac.partner.name)
             return
 
         # link_arch.set() may be called multiple times in several situations:
@@ -317,23 +328,19 @@ class LinkLayer(ClassicCommandDispatcherMixin, Application[QNode]):
         epr_tpl, t_notify_a, t_notify_b = ch.link_arch.make_epr(1, self.simulator.ts, src=self.node, dst=ac.partner, key=None)
 
         self.log_debug(
-            "activating qchannel %s as primary with partner %s, link arch %s, EPR template %s t_notify_a=%s t_notify_b=%s",
+            "CHANNEL_ACTIVATE_pri %s partner=%s link_arch=%s t_notify=%s,%s | template %s",
             ch.name,
             ac.partner.name,
             ch.link_arch.name,
-            epr_tpl,
             t_notify_a,
             t_notify_b,
+            epr_tpl,
         )
 
     @event_handler
     def path_deactivate(self, event: PathDeactivateEvent) -> None:
         """
         Handle path deactivation command.
-
-        Args:
-            ch: Quantum channel.
-            path_id: Act only on qubits allocated to a path.
         """
         event.cancel()
         ch = event.qchannel
@@ -357,14 +364,19 @@ class LinkLayer(ClassicCommandDispatcherMixin, Application[QNode]):
             addrs.append(mq.addr)
 
         del ac.paths[path_id]
-        self.log_debug("removing path %s in qchannel %s, reset-addrs=%s", path_id, ch.name, addrs)
+        self.log_debug(
+            "PATH_DEACTIVATE_%s %s path=%s partner=%s reset-addrs=%s",
+            PathActivateEvent.ROLE_STR[ac.is_primary],
+            ch.name,
+            path_id,
+            partner.name,
+            addrs,
+        )
         if len(ac.paths) > 0:
             return
 
         del self.channels[partner.name]
-        self.log_debug(
-            "deactivating qchannel %s as %s with partner %s", ch.name, PathActivateEvent.ROLE_STR[ac.is_primary], partner.name
-        )
+        self.log_debug("CHANNEL_DEACTIVATE_%s %s partner=%s", PathActivateEvent.ROLE_STR[ac.is_primary], ch.name, partner.name)
 
     def run_channel(self, ac: _ActiveChannel, ap: _ActivePath | None = None) -> None:
         """

--- a/mqns/network/protocol/link_layer.py
+++ b/mqns/network/protocol/link_layer.py
@@ -28,7 +28,8 @@ from mqns.network.network import TimingPhase, sync_phase_handler
 from mqns.network.protocol.event import (
     LinkArchNotifyDstEvent,
     LinkArchNotifySrcEvent,
-    ManageActiveChannel,
+    PathActivateEvent,
+    PathDeactivateEvent,
     QubitEntangledEvent,
     QubitReleasedEvent,
 )
@@ -260,23 +261,15 @@ class LinkLayer(ClassicCommandDispatcherMixin, Application[QNode]):
         self.memory.clear()
 
     @event_handler
-    def handle_manage_active_channels(self, event: ManageActiveChannel) -> None:
+    def path_activate(self, event: PathActivateEvent) -> None:
+        """
+        Handle path activation command.
+        """
         event.cancel()
-        if event.start:
-            self._activate_channel(event.qchannel, event.is_primary, event.path_id)
-        else:
-            self._deactivate_channel(event.qchannel, event.path_id)
-
-    def _activate_channel(self, ch: QuantumChannel, is_primary: bool, path_id: int | None) -> None:
-        """
-        Handle channel activation command from ``ManageActiveChannel`` event.
-
-        Args:
-            ch: Quantum channel.
-            is_primary: Role of this node on this channel.
-            path_id: Act only on qubits allocated to a path.
-        """
+        ch = event.qchannel
         partner = ch.find_peer(self.node)
+        path_id = event.path_id
+        is_primary = event.is_primary
 
         ac = self.channels.get(partner.name)
         if ac:
@@ -285,7 +278,7 @@ class LinkLayer(ClassicCommandDispatcherMixin, Application[QNode]):
             ac = _ActiveChannel(ch, partner, is_primary)
             self.channels[partner.name] = ac
 
-            self._activate_channel_new(ac)
+            self._path_activate_new(ac)
 
         ap = ac.paths.get(path_id)
         if not ap:
@@ -300,7 +293,7 @@ class LinkLayer(ClassicCommandDispatcherMixin, Application[QNode]):
         if is_primary and self.node.timing.is_async():
             self.run_channel(ac, ap)
 
-    def _activate_channel_new(self, ac: _ActiveChannel) -> None:
+    def _path_activate_new(self, ac: _ActiveChannel) -> None:
         ch = ac.qchannel
         if not ac.is_primary:
             self.log_debug("activating qchannel %s as secondary with partner %s", ch.name, ac.partner.name)
@@ -334,15 +327,20 @@ class LinkLayer(ClassicCommandDispatcherMixin, Application[QNode]):
             t_notify_b,
         )
 
-    def _deactivate_channel(self, ch: QuantumChannel, path_id: int | None) -> None:
+    @event_handler
+    def path_deactivate(self, event: PathDeactivateEvent) -> None:
         """
-        Handle channel deactivation command from ``ManageActiveChannel`` event.
+        Handle path deactivation command.
 
         Args:
             ch: Quantum channel.
             path_id: Act only on qubits allocated to a path.
         """
+        event.cancel()
+        ch = event.qchannel
         partner = ch.find_peer(self.node)
+        path_id = event.path_id
+
         ac = self.channels[partner.name]
         assert ac.qchannel is ch
 
@@ -366,7 +364,7 @@ class LinkLayer(ClassicCommandDispatcherMixin, Application[QNode]):
 
         del self.channels[partner.name]
         self.log_debug(
-            "deactivating qchannel %s as %s with partner %s", ch.name, ManageActiveChannel.ROLE_STR[ac.is_primary], partner.name
+            "deactivating qchannel %s as %s with partner %s", ch.name, PathActivateEvent.ROLE_STR[ac.is_primary], partner.name
         )
 
     def run_channel(self, ac: _ActiveChannel, ap: _ActivePath | None = None) -> None:

--- a/mqns/network/protocol/link_layer.py
+++ b/mqns/network/protocol/link_layer.py
@@ -23,18 +23,17 @@ from mqns.entity.cchannel import ClassicCommandDispatcherMixin, ClassicPacket, c
 from mqns.entity.memory import MemoryQubit, QubitState
 from mqns.entity.node import Application, QNode
 from mqns.entity.qchannel import QuantumChannel
-from mqns.models.epr import Entanglement
 from mqns.network.network import TimingPhase, sync_phase_handler
 from mqns.network.protocol.event import (
-    LinkArchNotifyDstEvent,
-    LinkArchNotifySrcEvent,
+    LinkArchNotify2ndEvent,
+    LinkArchNotifyPriEvent,
     PathActivateEvent,
     PathDeactivateEvent,
     QubitEntangledEvent,
     QubitReleasedEvent,
 )
 from mqns.simulator import event_handler
-from mqns.utils import AutoIncrementIdentifier, json_encodable, rng, unwrap, unwrap_cast
+from mqns.utils import AutoIncrementIdentifier, json_encodable, rng, unwrap
 
 _AUTOID = AutoIncrementIdentifier("llk_")
 """
@@ -542,10 +541,10 @@ class LinkLayer(ClassicCommandDispatcherMixin, Application[QNode]):
         # the EPR would not arrive in time, and therefore is not scheduled.
         if not src.timing.is_external(max(t_notify_a, t_notify_b)):
             self.log_debug(
-                "skip prepare EPR %s key=%s dst=%s attempts=%s notify-times=%s,%s reason=beyond-external-phase",
+                "EPR_SKIP %s dst=%s key=%s attempts=%s notify-times=%s,%s reason=beyond-external-phase",
                 epr.name,
-                key,
                 dst.name,
+                key,
                 k,
                 t_notify_a,
                 t_notify_b,
@@ -555,44 +554,49 @@ class LinkLayer(ClassicCommandDispatcherMixin, Application[QNode]):
         # If the network uses ASYNC timing mode or the successful attempt can complete within the current EXTERNAL phase,
         # schedule the EPR arrival on both nodes via LinkArchSuccessEvents.
         self.log_debug(
-            "prepare EPR %s key=%s dst=%s attempts=%s notify-times=%s,%s", epr.name, key, dst.name, k, t_notify_a, t_notify_b
+            "EPR_PREPARE %s dst=%s key=%s attempts=%s notify-times=%s,%s", epr.name, dst.name, key, k, t_notify_a, t_notify_b
         )
 
-        self.simulator.add_event(LinkArchNotifySrcEvent(key, epr, t=t_notify_a, attempts=k))
-        self.simulator.add_event(LinkArchNotifyDstEvent(key, epr, t=t_notify_b))
+        self.simulator.add_event(LinkArchNotifyPriEvent(key, epr, t=t_notify_a, attempts=k))
+        self.simulator.add_event(LinkArchNotify2ndEvent(key, epr, t=t_notify_b))
 
     def _calc_attempt(self, qchannel: QuantumChannel) -> int:
         return rng.geometric(qchannel.link_arch.success_prob)
 
     @event_handler
-    def _la_notify_src(self, event: LinkArchNotifySrcEvent) -> None:
-        event.cancel()
+    def _la_notify_pri(self, event: LinkArchNotifyPriEvent) -> None:
         self.cnt.increment_n_etg(event.attempts)
-        epr = event.epr
-        self._la_notify(event.key, epr, "primary", "dst", unwrap_cast(epr.dst))
+        self._la_notify("pri", event)
 
     @event_handler
-    def _la_notify_dst(self, event: LinkArchNotifyDstEvent) -> None:
-        event.cancel()
-        epr = event.epr
-        self._la_notify(event.key, epr, "secondary", "src", unwrap_cast(epr.src))
+    def _la_notify_2nd(self, event: LinkArchNotify2ndEvent) -> None:
+        self._la_notify("2nd", event)
 
-    def _la_notify(self, key: str, epr: Entanglement, own_role: str, partner_role: str, partner: QNode) -> None:
+    def _la_notify(self, own_role: str, event: LinkArchNotifyPriEvent | LinkArchNotify2ndEvent) -> None:
+        event.cancel()
         assert self.node.timing.is_external()
+        partner = event.partner
+        key = event.key
+        epr = event.epr
         try:
             mq = self.memory.write(key, epr)
         except LookupError:
             # Path was deactivated and qubit was deallocated.
-            self.log_debug("EPR-notify-%s %s ignored key=%s reason=qubit-not-found", own_role, epr.name, key)
+            self.log_debug(
+                "EPR_SKIP_%s %s partner=%s key=%s reason=qubit-not-found",
+                own_role,
+                epr.name,
+                partner.name,
+                key,
+            )
             return
 
         self.log_debug(
-            "EPR-notify-%s %s delivered key=%s %s=%s addr=%s path=%s",
+            "EPR_DELIVER_%s %s partner=%s key=%s addr=%s path=%s",
             own_role,
             epr.name,
+            partner.name,
             key,
-            partner_role,
-            partner,
             mq.addr,
             mq.path_id,
         )

--- a/mqns/network/reactive/forwarder.py
+++ b/mqns/network/reactive/forwarder.py
@@ -88,7 +88,6 @@ class ReactiveForwarder(Forwarder):
     def activate_qchannels(self):
         for ch in self.node.qchannels:
             is_primary = ch.node_list[0] is self.node
-            self.log_debug("activate qchannel %s as %s", ch.name, PathActivateEvent.ROLE_STR[is_primary])
             self.simulator.add_event(PathActivateEvent(self.node, ch, None, t=self.simulator.tc, is_primary=is_primary))
 
     @sync_phase_handler(TimingPhase.ROUTING, True)

--- a/mqns/network/reactive/forwarder.py
+++ b/mqns/network/reactive/forwarder.py
@@ -17,24 +17,27 @@
 
 from typing import Unpack, override
 
-from mqns.network.fw import Forwarder, ForwarderInitKwargs, ForwarderNorthbound
+from mqns.entity.memory import PathDirection
+from mqns.entity.qchannel import QuantumChannel
+from mqns.network.fw import FibEntry, Forwarder, ForwarderInitKwargs, ForwarderNorthbound
 from mqns.network.network import TimingPhase, sync_phase_handler
-from mqns.network.protocol.event import ManageActiveChannel
+from mqns.network.protocol.event import PathActivateEvent
 from mqns.network.reactive.message import LinkStateEntry, LinkStateMsg
 
 
 class ReactiveForwarderNorthbound(ForwarderNorthbound):
     @override
-    def handle_path_change(self, *, path_id: int, uninstall: bool, **_):
-        """
-        Process LinkLayer changes after a path has been installed or uninstalled.
-
-        This does nothing because LinkLayer is always running based on topology.
-        """
-        if uninstall:
-            raise ValueError("ReactiveForwarder should not receive UNINSTALL_PATH command")
+    def install_path_adj(self, fib_entry: FibEntry, dir: PathDirection, ch: QuantumChannel) -> None:
+        _ = dir, ch
         if not self.node.timing.is_routing():
-            self.log_warning("received INSTALL_PATH message for path %s outside of ROUTING phase; t_rtg is too short?", path_id)
+            self.log_warning(
+                "received INSTALL_PATH message for path %s outside of ROUTING phase; t_rtg is too short?", fib_entry.path_id
+            )
+
+    @override
+    def uninstall_path_adj(self, fib_entry: FibEntry, dir: PathDirection, ch: QuantumChannel) -> None:
+        _ = fib_entry, dir, ch
+        raise ValueError(f"{self} should not receive UNINSTALL_PATH command")
 
     def send_link_state(self):
         """
@@ -84,17 +87,9 @@ class ReactiveForwarder(Forwarder):
 
     def activate_qchannels(self):
         for ch in self.node.qchannels:
-            self.log_debug("activate qchannel %s", ch.name)
-            self.simulator.add_event(
-                ManageActiveChannel(
-                    self.node,
-                    ch,
-                    path_id=None,
-                    start=True,
-                    is_primary=ch.node_list[0] is self.node,
-                    t=self.simulator.tc,
-                )
-            )
+            is_primary = ch.node_list[0] is self.node
+            self.log_debug("activate qchannel %s as %s", ch.name, PathActivateEvent.ROLE_STR[is_primary])
+            self.simulator.add_event(PathActivateEvent(self.node, ch, None, t=self.simulator.tc, is_primary=is_primary))
 
     @sync_phase_handler(TimingPhase.ROUTING, True)
     def sync_routing_enter(self):

--- a/tests/fw/fw_common.py
+++ b/tests/fw/fw_common.py
@@ -21,14 +21,7 @@ from mqns.network.fw import (
     RoutingPath,
 )
 from mqns.network.fw.fw_swap import ForwarderSwapProc
-from mqns.network.network import (
-    QuantumNetwork,
-    Request,
-    TimingMode,
-    TimingModeAsync,
-    TimingPhase,
-    sync_phase_handler,
-)
+from mqns.network.network import QuantumNetwork, Request, TimingMode, TimingModeAsync, TimingPhase, sync_phase_handler
 from mqns.network.proactive import ProactiveForwarder, ProactiveRoutingController
 from mqns.network.protocol.consumer import Consumer
 from mqns.network.protocol.event import QubitEntangledEvent, QubitReleasedEvent

--- a/tests/fw/test_p_integ.py
+++ b/tests/fw/test_p_integ.py
@@ -7,13 +7,22 @@ import pytest
 from mqns.entity.memory import QuantumMemory
 from mqns.entity.timer import Timer
 from mqns.models.epr import Entanglement, MixedStateEntanglement, WernerStateEntanglement
-from mqns.network.fw import RoutingPathSingle, RoutingPathStatic, SwapSequenceInput
+from mqns.network.fw import (
+    MuxScheme,
+    MuxSchemeBufferSpace,
+    MuxSchemeDynamicEpr,
+    MuxSchemeStatistical,
+    RoutingPathInitArgs,
+    RoutingPathSingle,
+    RoutingPathStatic,
+    SwapSequenceInput,
+)
 from mqns.network.network import TimingMode, TimingModeAsync, TimingModeSync
 from mqns.network.proactive import ProactiveForwarder
 from mqns.network.protocol.consumer import RequestCounters
 from mqns.network.protocol.link_layer import LinkLayer
 
-from .fw_common import build_linear_network, build_rect_network, install_path, print_node_counters
+from .fw_common import build_linear_network, build_rect_network, build_tree_network, install_path, print_node_counters
 
 
 @pytest.mark.parametrize("epr_type", [WernerStateEntanglement, MixedStateEntanglement])
@@ -36,6 +45,51 @@ def test_4_swap(epr_type: type[Entanglement], timing: TimingMode, swap: SwapSequ
     assert fwB.cnt.n_swapped >= 16
     assert fwC.cnt.n_swapped >= 16
     assert RequestCounters.of(net, rp).n_consumed >= 16
+
+
+@pytest.mark.parametrize(
+    ("mux", "swap", "end_time"),
+    [
+        pytest.param(MuxSchemeBufferSpace(), "asap", 1, id="BufferSpace-asap"),
+        pytest.param(MuxSchemeBufferSpace(), "l2r", 1, id="BufferSpace-l2r"),
+        pytest.param(MuxSchemeStatistical(select_swap_qubit="random"), "asap", 1, id="Statistical"),
+        pytest.param(MuxSchemeDynamicEpr(), "asap", 10, id="DynamicEpr"),
+    ],
+)
+@pytest.mark.parametrize("route_len", [3, 5])
+def test_tree2_bidir(mux: MuxScheme, swap: SwapSequenceInput, end_time: float, route_len: int):
+    """Test bidirectional paths in tree topology."""
+    net, simulator = build_tree_network(
+        t_cohere=1.0,
+        ch_capacity=2,
+        fw={"p_swap": 1, "mux": mux},
+        swap_table_leak_tol=256,
+        end_time=end_time,
+        has_link_layer=True,
+    )
+
+    # Path 0 uses A-C or B-A-C segment in one direction.
+    # Path 1 uses C-A or C-A-B segment in the opposite direction.
+    rp_args = RoutingPathInitArgs(
+        m_v=1 if isinstance(mux, MuxSchemeBufferSpace) else "none",
+        swap=swap,
+        swap_cutoff=[0.01, 0.01] * (route_len - 2),
+    )
+    rp0 = install_path(net, RoutingPathStatic("DBACF"[-route_len:], **rp_args), t_install=0.010)
+    rp1 = install_path(net, RoutingPathStatic("GCABE"[:route_len], **rp_args), t_install=0.020)
+    simulator.run()
+    print_node_counters(net)
+
+    rp0cnt = RequestCounters.of(net, rp0).n_consumed
+    rp1cnt = RequestCounters.of(net, rp1).n_consumed
+
+    if isinstance(mux, MuxSchemeDynamicEpr) and route_len == 5:
+        assert rp0cnt + rp1cnt > 0
+        if min(rp0cnt, rp1cnt) == 0:
+            pytest.xfail(reason="https://github.com/usnistgov/mqns/issues/60#issuecomment-5180421126")
+
+    assert rp0cnt > 0
+    assert rp1cnt > 0
 
 
 def test_rect2_uninstall_path():

--- a/tests/fw/test_p_purif.py
+++ b/tests/fw/test_p_purif.py
@@ -13,16 +13,16 @@ from mqns.network.protocol.consumer import RequestCounters
 from mqns.simulator import Time
 from mqns.utils import rng
 
-from .fw_common import (
-    build_linear_network,
-    check_fw_counters,
-    install_path,
-    print_node_counters,
-    provide_entanglements,
-)
+from .fw_common import build_linear_network, check_fw_counters, install_path, print_node_counters, provide_entanglements
 
 
 def force_purify_outcome(monkeypatch: pytest.MonkeyPatch, *success: bool):
+    """
+    Force purification attempts to succeed or fail.
+
+    Args:
+        success: A list of outcomes for upcoming purification attempts.
+    """
     l = list(success)
 
     def new_random() -> float:
@@ -177,6 +177,7 @@ def test_3_uninstall(
         mq_reset_state_old(self, state)
 
     monkeypatch.setattr(MemoryQubit, "reset_state", mq_reset_state_new)
+    force_purify_outcome(monkeypatch, True)
 
     simulator.run()
     print_node_counters(net)

--- a/tests/fw/test_p_swap.py
+++ b/tests/fw/test_p_swap.py
@@ -630,7 +630,7 @@ def test_rect_multipath(has_etg: tuple[int, int, int, int], n_swapped: tuple[int
 def test_tree2_dynepr(t_edge_etg: float, selected_path: tuple[int, int], n_consumed: tuple[int, int]):
     """Test MuxSchemeDynamicEpr in tree (height=2) topology."""
 
-    def select_path(epr: Entanglement, fib: Fib, path_ids: list[int]) -> int:
+    def select_path(path_ids: list[int], epr: Entanglement, fib: Fib) -> int:
         _ = fib
         if len(path_ids) != 2:
             chosen = path_ids[0]

--- a/tests/fw/test_p_swap.py
+++ b/tests/fw/test_p_swap.py
@@ -510,7 +510,7 @@ def test_5_sequential(swap: Sequence[int], su_lower: Sequence[int], etg_ms: tupl
 
 
 @pytest.mark.parametrize(
-    ("etg_ms", "swap_delay", "cutoff4", "t_release", "n_consumed"),
+    ("etg_ms", "swap_delay", "cutoffD", "t_release", "n_consumed"),
     [
         # 1. t=1.0010, A-B and B-C EPRs arrive, B starts swapping.
         # 2. t=1.0015, B completes swapping, heralds success to C.
@@ -542,20 +542,31 @@ def test_5_sequential(swap: Sequence[int], su_lower: Sequence[int], etg_ms: tupl
         #              B saves SwapTask awaiting heralding from C.
         # 4. t=1.0017, C receives B heralding, heralds success to D.
         # 5. t=1.0020, D discards qubit due to exceeding wait-time cut-off.
-        # 6. t=1.0022, D receives C heralding, cannot swap due to lack of D-E EPR.
+        # 6. t=1.0022, D receives C heralding, ignored because qubit has been discarded.
         # 7. t=1.0100, memory qubit decoheres at A.
         #              XXX Ideally, A should be informed so that it can release its qubit earlier.
         ((0, 0, 0, -1), 0.0002, 0.0010, (1.0100, 1.0012, 1.0012, 1.0020), 0),
+        # 1. t=1.0010, A-B and B-C and C-D EPRs arrive, B and C start swapping.
+        # 2. t=1.0012, C completes swapping, cannot herald either side.
+        #              C saves SwapTask awaiting heralding from B and D.
+        # 3. t=1.0012, B completes swapping, heralds success to C.
+        #              B saves SwapTask awaiting heralding from C.
+        # 4. t=1.0017, C receives B heralding, heralds success to D.
+        # 5. t=1.0022, D receives C heralding, cannot swap due to lack of D-E EPR.
+        # 6. t=1.0030, D discards qubit due to exceeding wait-time cut-off.
+        # 7. t=1.0100, memory qubit decoheres at A.
+        #              XXX Ideally, A should be informed so that it can release its qubit earlier.
+        ((0, 0, 0, -1), 0.0002, 0.0020, (1.0100, 1.0012, 1.0012, 1.0030), 0),
     ],
 )
 def test_5_decohere(
-    etg_ms: tuple[int, int, int], swap_delay: float, cutoff4: float | None, t_release: tuple[float, ...], n_consumed: int
+    etg_ms: tuple[int, int, int], swap_delay: float, cutoffD: float | None, t_release: tuple[float, ...], n_consumed: int
 ):
     """Test short decoherence time in 5-node topology."""
     net, simulator = build_linear_network(5, t_cohere=0.010, fw={"p_swap": 1.0, "swap_delay": swap_delay}, end_time=2)
     fwA, fwB, fwC, fwD, fwE = (node.get_app(ProactiveForwarder) for node in net.nodes)
 
-    swap_cutoff = None if cutoff4 is None else [-1, -1, -1, -1, cutoff4, cutoff4]
+    swap_cutoff = None if cutoffD is None else [-1, -1, -1, -1, cutoffD, cutoffD]
     rp = install_path(net, RoutingPathStatic("ABCDE", swap_cutoff=swap_cutoff))
     provide_entanglements(
         (etg_ms, (fwA, fwB, fwC, fwD, fwE)),

--- a/tests/protocol/test_link_layer.py
+++ b/tests/protocol/test_link_layer.py
@@ -1,14 +1,14 @@
-from collections import deque
+from collections import defaultdict, deque
 from typing import override
 
 import pytest
 
-from mqns.entity.memory import MemoryDecohereEvent, MemoryQubit, QuantumMemory, QubitState
+from mqns.entity.memory import MemoryDecohereEvent, MemoryQubit, PathDirection, QuantumMemory, QubitState
 from mqns.entity.node import Application, QNode
 from mqns.entity.qchannel import LinkArchAlways, LinkArchDimBk, LinkArchSr
 from mqns.models.epr import Entanglement, MixedStateEntanglement, WernerStateEntanglement
 from mqns.network.network import QuantumNetwork, TimingModeSync
-from mqns.network.protocol.event import ManageActiveChannel, QubitEntangledEvent, QubitReleasedEvent
+from mqns.network.protocol.event import PathActivateEvent, PathDeactivateEvent, QubitEntangledEvent, QubitReleasedEvent
 from mqns.network.protocol.link_layer import LinkLayer, LinkLayerCounters
 from mqns.network.topology import ClassicTopology, CustomTopology, LinearTopology
 from mqns.simulator import Simulator, event_handler, func_to_event
@@ -22,6 +22,8 @@ class NetworkLayer(Application[QNode]):
         """If non-empty, ``QubitReleasedEvent`` would be emitted after specified duration for the next entanglement."""
         self.entangle: list[tuple[float, float]] = []
         """Entanglement events, each entry contains entanglement time and EPR creation time."""
+        self.path_entangle = defaultdict[int | None, list[float]](lambda: [])
+        """Entanglement times per path_id."""
         self.decohere: list[float] = []
         """Decoherence events, each entry is event time."""
 
@@ -37,6 +39,7 @@ class NetworkLayer(Application[QNode]):
         assert mq is event.qubit
         t_create = epr.decohere_time - self.memory.t_cohere
         self.entangle.append((event.t.sec, t_create.sec))
+        self.path_entangle[mq.path_id].append(event.t.sec)
 
         try:
             release_after = self.release_after.popleft()
@@ -57,12 +60,22 @@ class NetworkLayer(Application[QNode]):
         self.simulator.add_event(QubitReleasedEvent(self.node, event.qubit, is_decoh=True, t=event.t))
 
 
-def manage_active_channel(t: float, src: NetworkLayer, dst: NetworkLayer, *, start=True):
+def activate_path(t0: float | None, t1: float | None, src: Application[QNode], dst: Application[QNode], path_id: int | None):
+    """
+    Schedule ``PathActivateEvent`` and ``PathDeactivateEvent``.
+    """
     simulator = src.simulator
     ch = src.node.get_qchannel(dst.node)
-    time = simulator.time(sec=t)
-    simulator.add_event(ManageActiveChannel(src.node, ch, path_id=None, start=start, is_primary=True, t=time))
-    simulator.add_event(ManageActiveChannel(dst.node, ch, path_id=None, start=start, is_primary=False, t=time))
+
+    if t0 is not None:
+        t = simulator.time(sec=t0)
+        simulator.add_event(PathActivateEvent(src.node, ch, path_id, t=t, is_primary=True))
+        simulator.add_event(PathActivateEvent(dst.node, ch, path_id, t=t, is_primary=False))
+
+    if t1 is not None:
+        t = simulator.time(sec=t1)
+        simulator.add_event(PathDeactivateEvent(src.node, ch, path_id, t=t))
+        simulator.add_event(PathDeactivateEvent(dst.node, ch, path_id, t=t))
 
 
 @pytest.mark.parametrize("epr_type", [WernerStateEntanglement, MixedStateEntanglement])
@@ -82,8 +95,7 @@ def test_basic(epr_type: type[Entanglement]):
 
     ll1, ll2 = (node.get_app(LinkLayer) for node in net.nodes)
     nl1, nl2 = (node.get_app(NetworkLayer) for node in net.nodes)
-    manage_active_channel(0.5, nl1, nl2)
-    manage_active_channel(8.8, nl1, nl2, start=False)
+    activate_path(0.5, 8.8, nl1, nl2, None)
     nl1.release_after.append(2.9)
     nl2.release_after.append(3.2)
 
@@ -133,6 +145,47 @@ def test_basic(epr_type: type[Entanglement]):
     QuantumMemory.check_leaks(net.nodes)
 
 
+def test_multiple_paths():
+    """
+    Test multiple active paths.
+    """
+    topo = LinearTopology(
+        nodes_number=2,
+        nodes_apps=[NetworkLayer(), LinkLayer()],
+        qchannel_args={"delay": 0.005},
+        cchannel_args={"delay": 0.005},
+        memory_args={"capacity": 1 + 2 + 3 + 4, "t_cohere": 0.1},
+    )
+    net = QuantumNetwork(topo, classic_topo=ClassicTopology.Follow)
+    net.build_route()
+    ch = net.get_qchannel("n1", "n2")
+    ch.assign_memory_qubits(capacity=1 + 2 + 3 + 4)
+
+    simulator = Simulator(0.0, 10.0, install_to=(log, net))
+
+    ll1, ll2 = (node.get_app(LinkLayer) for node in net.nodes)
+    nl1, nl2 = (node.get_app(NetworkLayer) for node in net.nodes)
+
+    def alloc_activate_path(src: NetworkLayer, dst: NetworkLayer, path_id: int, n: int) -> None:
+        src.memory.allocate(ch, path_id, PathDirection.R, n=path_id)
+        dst.memory.allocate(ch, path_id, PathDirection.L, n=path_id)
+        activate_path(0.1, 9.9, src, dst, path_id)
+
+    alloc_activate_path(nl1, nl2, 1, 1)
+    alloc_activate_path(nl1, nl2, 2, 2)
+    alloc_activate_path(nl1, nl2, 3, 3)
+    alloc_activate_path(nl1, nl2, 4, 4)
+
+    simulator.run()
+
+    for ll, nl in (ll1, nl1), (ll2, nl2):
+        path_entangle_cnts = [len(nl.path_entangle[path_id]) for path_id in range(1, 5)]
+        print(ll.node.name, ll.cnt, f"path_entangle_cnts={path_entangle_cnts}")
+        assert all(c > 0 for c in path_entangle_cnts)
+
+    assert ll2.cnt.n_attempts == 0
+
+
 @pytest.mark.parametrize(
     ("uninstall_t", "qubits_state", "n_entangle"),
     [
@@ -171,8 +224,7 @@ def test_uninstall(uninstall_t: float, qubits_state: tuple[QubitState, QubitStat
     simulator = Simulator(0.0, 6.5, install_to=(log, net))
 
     nl1, nl2 = (node.get_app(NetworkLayer) for node in net.nodes)
-    manage_active_channel(0.1, nl1, nl2)
-    manage_active_channel(uninstall_t, nl1, nl2, start=False)
+    activate_path(0.1, uninstall_t, nl1, nl2, None)
 
     def assert_states(expected: tuple[QubitState, QubitState]) -> None:
         mq1 = nl1.memory.read(0, must=True)
@@ -254,7 +306,7 @@ def test_skip_ahead():
 
     ll1, ll2 = (node.get_app(LinkLayer) for node in net.nodes)
     nl1, nl2 = (node.get_app(NetworkLayer) for node in net.nodes)
-    manage_active_channel(0.5, nl1, nl2)
+    activate_path(0.5, None, nl1, nl2, None)
 
     simulator.run()
 
@@ -293,11 +345,9 @@ def test_timing_mode_sync():
     simulator = Simulator(0.0, 6.1, install_to=(log, net))
 
     nl0, nl1, nl2, nl3 = (node.get_app(NetworkLayer) for node in net.nodes)
-    manage_active_channel(0.1, nl0, nl1)
-    manage_active_channel(0.1, nl2, nl3)  # insertion_count=1, start entanglements
-    manage_active_channel(1.1, nl2, nl3)  # insertion_count=2, no change
-    manage_active_channel(4.1, nl2, nl3, start=False)  # insertion_count=1, no change
-    manage_active_channel(5.9, nl2, nl3, start=False)  # insertion_count=0, stop entanglements
+    activate_path(0.1, None, nl0, nl1, None)
+    activate_path(0.1, 5.9, nl2, nl3, None)  # insertion_count=1
+    activate_path(1.1, 4.1, nl2, nl3, None)  # insertion_count=2
 
     simulator.run()
 

--- a/tests/protocol/test_link_layer.py
+++ b/tests/protocol/test_link_layer.py
@@ -174,7 +174,9 @@ def test_multiple_paths():
     alloc_activate_path(nl1, nl2, 1, 1)
     alloc_activate_path(nl1, nl2, 2, 2)
     alloc_activate_path(nl1, nl2, 3, 3)
-    alloc_activate_path(nl1, nl2, 4, 4)
+    alloc_activate_path(nl2, nl1, 4, 4)
+    # Path 4 is requesting n2-n1 direction, but the channel is already activated in n1-n2 direction
+    # so that path 4 would retain the existing n1-n2 direction.
 
     simulator.run()
 
@@ -183,6 +185,9 @@ def test_multiple_paths():
         print(ll.node.name, ll.cnt, f"path_entangle_cnts={path_entangle_cnts}")
         assert all(c > 0 for c in path_entangle_cnts)
 
+    # Given the channel is operating in n1-n2 direction for all paths,
+    # all attempts should be initiated by ll1.
+    assert ll1.cnt.n_attempts > 0
     assert ll2.cnt.n_attempts == 0
 
 


### PR DESCRIPTION
This PR primarily resolves the assertion failures when simulating randomly generated requests in a random topology, described in https://github.com/usnistgov/mqns/pull/144#issuecomment-5121807024 for `scalability_randomtopo` example but could also occur in traffic matrix.

LinkLayer now allows activating paths in both directions on the same quantum channel.
The channel still operates unidirectional - the first activated path determines its direction.

Forwarder swapping procedures are also adjusted to accommodate elementary EPRs in either direction.
The SWAP_UPDATE message in particular no longer indicates the direction, although the FIB entry and SwapTask data structure are still directional.
If the physical EPR has the opposite direction, it is flipped to match the FIB entry path direction.
This flipping logic isn't the most efficient method, but it can be optimized in the future.
