### PR TITLE
network: Request.epr_count

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,12 +9,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
-        with:
-          python-version: '3.12'
-          cache: pip
-      - run: pip install ruff
-      - run: |
-          ruff check . --output-format=github
-          ruff format --check .
+      - name: Run the Ruff Linter
+        uses: astral-sh/ruff-action@v4.1.0
+      - name: Run the Ruff Formatter
+        run: ruff format --check .
     timeout-minutes: 5

--- a/examples/extctrl/Cargo.lock
+++ b/examples/extctrl/Cargo.lock
@@ -4,24 +4,24 @@ version = 4
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "async-nats"
-version = "0.47.0"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07d6f157065c3461096d51aacde0c326fa49f3f6e0199e204c566842cdaa5299"
+checksum = "d83a251fa1a4c9d0fe6e816b7acd60549e473e08d14f27a1d992c2675abff05f"
 dependencies = [
  "base64",
  "bytes",
@@ -31,7 +31,7 @@ dependencies = [
  "nuid",
  "pin-project",
  "portable-atomic",
- "rand",
+ "rand 0.10.2",
  "regex",
  "ring",
  "rustls-native-certs",
@@ -67,9 +67,9 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
@@ -82,38 +82,38 @@ dependencies = [
 
 [[package]]
 name = "bpaf"
-version = "0.9.25"
+version = "0.9.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8d4b90317451025bfa1f7d359a5fa698a5f745927ff27696429b7fbd7c0c48"
+checksum = "c670d65eea33846872d5ccf668c00a94c5c67dbdcc0289ea1c362671ce1ddb82"
 dependencies = [
  "bpaf_derive",
 ]
 
 [[package]]
 name = "bpaf_derive"
-version = "0.5.23"
+version = "0.5.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "549ca9c364fdc06f9f36d1356980193d930abc80db848193c2dd4d0e9a83de1b"
+checksum = "2f7e98cee839b19076cb3ce1afdb62bb182e04ff5f71f70188827002fae91094"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -124,6 +124,17 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "const-oid"
@@ -157,6 +168,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -173,7 +193,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
@@ -189,14 +209,14 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "der"
@@ -215,7 +235,6 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -231,13 +250,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -295,27 +314,27 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -346,10 +365,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "http"
-version = "1.4.0"
+name = "getrandom"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "http"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -456,9 +487,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -472,9 +503,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "litemap"
@@ -493,21 +524,21 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
@@ -537,9 +568,9 @@ dependencies = [
  "data-encoding",
  "ed25519",
  "ed25519-dalek",
- "getrandom",
+ "getrandom 0.2.17",
  "log",
- "rand",
+ "rand 0.8.7",
  "signatory",
 ]
 
@@ -549,14 +580,14 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83"
 dependencies = [
- "rand",
+ "rand 0.8.7",
 ]
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "once_cell"
@@ -610,22 +641,22 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -646,9 +677,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
 
 [[package]]
 name = "potential_utf"
@@ -676,31 +707,48 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
-name = "rand"
-version = "0.8.6"
+name = "r-efi"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -710,7 +758,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -719,8 +767,14 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "redox_syscall"
@@ -733,9 +787,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -745,9 +799,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -756,9 +810,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "ring"
@@ -768,7 +822,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -785,9 +839,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.39"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "once_cell",
  "ring",
@@ -799,9 +853,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -811,9 +865,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "zeroize",
 ]
@@ -875,9 +929,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -885,29 +939,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -927,13 +981,13 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -943,15 +997,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -970,7 +1024,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1e303f8205714074f6068773f0e29527e0453937fe837c9717d066635b65f31"
 dependencies = [
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "signature",
  "zeroize",
 ]
@@ -982,7 +1036,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -993,15 +1047,15 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -1031,9 +1085,20 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1048,37 +1113,36 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.69"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -1088,15 +1152,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -1114,9 +1178,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -1131,13 +1195,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1152,9 +1216,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -1163,13 +1227,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -1186,7 +1251,7 @@ dependencies = [
  "futures-sink",
  "http",
  "httparse",
- "rand",
+ "rand 0.8.7",
  "ring",
  "rustls-pki-types",
  "tokio",
@@ -1214,7 +1279,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1238,9 +1303,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
@@ -1290,14 +1355,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -1398,9 +1463,9 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -1415,35 +1480,35 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
@@ -1456,15 +1521,15 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
@@ -1496,11 +1561,11 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/examples/extctrl/Cargo.toml
+++ b/examples/extctrl/Cargo.toml
@@ -4,11 +4,11 @@ version = "0.0.0"
 edition = "2024"
 
 [dependencies]
-anyhow = "^1.0.102"
-async-nats = { version = "^0.47.0", features = ["websockets"] }
-bpaf = { version = "^0.9.24", features = ["derive"] }
-bytes = "^1.11.0"
-serde = { version = "^1.0.228", features = ["derive"] }
-serde_json = "^1.0.149"
-tokio = { version = "^1.50.0", features = ["full"] }
-tokio-stream = "^0.1.18"
+anyhow = "^1.0.104"
+async-nats = { version = "^0.50.0", features = ["websockets"] }
+bpaf = { version = "^0.9.27", features = ["derive"] }
+bytes = "^1.12.1"
+serde = { version = "^1.0.229", features = ["derive"] }
+serde_json = "^1.0.151"
+tokio = { version = "^1.53.1", features = ["full"] }
+tokio-stream = "^0.1.19"

--- a/examples/extctrl/extctrl_dp.py
+++ b/examples/extctrl/extctrl_dp.py
@@ -1,7 +1,6 @@
 import math
 from collections.abc import Iterable
-from dataclasses import dataclass
-from typing import Literal, override
+from typing import Literal, NamedTuple, override
 
 from tap import Tap
 
@@ -33,8 +32,7 @@ class Args(Tap):
         self.add_argument("--M", metavar=("M_edge", "M_center"))
 
 
-@dataclass
-class Stats:
+class Stats(NamedTuple):
     path1: RequestCounters
     path2: RequestCounters
     fw: dict[str, ForwarderCounters]

--- a/examples/extctrl/src/lib.rs
+++ b/examples/extctrl/src/lib.rs
@@ -3,7 +3,10 @@ use async_nats::{self, HeaderMap, jetstream};
 use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use serde_json;
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{BTreeSet, HashMap},
+    sync::Arc,
+};
 use tokio::sync::{Mutex, mpsc};
 use tokio_stream::StreamExt;
 
@@ -14,28 +17,30 @@ pub fn sec_to_time_slot(sec: f64, accuracy: u64) -> u64 {
     (sec * accuracy as f64).round() as u64
 }
 
-const CMD_INSTALL_PATH: &str = "INSTALL_PATH";
-const CMD_UNINSTALL_PATH: &str = "UNINSTALL_PATH";
+const CMD_PATH_INSERT: &str = "PATH_INSERT";
+const CMD_PATH_DELETE: &str = "PATH_DELETE";
 const CMD_LS: &str = "LS";
 
+/// Path insertion command from controller to forwarders.
 #[derive(Debug, Clone, Serialize)]
-struct InstallPathCmd<'a> {
-    cmd: String, // CMD_INSTALL_PATH
-    path_id: u32,
-    instructions: &'a PathInstructions,
+struct PathInsertMsg<'a> {
+    cmd: &'static str, // CMD_PATH_INSERT
+    req_id: u32,
+    paths: &'a [PathInstructions],
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
-struct UninstallPathCmd {
-    cmd: String, // CMD_UNINSTALL_PATH
-    path_id: u32,
+/// Path deletion command from controller to forwarders.
+#[derive(Debug, Clone, Serialize)]
+struct PathDeleteMsg {
+    cmd: &'static str, // CMD_PATH_DELETE
+    req_id: u32,
 }
 
-/// Instructions from the controller to forwarders regarding a routing path.
+/// Swapping and purification instructions for the forwarders.
 /// See mqns.network.fw.PathInstructions struct for details.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct PathInstructions {
-    pub req_id: u32,
+    pub path_id: u32,
     pub route: Vec<String>,
     pub swap: Vec<i32>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -43,6 +48,20 @@ pub struct PathInstructions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub m_v: Option<Vec<MultiplexingVectorElem>>,
     pub purif: HashMap<String, String>,
+}
+
+impl PathInstructions {
+    /// Assign m_v with specific qubits.
+    ///
+    /// * `qubits`: A vector of qubit reservation keys, one per quantum channel in the route.
+    pub fn set_mv_qubits(&mut self, qubits: Vec<String>) {
+        self.m_v = Some(
+            qubits
+                .into_iter()
+                .map(MultiplexingVectorElem::Key)
+                .collect(),
+        );
+    }
 }
 
 /// Multiplexing Vector element in PathInstructions.
@@ -156,53 +175,49 @@ impl Southbound {
         Ok(())
     }
 
-    /// Send install_path command.
+    /// Send PATH_INSERT command.
     ///
     /// * `t`: Command transmission time in time slots.
-    /// * `path_id`: Path identifier.
-    /// * `instructions`: Routing path instructions. A copy of the command is sent to each node in the route.
-    pub async fn install_path(
-        &self,
-        t: u64,
-        path_id: u32,
-        instructions: &PathInstructions,
-    ) -> Result<()> {
-        let cmd = InstallPathCmd {
-            cmd: CMD_INSTALL_PATH.to_string(),
-            path_id: path_id,
-            instructions: instructions,
+    /// * `req_id`: Request identifier.
+    /// * `paths`: Slice of routing path instructions belonging to this request.
+    pub async fn path_insert(&self, t: u64, req_id: u32, paths: &[PathInstructions]) -> Result<()> {
+        let msg = PathInsertMsg {
+            cmd: CMD_PATH_INSERT,
+            req_id,
+            paths,
         };
-        let payload = Bytes::from(serde_json::to_vec(&cmd)?);
-        self.send_instructions(t, payload, instructions).await
+        let payload = Bytes::from(serde_json::to_vec(&msg)?);
+        self.send_instructions(t, payload, paths).await
     }
 
-    /// Send uninstall_path command.
+    /// Send PATH_DELETE command.
     ///
     /// * `t`: Command transmission time in time slots.
-    /// * `path_id`: Path identifier.
-    /// * `instructions`: Routing path instructions. A copy of the command is sent to each node in the route.
-    pub async fn uninstall_path(
-        &self,
-        t: u64,
-        path_id: u32,
-        instructions: &PathInstructions,
-    ) -> Result<()> {
-        let cmd = UninstallPathCmd {
-            cmd: CMD_UNINSTALL_PATH.to_string(),
-            path_id: path_id,
+    /// * `req_id`: Request identifier.
+    /// * `paths`: Slice of routing path instructions belonging to this request.
+    pub async fn path_delete(&self, t: u64, req_id: u32, paths: &[PathInstructions]) -> Result<()> {
+        let msg = PathDeleteMsg {
+            cmd: CMD_PATH_DELETE,
+            req_id,
         };
-        let payload = Bytes::from(serde_json::to_vec(&cmd)?);
-        self.send_instructions(t, payload, instructions).await
+        let payload = Bytes::from(serde_json::to_vec(&msg)?);
+        self.send_instructions(t, payload, paths).await
     }
 
     async fn send_instructions(
         &self,
         t: u64,
         payload: Bytes,
-        instructions: &PathInstructions,
+        paths: &[PathInstructions],
     ) -> Result<()> {
-        for dst in &instructions.route {
-            let subject = format!("{}.I.{dst}.ctrl", self.nats_prefix);
+        // Collect unique node names in deterministic order across all paths
+        let nodes: BTreeSet<&str> = paths
+            .iter()
+            .flat_map(|p| p.route.iter().map(|s| s.as_str()))
+            .collect();
+
+        for dest in nodes {
+            let subject = format!("{}.I.{dest}.ctrl", self.nats_prefix);
             let mut headers = HeaderMap::new();
             headers.insert("t", t.to_string());
             headers.insert("fmt", "json");
@@ -212,7 +227,7 @@ impl Southbound {
                 .await?
                 .await
             {
-                return Err(anyhow!("Failed to deliver instructions to {}: {}", dst, e));
+                return Err(anyhow!("Failed to deliver instructions to {}: {}", dest, e));
             }
         }
         Ok(())

--- a/examples/extctrl/src/main.rs
+++ b/examples/extctrl/src/main.rs
@@ -5,6 +5,7 @@ use mqns_example_extctrl::{
     LinkStateEntry, LinkStateMsg, MultiplexingVectorElem, PathInstructions, Southbound,
     sec_to_time_slot,
 };
+use serde_json;
 use std::{
     collections::{HashMap, HashSet},
     env,
@@ -115,7 +116,7 @@ struct Args {
     #[bpaf(fallback(PathOpt::L2R))]
     path1: PathOpt,
 
-    /// S1-D1 path install time in seconds
+    /// S1-D1 path insertion time in seconds
     #[bpaf(long("path1_i"), argument("SEC"), fallback(0))]
     path1_i: u64,
 
@@ -123,7 +124,7 @@ struct Args {
     #[bpaf(fallback(PathOpt::Disabled))]
     path2: PathOpt,
 
-    /// S2-D2 path install time in seconds
+    /// S2-D2 path insertion time in seconds
     #[bpaf(long("path2_i"), argument("SEC"), fallback(0))]
     path2_i: u64,
 }
@@ -153,27 +154,17 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-fn make_path(req_id: u32, nodes: &str, opt: PathOpt) -> PathInstructions {
+fn make_path(path_id: u32, nodes: &str, opt: PathOpt) -> PathInstructions {
     let route: Vec<String> = nodes.split('-').map(String::from).collect();
     let len = route.len();
     PathInstructions {
-        req_id,
+        path_id,
         route,
         swap: opt.to_swap(),
         swap_cutoff: None,
         m_v: Some(vec![MultiplexingVectorElem::Count(1, 1); len - 1]),
         purif: HashMap::new(),
     }
-}
-
-fn replace_path_mv(mut path: PathInstructions, qubits: Vec<String>) -> PathInstructions {
-    path.m_v = Some(
-        qubits
-            .iter()
-            .map(|key| MultiplexingVectorElem::Key(key.clone()))
-            .collect(),
-    );
-    path
 }
 
 async fn tx_loop_pca(args: &Args, sb: &Southbound) -> Result<()> {
@@ -184,13 +175,13 @@ async fn tx_loop_pca(args: &Args, sb: &Southbound) -> Result<()> {
         if args.path1 != PathOpt::Disabled && args.path1_i == sec {
             let path = make_path(10, "S1-R1-R2-D1", args.path1);
             println!("    Installing path1");
-            sb.install_path(t, 10, &path).await?;
+            sb.path_insert(t, path.path_id, &[path]).await?;
         }
 
         if args.path2 != PathOpt::Disabled && args.path2_i == sec {
             let path = make_path(20, "S2-R1-R2-D2", args.path2);
             println!("    Installing path2");
-            sb.install_path(t, 20, &path).await?;
+            sb.path_insert(t, path.path_id, &[path]).await?;
         }
 
         if args.sim_duration == sec {
@@ -293,20 +284,26 @@ async fn tx_loop_rcs(
         println!("    {:?}", tls);
 
         if args.path1 != PathOpt::Disabled && args.path1_i <= sec {
-            let path = make_path(10, "S1-R1-R2-D1", args.path1);
+            let mut path = make_path(10, "S1-R1-R2-D1", args.path1);
             if let Some(consumed) = tls.try_consume(&path.route) {
-                let path = replace_path_mv(path, consumed);
-                println!("    Installing path1: {:?}", path.m_v);
-                sb.install_path(t, 10, &path).await?;
+                path.set_mv_qubits(consumed);
+                println!(
+                    "    Installing path1: {}",
+                    serde_json::to_string(&path.m_v).unwrap()
+                );
+                sb.path_insert(t, path.path_id, &[path]).await?;
             }
         }
 
         if args.path2 != PathOpt::Disabled && args.path2_i <= sec {
-            let path = make_path(20, "S2-R1-R2-D2", args.path2);
+            let mut path = make_path(20, "S2-R1-R2-D2", args.path2);
             if let Some(consumed) = tls.try_consume(&path.route) {
-                let path = replace_path_mv(path, consumed);
-                println!("    Installing path2: {:?}", path.m_v);
-                sb.install_path(t, 20, &path).await?;
+                path.set_mv_qubits(consumed);
+                println!(
+                    "    Installing path2: {}",
+                    serde_json::to_string(&path.m_v).unwrap()
+                );
+                sb.path_insert(t, path.path_id, &[path]).await?;
             }
         }
 

--- a/mqns/entity/node/node.py
+++ b/mqns/entity/node/node.py
@@ -63,7 +63,7 @@ class Node(Entity):
         self._install_channels(self.cchannels, self._cchannel_by_dst)
         self._node_install()
 
-        apps_by_type = defaultdict[type, list[Application]](lambda: [])
+        apps_by_type = defaultdict[type, list[Application]](list)
         for app in self.apps:
             apps_by_type[type(app)].append(app)
             app.install(self)

--- a/mqns/models/core/traffic_matrix.py
+++ b/mqns/models/core/traffic_matrix.py
@@ -7,6 +7,10 @@ type TrafficMatrixInput = np.ndarray | list[list[int]]
 
 
 class TrafficMatrix:
+    """
+    Traffic matrix low-level model, where each node is represented by an index number.
+    """
+
     _matrix: np.ndarray[tuple[int, int], np.dtype[np.float64]]
     """
     Traffic matrix for N nodes, shape is (N,N).

--- a/mqns/network/builder.py
+++ b/mqns/network/builder.py
@@ -560,7 +560,7 @@ class NetworkBuilder:
             raise TypeError("must install controller application first")
 
         if isinstance(arg1, RoutingPath):
-            self.requests.append(Request((arg1.src, arg1.dst)).path(arg1))
+            self.requests.append(Request(arg1))
         else:
             self.requests.append(Request(arg1).path(**kwargs))
 

--- a/mqns/network/fw/__init__.py
+++ b/mqns/network/fw/__init__.py
@@ -1,6 +1,6 @@
 from mqns.network.fw.controller import RoutingController
 from mqns.network.fw.cutoff import CutoffScheme, CutoffSchemeWaitTime, CutoffSchemeWaitTimeCounters
-from mqns.network.fw.fib import Fib, FibEntry
+from mqns.network.fw.fib import Fib, FibPath, FibRequest
 from mqns.network.fw.forwarder import Forwarder, ForwarderCounters, ForwarderInitKwargs
 from mqns.network.fw.fw_module import fw_control_cmd_handler, fw_signaling_cmd_handler
 from mqns.network.fw.fw_nb import ForwarderNorthbound
@@ -25,7 +25,8 @@ __all__ = [
     "CutoffSchemeWaitTime",
     "CutoffSchemeWaitTimeCounters",
     "Fib",
-    "FibEntry",
+    "FibPath",
+    "FibRequest",
     "Forwarder",
     "ForwarderCounters",
     "ForwarderInitKwargs",

--- a/mqns/network/fw/controller.py
+++ b/mqns/network/fw/controller.py
@@ -1,12 +1,13 @@
 from typing import override
 
-from mqns.entity.cchannel import ClassicPacket
+from mqns.entity.cchannel import ClassicCommandDispatcherMixin, ClassicPacket, classic_cmd_handler
 from mqns.entity.node import Application, Controller
-from mqns.network.fw.message import PathDeleteMsg, PathInsertMsg, PathInstructions
+from mqns.network.fw.message import PathDeleteMsg, PathInsertMsg, PathInstructions, PathReachEprCountMsg
 from mqns.network.fw.routing import MultiplexingVectorInput, RoutingPath
+from mqns.network.network import RequestInactiveEvent
 
 
-class RoutingController(Application[Controller]):
+class RoutingController(ClassicCommandDispatcherMixin, Application[Controller]):
     """
     Centralized control plane that works with ``Forwarder`` subclass.
     """
@@ -29,7 +30,7 @@ class RoutingController(Application[Controller]):
 
         self.net.build_route()
 
-    def install_path(self, rp: RoutingPath):
+    def install_path(self, rp: RoutingPath, *, epr_count=-1):
         """
         Compute routing path(s) and send PATH_INSERT commands to nodes.
         """
@@ -56,6 +57,7 @@ class RoutingController(Application[Controller]):
             PathInsertMsg(
                 cmd="PATH_INSERT",
                 req_id=rp.req_id,
+                epr_count=epr_count,
                 paths=insts,
             ),
         )
@@ -85,3 +87,30 @@ class RoutingController(Application[Controller]):
         for node_name in node_list:
             node = self.net.get_node(node_name)
             self.node.send_cpacket(node, ClassicPacket(msg, src=self.node, dest=node))
+
+    @classic_cmd_handler("PATH_REACH_EPR_COUNT")
+    def handle_reach_epr_count(self, pkt: ClassicPacket, msg: PathReachEprCountMsg) -> None:
+        req_id = msg["req_id"]
+        end_node = pkt.src.name
+
+        req = next((req for req in self.net.requests if req.req_id == req_id), None)
+        if req is None:
+            self.log_debug("reach_epr_count req=%s end_node=%s outcome=req_not_found", req_id, end_node)
+            return
+
+        try:
+            req.epr_count_await.remove(end_node)
+        except KeyError:
+            self.log_debug("reach_epr_count req=%s end_node=%s outcome=node_not_pending", req_id, end_node)
+            return
+
+        if req.epr_count_await:
+            self.log_debug(
+                "reach_epr_count req=%s end_node=%s outcome=wait_for_other_end await=%s", req_id, end_node, req.epr_count_await
+            )
+            return
+
+        self.log_debug("reach_epr_count req=%s end_node=%s outcome=deactivate_request", req_id, end_node)
+        if req.inactive_event:
+            req.inactive_event.cancel()
+        self.simulator.add_event(RequestInactiveEvent(self.node, req, t=self.simulator.tc))

--- a/mqns/network/fw/controller.py
+++ b/mqns/network/fw/controller.py
@@ -2,7 +2,7 @@ from typing import override
 
 from mqns.entity.cchannel import ClassicPacket
 from mqns.entity.node import Application, Controller
-from mqns.network.fw.message import InstallPathMsg, PathInstructions, UninstallPathMsg
+from mqns.network.fw.message import PathDeleteMsg, PathInsertMsg, PathInstructions
 from mqns.network.fw.routing import MultiplexingVectorInput, RoutingPath
 
 
@@ -31,7 +31,7 @@ class RoutingController(Application[Controller]):
 
     def install_path(self, rp: RoutingPath):
         """
-        Compute routing path(s) and send install commands to nodes.
+        Compute routing path(s) and send PATH_INSERT commands to nodes.
         """
         if rp.req_id < 0:
             rp.req_id = self._next_req_id
@@ -43,25 +43,45 @@ class RoutingController(Application[Controller]):
         if rp.m_v == "auto":
             rp.m_v = self.mv_auto
 
-        for path_id, instructions in enumerate(rp.compute_paths(self.net), start=rp.path_id):
+        insts: list[PathInstructions] = []
+        nodes = set[str]()
+        for path_id, inst in enumerate(rp.compute_paths(self.net), start=rp.path_id):
             self._next_path_id = max(self._next_path_id, path_id + 1)
-            self._send_instructions(
-                InstallPathMsg(cmd="INSTALL_PATH", path_id=path_id, instructions=instructions),
-                instructions,
-            )
+            inst["path_id"] = path_id
+            insts.append(inst)
+            nodes.update(inst["route"])
+
+        self._send_path_command(
+            nodes,
+            PathInsertMsg(
+                cmd="PATH_INSERT",
+                req_id=rp.req_id,
+                paths=insts,
+            ),
+        )
 
     def uninstall_path(self, rp: RoutingPath):
         """
-        Compute routing path(s) and send uninstall commands to nodes.
+        Compute routing path(s) and send PATH_DELETE commands to nodes.
         """
         assert rp.req_id >= 0
         assert rp.path_id >= 0
 
-        for path_id_add, instructions in enumerate(rp.compute_paths(self.net)):
-            self._send_instructions(UninstallPathMsg(cmd="UNINSTALL_PATH", path_id=rp.path_id + path_id_add), instructions)
+        nodes = set[str]()
+        for inst in rp.compute_paths(self.net):
+            nodes.update(inst["route"])
 
-    def _send_instructions(self, msg: InstallPathMsg | UninstallPathMsg, instructions: PathInstructions):
-        for node_name in instructions["route"]:
-            qnode = self.net.get_node(node_name)
-            self.node.send_cpacket(qnode, ClassicPacket(msg, src=self.node, dest=qnode))
-            self.log_debug("%s #%s at %s: %s", msg["cmd"], msg["path_id"], qnode.name, instructions)
+        self._send_path_command(
+            nodes,
+            PathDeleteMsg(
+                cmd="PATH_DELETE",
+                req_id=rp.req_id,
+            ),
+        )
+
+    def _send_path_command(self, nodes: set[str], msg: PathInsertMsg | PathDeleteMsg) -> None:
+        node_list = sorted(nodes)  # ensure deterministic order
+        self.log_debug("%s #%s sendto %s | %s", msg["cmd"], msg["req_id"], node_list, msg)
+        for node_name in node_list:
+            node = self.net.get_node(node_name)
+            self.node.send_cpacket(node, ClassicPacket(msg, src=self.node, dest=node))

--- a/mqns/network/fw/cutoff.py
+++ b/mqns/network/fw/cutoff.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, ClassVar, final, override
 
 from mqns.entity.memory import MemoryQubit, PathDirection
-from mqns.network.fw.fib import FibEntry
+from mqns.network.fw.fib import FibPath
 from mqns.network.fw.fw_module import ForwarderModule, fw_signaling_cmd_handler
 from mqns.network.fw.message import CutoffDiscardMsg
 from mqns.simulator import Event, Time
@@ -27,7 +27,7 @@ class CutoffScheme(ForwarderModule, ABC):
         assert isinstance(fw.cutoff, cls)
         return fw.cutoff
 
-    def initiate_discard(self, qubit: MemoryQubit, fib_entry: FibEntry, *, round=-1):
+    def initiate_discard(self, qubit: MemoryQubit, fp: FibPath, *, round=-1):
         """
         Discard a qubit that has exceeded cutoff time at the local forwarder.
 
@@ -58,20 +58,20 @@ class CutoffScheme(ForwarderModule, ABC):
         # Ask partner to discard secondary qubit.
         msg: CutoffDiscardMsg = {
             "cmd": "CUTOFF_DISCARD",
-            "path_id": fib_entry.path_id,
+            "path_id": fp.path_id,
             "key": p_key,
             "round": round,
         }
-        self.send_msg(partner, msg, fib_entry)
+        self.send_msg(partner, msg, fp)
 
     @fw_signaling_cmd_handler("CUTOFF_DISCARD")
-    def handle_discard(self, msg: CutoffDiscardMsg, fib_entry: FibEntry):
+    def handle_discard(self, msg: CutoffDiscardMsg, fp: FibPath):
         """
         Discard a qubit that has exceeded cutoff time at the remote forwarder.
 
         This is called by ProactiveForwarder upon receiving a CUTOFF_DISCARD message.
         """
-        _ = fib_entry
+        _ = fp
         fw = self.fw
         o_key = msg["key"]
         round = msg["round"]
@@ -93,13 +93,13 @@ class CutoffScheme(ForwarderModule, ABC):
         fw.release_qubit(qubit)
 
     @abstractmethod
-    def before_store_eligible(self, mq: MemoryQubit, dir: PathDirection, fib_entry: FibEntry | None) -> None:
+    def before_store_eligible(self, mq: MemoryQubit, dir: PathDirection, fp: FibPath | None) -> None:
         """
         Handle an ELIGIBLE qubit stored for future swapping.
         """
 
     @abstractmethod
-    def before_swap(self, mq0: MemoryQubit, mq1: MemoryQubit, fib_entry: FibEntry | None) -> None:
+    def before_swap(self, mq0: MemoryQubit, mq1: MemoryQubit, fp: FibPath | None) -> None:
         """
         Handle a pair of ELIGIBLE qubits before swapping.
 
@@ -115,7 +115,7 @@ class CutoffDiscardEvent(Event):
         self,
         cutoff: CutoffScheme,
         qubit: MemoryQubit,
-        fib_entry: FibEntry,
+        fp: FibPath,
         *,
         t: Time,
         round: int,
@@ -124,13 +124,13 @@ class CutoffDiscardEvent(Event):
         super().__init__(t, f"addr={qubit.addr} key={qubit.key}")
         self.cutoff = cutoff
         self.qubit = qubit
-        self.fib_entry = fib_entry
+        self.fp = fp
         self.round = round
         self.eligible_t = eligible_t
 
     @override
     def invoke(self) -> None:
-        self.cutoff.initiate_discard(self.qubit, self.fib_entry, round=self.round)
+        self.cutoff.initiate_discard(self.qubit, self.fp, round=self.round)
 
 
 class CutoffSchemeWaitTimeCounters:
@@ -165,8 +165,8 @@ class CutoffSchemeWaitTime(CutoffScheme):
         self.cnt = CutoffSchemeWaitTimeCounters()
 
     @override
-    def before_store_eligible(self, mq: MemoryQubit, dir: PathDirection, fib_entry: FibEntry | None) -> None:
-        if not fib_entry or (wait_budget := fib_entry.swap_cutoff[2 * fib_entry.own_idx + self._DIR_OFFSET[dir]]) is None:
+    def before_store_eligible(self, mq: MemoryQubit, dir: PathDirection, fp: FibPath | None) -> None:
+        if not fp or (wait_budget := fp.swap_cutoff[2 * fp.own_idx + self._DIR_OFFSET[dir]]) is None:
             return
 
         now = self.simulator.tc
@@ -175,18 +175,18 @@ class CutoffSchemeWaitTime(CutoffScheme):
             "wait-time key=%s addr=%s path=%s(%s)%s budget=%s deadline=%s",
             mq.key,
             mq.addr,
-            fib_entry.path_id,
-            fib_entry.own_idx,
+            fp.path_id,
+            fp.own_idx,
             dir.name,
             wait_budget,
             deadline,
         )
-        self.simulator.add_event(event := CutoffDiscardEvent(self, mq, fib_entry, round=-1, eligible_t=now, t=deadline))
+        self.simulator.add_event(event := CutoffDiscardEvent(self, mq, fp, round=-1, eligible_t=now, t=deadline))
         mq.events.add(event)
 
     @override
-    def before_swap(self, mq0: MemoryQubit, mq1: MemoryQubit, fib_entry: FibEntry | None) -> None:
-        _ = fib_entry
+    def before_swap(self, mq0: MemoryQubit, mq1: MemoryQubit, fp: FibPath | None) -> None:
+        _ = fp
         assert mq0.events.get(CutoffDiscardEvent) is None
 
         event = mq1.events.discard(CutoffDiscardEvent)

--- a/mqns/network/fw/fib.py
+++ b/mqns/network/fw/fib.py
@@ -15,32 +15,26 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
+from collections.abc import Iterable, Iterator, Mapping, Sequence
 from typing import TYPE_CHECKING, Final, Literal, final
 
 from mqns.network.fw.message import SwapSequence
-from mqns.simulator import Time
+from mqns.simulator import Time, func_to_event
 
 if TYPE_CHECKING:
     from mqns.network.fw.forwarder import Forwarder
 
 
 @final
-class FibEntry:
-    """FIB entry."""
+class FibPath:
+    """FIB information related to a path."""
 
-    __slots__ = ("req_id", "path_id", "active_until", "route", "own_idx", "swap", "swap_cutoff", "purif", "sg")
+    __slots__ = ("req", "path_id", "route", "own_idx", "swap", "swap_cutoff", "purif", "sg")
 
-    req_id: Final[int]
-    """Request identifier, identifies source-destination pair."""
+    req: "FibRequest"
+    """Request group reference, assigned by ``FibRequestGroup.__init__``."""
     path_id: Final[int]
     """Path identifier, identifies end-to-end path."""
-
-    active_until: Time
-    """
-    Active period upper bound (exclusive), ``Time.MAX`` means no restriction.
-    This field becomes valid when the request is added to a network and a simulator is installed into the network.
-    """
 
     route: Final[Sequence[str]]
     """List of nodes traversed by the path."""
@@ -58,7 +52,6 @@ class FibEntry:
     def __init__(
         self,
         *,
-        req_id: int,
         path_id: int,
         route: Sequence[str],
         own_idx: int,
@@ -66,9 +59,7 @@ class FibEntry:
         swap_cutoff: Sequence[Time | None],
         purif: Mapping[str, int],
     ):
-        self.req_id = req_id
         self.path_id = path_id
-        self.active_until = Time.MAX
         self.route = route
         self.own_idx = own_idx
         self.swap = swap
@@ -77,26 +68,13 @@ class FibEntry:
         self.sg = None if self.own_swap_rank == self.swap[0] else FibSwapGroup(self)
 
     @property
-    def own_swap_rank(self) -> int:
-        return self.swap[self.own_idx]
+    def req_id(self) -> int:
+        """Request identifier."""
+        return self.req.req_id
 
     @property
-    def is_swap_disabled(self) -> bool:
-        """
-        Determine whether swapping has been disabled.
-
-        To disable swapping, set SwapSequence to a list of zeros.
-
-        When swapping is disabled, the forwarder will consume entanglement upon completing purification,
-        without attempting entanglement swapping.
-        """
-        return self.swap[0] == 0 == self.swap[-1]
-
-    def is_active(self, t: Time) -> bool:
-        """
-        Determine if the time point ``t`` is within the FIB entry's active period.
-        """
-        return t < self.active_until
+    def own_swap_rank(self) -> int:
+        return self.swap[self.own_idx]
 
     def find_index_and_swap_rank(self, node_name: str) -> tuple[int, int]:
         """
@@ -162,29 +140,27 @@ class FibSwapGroup:
     own_idx: Final[int]
     """Index of own node within ``nodes``."""
 
-    def __init__(self, entry: FibEntry):
-        route_len = len(entry.route)
-        if entry.own_idx in (0, route_len - 1):
-            raise ValueError("FibSwapGroup is undefined for end nodes")
+    def __init__(self, fp: FibPath):
+        route_len = len(fp.route)
 
-        self.path_id = entry.path_id
-        self.rank = entry.own_swap_rank
+        self.path_id = fp.path_id
+        self.rank = fp.own_swap_rank
 
-        nodes = [entry.route[entry.own_idx]]
-        self.l_neigh, l_rank = self._extend_1d(entry, nodes, range(entry.own_idx - 1, -1, -1))
+        nodes = [fp.route[fp.own_idx]]
+        self.l_neigh, l_rank = self._extend_1d(fp, nodes, range(fp.own_idx - 1, -1, -1))
         self.own_idx = len(nodes) - 1
         nodes.reverse()
-        self.r_neigh, r_rank = self._extend_1d(entry, nodes, range(entry.own_idx + 1, route_len))
+        self.r_neigh, r_rank = self._extend_1d(fp, nodes, range(fp.own_idx + 1, route_len))
         self.nodes = nodes
 
-        if l_rank == r_rank or entry.purif.get(f"{self.l_neigh}-{self.r_neigh}", 0) > 0:
+        if l_rank == r_rank or fp.purif.get(f"{self.l_neigh}-{self.r_neigh}", 0) > 0:
             self.dir = "b"
         elif l_rank < r_rank:
             self.dir = "l"
         else:
             self.dir = "r"
 
-    def _extend_1d(self, entry: FibEntry, nodes: list[str], index_range: Iterable[int]) -> tuple[str, int]:
+    def _extend_1d(self, entry: FibPath, nodes: list[str], index_range: Iterable[int]) -> tuple[str, int]:
         for i in index_range:
             node_rank = entry.swap[i]
             if node_rank > self.rank:
@@ -241,119 +217,128 @@ class FibSwapGroup:
         return f"FibSwapGroup({self.repr_route()}, rank={self.rank})"
 
 
-class FibRequestGroup:
-    """FIB information grouped by req_id."""
+class FibRequest:
+    """FIB information related to an end-to-end request."""
 
-    def __init__(self, entry: FibEntry):
-        """Construct from first FIB entry."""
-        self.req_id = entry.req_id
-        self.src = entry.route[0]
-        self.dst = entry.route[-1]
-        self.path_ids = {entry.path_id}
+    __slots__ = ("req_id", "src", "dst", "paths", "active_until")
 
-    def add(self, entry: FibEntry) -> None:
-        """Check consistency and save FIB entry."""
-        assert self.req_id == entry.req_id
-        assert self.src == entry.route[0]
-        assert self.dst == entry.route[-1]
-        self.path_ids.add(entry.path_id)
+    req_id: Final[int]
+    """Request identifier."""
+    src: Final[str]
+    """Source node."""
+    dst: Final[str]
+    """Destination node."""
+    paths: Final[Sequence[FibPath]]
+    """List of ``FibPath`` entries."""
 
-    def remove(self, entry: FibEntry) -> bool:
+    active_until: Time
+    """
+    Active period upper bound (exclusive), ``Time.MAX`` means no restriction.
+    """
+
+    def __init__(self, req_id: int, entries: Sequence[FibPath]):
+        self.req_id = req_id
+        self.src, *_, self.dst = entries[0].route
+        self.paths = entries
+        self.active_until = Time.MAX
+
+        for entry in entries:
+            entry.req = self
+            assert entry.route[0] == self.src
+            assert entry.route[-1] == self.dst
+
+    def is_active(self, t: Time) -> bool:
         """
-        Remove FIB entry.
-
-        Returns:
-            Whether the group has become empty.
+        Determine if the time point ``t`` is within the FIB entry's active period.
         """
-        assert self.req_id == entry.req_id
-        self.path_ids.remove(entry.path_id)
-        return len(self.path_ids) == 0
+        return t < self.active_until
 
 
 class Fib:
+    """
+    Forwarding Information Base of a forwarder.
+    """
+
     def __init__(self):
-        self.table: dict[int, FibEntry] = {}
-        """
-        FIB table.
-        Key is path_id.
-        Value is FIB entry.
-        """
-        self.by_req_id: dict[int, FibRequestGroup] = {}
-        """
-        Lookup table indexed by req_id.
-        Key is req_id.
-        Value contains aggregated information.
-        """
+        self._reqs: dict[int, FibRequest] = {}  # req_id => FibEntry
+        self._paths: dict[int, FibPath] = {}  # path_id => FibPath
 
     def install(self, fw: "Forwarder") -> None:
         self.simulator = fw.simulator
 
-    def get(self, path_id: int) -> FibEntry:
+    def clear(self) -> None:
         """
-        Retrieve an entry by path_id.
+        Clear all tables.
+        """
+        self._reqs.clear()
+        self._paths.clear()
+
+    def get_path(self, path_id: int) -> FibPath:
+        """
+        Retrieve FIB path entry by path identifier.
 
         Raises:
-            LookupError: Entry not found.
+            LookupError: Path entry not found.
         """
         try:
-            return self.table[path_id]
+            return self._paths[path_id]
         except KeyError:
-            raise LookupError(f"FIB entry not found for path_id={path_id}") from None
+            raise LookupError(f"FibPath({path_id}) not found") from None
 
-    def insert_or_replace(self, entry: FibEntry):
+    def get_req(self, req_id: int) -> FibRequest:
         """
-        Insert an entry or replace entry with same path_id.
-        """
-        self.erase(entry.path_id)
-        self.table[entry.path_id] = entry
+        Retrieve FIB request entry by request identifier.
 
-        rg = self.by_req_id.get(entry.req_id)
-        if rg:
-            rg.add(entry)
-        else:
-            rg = FibRequestGroup(entry)
-            self.by_req_id[rg.req_id] = rg
-
-    def erase(self, path_id: int):
-        """
-        Remove an entry from the table.
-
-        Nonexistent entry is silent ignored.
+        Raises:
+            LookupError: Request entry not found.
         """
         try:
-            entry = self.table.pop(path_id)
+            return self._reqs[req_id]
         except KeyError:
-            return
+            raise LookupError(f"FibRequestGroup({req_id}) not found") from None
 
-        rg = self.by_req_id[entry.req_id]
-        if rg.remove(entry):
-            del self.by_req_id[entry.req_id]
-
-    def find_request(
-        self,
-        predicate: Callable[[FibRequestGroup], bool],
-        *,
-        has_active=False,
-    ) -> Iterator[FibRequestGroup]:
+    def insert_req(self, fr: FibRequest) -> None:
         """
-        List ``FibRequestGroup`` satisfying a predicate.
+        Insert a request entry and all its path entries.
+        """
+        if fr.req_id in self._reqs:
+            raise ValueError(f"FibRequestGroup({fr.req_id}) already exists")
+        self._reqs[fr.req_id] = fr
+
+        for entry in fr.paths:
+            if entry.path_id in self._paths:
+                raise ValueError(f"FibEntry({entry.path_id}) already exists")
+            self._paths[entry.path_id] = entry
+
+    def delete_req(self, req_id: int, *, delay: Time) -> FibRequest:
+        """
+        Schedule the deletion of a request entry and all its path entries.
 
         Args:
-            predicate: Function to determine the condition.
-            has_active: Also require at least one FIB entry to be within the active period.
+            delay: Delay for the final deletion.
+
+        Returns:
+            The FIB request entry.
         """
-        for rg in self.by_req_id.values():
-            if predicate(rg) and ((not has_active) or self._request_has_active(rg)):
-                yield rg
+        fr = self.get_req(req_id)
+        fr.active_until = self.simulator.tc
+        self.simulator.add_event(func_to_event(fr.active_until + delay, self._delete_req, req_id))
+        return fr
 
-    def _request_has_active(self, rg: FibRequestGroup) -> bool:
+    def _delete_req(self, req_id: int) -> None:
+        fr = self.get_req(req_id)
+        del self._reqs[req_id]
+
+        for entry in fr.paths:
+            del self._paths[entry.path_id]
+
+    def find_active_req(self, node0: str, node1: str) -> Iterator[FibRequest]:
+        """
+        List FIB request entries between two nodes.
+
+        The request must be active and may have either direction.
+        """
         now = self.simulator.tc
-        return any(self.table[path_id].is_active(now) for path_id in rg.path_ids)
-
-    def __repr__(self):
-        """Return a string representation of the forwarding table."""
-        return "\n".join(
-            f"Path ID: {path_id}, Request ID: {entry.req_id}, Path: {entry.route}, "
-            f"Swap Sequence: {entry.swap}, Purification: {entry.purif}"
-            for path_id, entry in self.table.items()
-        )
+        for req in self._reqs.values():
+            if req.is_active(now) and ((req.src == node0 and req.dst == node1) or (req.src == node1 and req.dst == node0)):
+                yield req

--- a/mqns/network/fw/fib.py
+++ b/mqns/network/fw/fib.py
@@ -18,6 +18,8 @@
 from collections.abc import Iterable, Iterator, Mapping, Sequence
 from typing import TYPE_CHECKING, Final, Literal, final
 
+import numpy as np
+
 from mqns.network.fw.message import SwapSequence
 from mqns.simulator import Time, func_to_event
 
@@ -220,7 +222,7 @@ class FibSwapGroup:
 class FibRequest:
     """FIB information related to an end-to-end request."""
 
-    __slots__ = ("req_id", "src", "dst", "paths", "active_until")
+    __slots__ = ("req_id", "src", "dst", "paths", "active_until", "epr_count_remain")
 
     req_id: Final[int]
     """Request identifier."""
@@ -235,23 +237,32 @@ class FibRequest:
     """
     Active period upper bound (exclusive), ``Time.MAX`` means no restriction.
     """
+    epr_count_remain: int | float
+    """
+    If ``epr_count`` is restricted, remaining quantity of entangled pairs.
+    Otherwise, positive infinity.
+    This field is only used on end nodes.
+    """
 
-    def __init__(self, req_id: int, entries: Sequence[FibPath]):
+    def __init__(self, req_id: int, entries: Sequence[FibPath], *, epr_count=-1):
         self.req_id = req_id
         self.src, *_, self.dst = entries[0].route
         self.paths = entries
         self.active_until = Time.MAX
+        self.epr_count_remain = np.inf if epr_count < 0 else epr_count
 
         for entry in entries:
             entry.req = self
             assert entry.route[0] == self.src
             assert entry.route[-1] == self.dst
 
-    def is_active(self, t: Time) -> bool:
+    def is_active(self, now: Time) -> bool:
         """
-        Determine if the time point ``t`` is within the FIB entry's active period.
+        Determine if the request is active.
+
+        The condition is same as ``Request.is_active``.
         """
-        return t < self.active_until
+        return now < self.active_until and self.epr_count_remain > 0
 
 
 class Fib:

--- a/mqns/network/fw/fib.py
+++ b/mqns/network/fw/fib.py
@@ -15,7 +15,8 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from collections.abc import Iterable, Iterator, Mapping, Sequence
+from collections import defaultdict
+from collections.abc import Iterable, Mapping, Sequence
 from typing import TYPE_CHECKING, Final, Literal, final
 
 import numpy as np
@@ -29,12 +30,12 @@ if TYPE_CHECKING:
 
 @final
 class FibPath:
-    """FIB information related to a path."""
+    """FIB path entry --- information related to a path."""
 
     __slots__ = ("req", "path_id", "route", "own_idx", "swap", "swap_cutoff", "purif", "sg")
 
     req: "FibRequest"
-    """Request group reference, assigned by ``FibRequestGroup.__init__``."""
+    """Request entry reference, assigned by ``FibRequest.__init__``."""
     path_id: Final[int]
     """Path identifier, identifies end-to-end path."""
 
@@ -220,7 +221,7 @@ class FibSwapGroup:
 
 
 class FibRequest:
-    """FIB information related to an end-to-end request."""
+    """FIB request entry --- information related to an end-to-end request."""
 
     __slots__ = ("req_id", "src", "dst", "paths", "active_until", "epr_count_remain")
 
@@ -271,17 +272,20 @@ class Fib:
     """
 
     def __init__(self):
-        self._reqs: dict[int, FibRequest] = {}  # req_id => FibEntry
-        self._paths: dict[int, FibPath] = {}  # path_id => FibPath
+        self._reqs: dict[int, FibRequest] = {}  # keyed by req_id
+        self._end_reqs = defaultdict[str, list[FibRequest]](list)  # own node is end-node, keyed by opposite end-node
+        self._paths: dict[int, FibPath] = {}  # keyed by path_id
 
     def install(self, fw: "Forwarder") -> None:
         self.simulator = fw.simulator
+        self._own_name = fw.node.name
 
     def clear(self) -> None:
         """
         Clear all tables.
         """
         self._reqs.clear()
+        self._end_reqs.clear()
         self._paths.clear()
 
     def get_path(self, path_id: int) -> FibPath:
@@ -306,20 +310,30 @@ class Fib:
         try:
             return self._reqs[req_id]
         except KeyError:
-            raise LookupError(f"FibRequestGroup({req_id}) not found") from None
+            raise LookupError(f"FibRequest({req_id}) not found") from None
+
+    def _req_opposite_end(self, fr: FibRequest) -> str | None:
+        if fr.src == self._own_name:
+            return fr.dst
+        if fr.dst == self._own_name:
+            return fr.src
+        return None
 
     def insert_req(self, fr: FibRequest) -> None:
         """
         Insert a request entry and all its path entries.
         """
         if fr.req_id in self._reqs:
-            raise ValueError(f"FibRequestGroup({fr.req_id}) already exists")
+            raise ValueError(f"FibRequest({fr.req_id}) already exists")
         self._reqs[fr.req_id] = fr
 
         for entry in fr.paths:
             if entry.path_id in self._paths:
                 raise ValueError(f"FibEntry({entry.path_id}) already exists")
             self._paths[entry.path_id] = entry
+
+        if opposite := self._req_opposite_end(fr):
+            self._end_reqs[opposite].append(fr)
 
     def delete_req(self, req_id: int, *, delay: Time) -> FibRequest:
         """
@@ -343,13 +357,17 @@ class Fib:
         for entry in fr.paths:
             del self._paths[entry.path_id]
 
-    def find_active_req(self, node0: str, node1: str) -> Iterator[FibRequest]:
-        """
-        List FIB request entries between two nodes.
+        if opposite := self._req_opposite_end(fr):
+            l = self._end_reqs[opposite]
+            l.remove(fr)
+            if not l:
+                del self._end_reqs[opposite]
 
-        The request must be active and may have either direction.
+    def list_end_reqs(self, opposite_end: str) -> list[FibRequest]:
         """
-        now = self.simulator.tc
-        for req in self._reqs.values():
-            if req.is_active(now) and ((req.src == node0 and req.dst == node1) or (req.src == node1 and req.dst == node0)):
-                yield req
+        List FIB request entries where own node is an end-node.
+
+        Args:
+            opposite_end: The opposite end-node.
+        """
+        return self._end_reqs.get(opposite_end, [])

--- a/mqns/network/fw/forwarder.py
+++ b/mqns/network/fw/forwarder.py
@@ -26,7 +26,7 @@ from mqns.models.epr import Entanglement
 from mqns.models.error import PerfectErrorModel
 from mqns.models.error.input import ErrorModelInputBasic, parse_error
 from mqns.network.fw.cutoff import CutoffScheme, CutoffSchemeWaitTime
-from mqns.network.fw.fib import Fib, FibEntry
+from mqns.network.fw.fib import Fib, FibPath
 from mqns.network.fw.fw_purif import ForwarderPurifProc
 from mqns.network.fw.fw_swap import ForwarderSwapProc
 from mqns.network.fw.mux import MuxScheme
@@ -51,7 +51,7 @@ class ForwarderInitKwargs(TypedDict, total=False):
     """EPR age cut-off scheme, default is wait-time."""
     mux: MuxScheme | None
     """Path multiplexing scheme, default is buffer-space."""
-    select_purif_qubit: Callable[[list[MemoryEprTuple], MemoryQubit, FibEntry, QNode], MemoryEprTuple] | None
+    select_purif_qubit: Callable[[list[MemoryEprTuple], MemoryQubit, FibPath, QNode], MemoryEprTuple] | None
     """Qubit selection among purification candidates, default is picking first candidate."""
 
 
@@ -244,20 +244,20 @@ class Forwarder(ClassicCommandDispatcherMixin, Application[QNode]):
 
         _, epr = self.memory.read(mq.addr, has=self.epr_type)
         assert not epr.orig_eprs, f"{mq} is not elementary entanglement"
-        fib_entry = self.mux.qubit_is_entangled(mq, epr, event.neighbor)
-        self.log_debug("ENTANGLED %s path_id=%s | %s", mq, fib_entry.path_id if fib_entry else None, epr)
+        fp = self.mux.qubit_is_entangled(mq, epr, event.neighbor)
+        self.log_debug("ENTANGLED %s path_id=%s | %s", mq, fp.path_id if fp else None, epr)
 
         match mq.state:
             case QubitState.PURIF:
-                assert fib_entry
-                self.qubit_is_purif(mq, fib_entry, event.neighbor)
+                assert fp
+                self.qubit_is_purif(mq, fp, event.neighbor)
             case QubitState.ELIGIBLE:
-                self.qubit_is_eligible(mq, fib_entry)
+                self.qubit_is_eligible(mq, fp)
 
         if mq.state is not QubitState.RELEASE:
             self.swap.pop_waiting_su(mq)
 
-    def qubit_is_purif(self, qubit: MemoryQubit, fib_entry: FibEntry, partner: QNode):
+    def qubit_is_purif(self, qubit: MemoryQubit, fp: FibPath, partner: QNode):
         """
         Handle a qubit entering PURIF state or have completed a previous purification round.
 
@@ -269,26 +269,26 @@ class Forwarder(ClassicCommandDispatcherMixin, Application[QNode]):
 
         Args:
             qubit: The memory qubit at PURIF state.
-            fib_entry: FIB entry containing routing and purification instructions.
+            fp: FIB path entry containing routing and purification instructions.
             partner: The node with which the qubit shares an EPR.
         """
         assert qubit.state is QubitState.PURIF, f"unexpected state {qubit.state}"
 
-        own_idx, own_rank = fib_entry.own_idx, fib_entry.own_swap_rank
-        partner_idx, partner_rank = fib_entry.find_index_and_swap_rank(partner.name)
+        own_idx, own_rank = fp.own_idx, fp.own_swap_rank
+        partner_idx, partner_rank = fp.find_index_and_swap_rank(partner.name)
         if own_rank > partner_rank:
             # swapping order disallows initiating purif / swap / consumption
             return
 
         segment_name = f"{self.node.name}-{partner.name}" if own_idx < partner_idx else f"{partner.name}-{self.node.name}"
-        want_rounds = fib_entry.purif.get(segment_name, 0)
+        want_rounds = fp.purif.get(segment_name, 0)
         self.log_debug(
             "segment %s (qubit %s) has %s and needs %s purif rounds", segment_name, qubit.addr, qubit.purif_rounds, want_rounds
         )
 
         if qubit.purif_rounds == want_rounds:
             qubit.state = QubitState.ELIGIBLE
-            self.qubit_is_eligible(qubit, fib_entry)
+            self.qubit_is_eligible(qubit, fp)
             return
         assert qubit.purif_rounds < want_rounds
 
@@ -303,18 +303,18 @@ class Forwarder(ClassicCommandDispatcherMixin, Application[QNode]):
                 and q.state is QubitState.PURIF  # in PURIF state
                 and q.purif_rounds == qubit.purif_rounds  # with same number of purif rounds
                 and partner in (v.src, v.dst)  # with the same partner
-                and q.path_id == fib_entry.path_id  # on the same path_id
+                and q.path_id == fp.path_id  # on the same path_id
             ),
             has=self.epr_type,
         )
-        found = call_select(candidates, self._select_purif_qubit, qubit, fib_entry, partner)
+        found = call_select(candidates, self._select_purif_qubit, qubit, fp, partner)
         if not found:
             self.log_debug("no candidate EPR for segment %s purif round %s", segment_name, 1 + qubit.purif_rounds)
             return
 
-        self.purif.start(qubit, found[0], fib_entry, partner)
+        self.purif.start(qubit, found[0], fp, partner)
 
-    def qubit_is_eligible(self, mq0: MemoryQubit, fib_entry: FibEntry | None):
+    def qubit_is_eligible(self, mq0: MemoryQubit, fp: FibPath | None):
         """
         Handle a qubit entering ELIGIBLE state.
 
@@ -328,7 +328,7 @@ class Forwarder(ClassicCommandDispatcherMixin, Application[QNode]):
 
         Args:
             qubit: The qubit that became eligible.
-            fib_entry: FIB entry (not available with MuxSchemeStatistical).
+            fp: FIB path entry (not available with MuxSchemeStatistical).
         """
         assert mq0.state is QubitState.ELIGIBLE, f"unexpected state {mq0.state}"
         self.cnt.n_eligible += 1
@@ -340,35 +340,31 @@ class Forwarder(ClassicCommandDispatcherMixin, Application[QNode]):
             return
 
         _, epr0 = self.memory.read(mq0.addr, has=self.epr_type)
-        if self._try_consume(mq0, epr0, fib_entry):
+        if self._try_consume(mq0, epr0, fp):
             return
 
-        swap_decision = self.mux.find_swap_with(mq0, epr0, fib_entry)
+        swap_decision = self.mux.find_swap_with(mq0, epr0, fp)
         if swap_decision:
-            mq1, fib_entry = swap_decision
-            self.cutoff.before_swap(mq0, mq1, fib_entry)
-            if fib_entry.route.index(unwrap_cast(mq0.partner)[0].name) < fib_entry.route.index(
-                unwrap_cast(mq1.partner)[0].name
-            ):
-                self.swap.start(mq0, mq1, fib_entry)
+            mq1, fp = swap_decision
+            self.cutoff.before_swap(mq0, mq1, fp)
+            if fp.route.index(unwrap_cast(mq0.partner)[0].name) < fp.route.index(unwrap_cast(mq1.partner)[0].name):
+                self.swap.start(mq0, mq1, fp)
             else:
-                self.swap.start(mq1, mq0, fib_entry)
+                self.swap.start(mq1, mq0, fp)
         else:
-            self.cutoff.before_store_eligible(mq0, PathDirection.L if epr0.dst is self.node else PathDirection.R, fib_entry)
+            self.cutoff.before_store_eligible(mq0, PathDirection.L if epr0.dst is self.node else PathDirection.R, fp)
 
-    def _try_consume(self, qubit: MemoryQubit, epr: Entanglement, fib_entry: FibEntry | None) -> bool:
+    def _try_consume(self, qubit: MemoryQubit, epr: Entanglement, fp: FibPath | None) -> bool:
         """
         If the EPR matches an end-to-end request, inform ``Consumer`` to consume the EPR.
         """
-        if fib_entry is None:
-            src, dst = unwrap_cast(epr.src).name, unwrap_cast(epr.dst).name
-            for req in self.fib.find_request(lambda g: g.src == src and g.dst == dst, has_active=True):
-                req_id = req.req_id
-                break
-            return False
-
-        if fib_entry.is_swap_disabled or fib_entry.own_idx in (0, len(fib_entry.route) - 1):
-            req_id = fib_entry.req_id
+        if fp is None:
+            if fr := next(self.fib.find_active_req(unwrap_cast(epr.src).name, unwrap_cast(epr.dst).name), None):
+                req_id = fr.req_id
+            else:
+                return False
+        elif fp.sg is None:
+            req_id = fp.req_id
         else:
             return False
 

--- a/mqns/network/fw/forwarder.py
+++ b/mqns/network/fw/forwarder.py
@@ -26,7 +26,7 @@ from mqns.models.epr import Entanglement
 from mqns.models.error import PerfectErrorModel
 from mqns.models.error.input import ErrorModelInputBasic, parse_error
 from mqns.network.fw.cutoff import CutoffScheme, CutoffSchemeWaitTime
-from mqns.network.fw.fib import Fib, FibPath
+from mqns.network.fw.fib import Fib, FibPath, FibRequest
 from mqns.network.fw.fw_purif import ForwarderPurifProc
 from mqns.network.fw.fw_swap import ForwarderSwapProc
 from mqns.network.fw.mux import MuxScheme
@@ -359,18 +359,27 @@ class Forwarder(ClassicCommandDispatcherMixin, Application[QNode]):
         If the EPR matches an end-to-end request, inform ``Consumer`` to consume the EPR.
         """
         if fp is None:
-            if fr := next(self.fib.find_active_req(unwrap_cast(epr.src).name, unwrap_cast(epr.dst).name), None):
-                req_id = fr.req_id
-            else:
+            if (fr := next(self.fib.find_active_req(unwrap_cast(epr.src).name, unwrap_cast(epr.dst).name), None)) is None:
                 return False
         elif fp.sg is None:
-            req_id = fp.req_id
+            fr = fp.req
+            # TODO disallow consumption if request is no longer active
         else:
             return False
 
+        fr.epr_count_remain -= 1
+        if fr.epr_count_remain == 0:
+            self.request_reached_epr_count(fr)
+
         qubit.state = QubitState.CONSUME
-        self.simulator.add_event(QubitConsumeEvent(self.node, qubit, epr, t=self.simulator.tc, req_id=req_id))
+        self.simulator.add_event(QubitConsumeEvent(self.node, qubit, epr, t=self.simulator.tc, req_id=fr.req_id))
         return True
+
+    def request_reached_epr_count(self, fr: FibRequest) -> None:
+        """
+        Invoked on an end node when a request with ``epr_count`` restriction has reached this limit.
+        """
+        _ = fr
 
     @event_handler
     def qubit_is_decohered(self, event: MemoryDecohereEvent) -> None:

--- a/mqns/network/fw/forwarder.py
+++ b/mqns/network/fw/forwarder.py
@@ -358,16 +358,47 @@ class Forwarder(ClassicCommandDispatcherMixin, Application[QNode]):
         """
         If the EPR matches an end-to-end request, inform ``Consumer`` to consume the EPR.
         """
+        now = self.simulator.tc
         if fp is None:
-            if (fr := next(self.fib.find_active_req(unwrap_cast(epr.src).name, unwrap_cast(epr.dst).name), None)) is None:
+            # This branch is taken when using MuxSchemeStatistical.
+            # It searches for active requests spanning src,dst in either direction.
+            # If none is found, the EPR cannot be consumed.
+            frs = self.fib.list_end_reqs(unwrap_cast(qubit.partner)[0].name)
+            if (fr := next((fr for fr in frs if fr.is_active(now)), None)) is None:
                 return False
-        elif fp.sg is None:
-            fr = fp.req
-            # TODO disallow consumption if request is no longer active
         else:
-            return False
+            # This branch is taken when using either MuxSchemeBufferSpace or MuxSchemeDynamicEpr.
+            if fp.sg is not None:
+                # Having a swap group in the FIB path entry implies own node is not an end node,
+                # so that the EPR should continue swapping and not be consumed.
+                return False
+            fr = fp.req
+            if not fr.is_active(now):
+                self.log_debug(
+                    "CONSUME_SKIP addr=%s key=%s partner=%s epr-count-remain=%s reason=req-inactive",
+                    qubit.addr,
+                    qubit.key,
+                    unwrap_cast(qubit.partner)[0].name,
+                    fr.epr_count_remain,
+                )
+                # If the FIB request entry is no longer active, consumption is disallowed.
+                # Returning False would cause .qubit_is_eligible() to start swapping but own node is an end-node
+                # for the FIB path entry so there's nothing to swap with.
+                # Instead, we release the qubit and return True to prevent swapping.
+                self.release_qubit(qubit, need_remove=True)
+                return True
 
+        # If epr_count is unrestricted, fr.epr_count_remain initializes as infinity and remains infinity.
         fr.epr_count_remain -= 1
+
+        self.log_debug(
+            "CONSUME_PASS addr=%s key=%s partner=%s epr-count-remain=%s",
+            qubit.addr,
+            qubit.key,
+            qubit.partner,
+            fr.epr_count_remain,
+        )
+
         if fr.epr_count_remain == 0:
             self.request_reached_epr_count(fr)
 

--- a/mqns/network/fw/fw_module.py
+++ b/mqns/network/fw/fw_module.py
@@ -6,7 +6,7 @@ from mqns.entity.cchannel import ClassicCommandModule, ClassicPacket, classic_cm
 from mqns.entity.memory import QuantumMemory
 from mqns.entity.node import Application, Node, QNode
 from mqns.models.epr import Entanglement
-from mqns.network.fw.fib import Fib, FibEntry
+from mqns.network.fw.fib import Fib, FibPath
 from mqns.network.network import QuantumNetwork
 from mqns.simulator import Simulator
 from mqns.utils import LogSelfMixin, log
@@ -37,25 +37,25 @@ def fw_signaling_cmd_handler(cmd: str):
     """
     Method decorator for a signaling message handler in Forwarder.
 
-    ``handle_message(self, msg: dict, fib_entry: FibEntry) -> Any``
+    ``handle_message(self, msg: dict, fp: FibPath) -> Any``
     """
 
-    def decorator(f: Callable[[Any, Any, FibEntry], Any]):
+    def decorator(f: Callable[[Any, Any, FibPath], Any]):
         @functools.wraps(f)
         def wrapper(self: "ForwarderModule", pkt: ClassicPacket, msg: dict):
             path_id: int = msg["path_id"]
             try:
-                fib_entry = self.fib.get(path_id)
+                fp = self.fib.get_path(path_id)
             except LookupError:
                 self.log_debug("dropping signaling message from %s, reason=no-fib-entry | %s", pkt.src.name, msg)
                 return
 
             if pkt.dest != self.node:
-                self.send_msg(pkt.dest, msg, fib_entry, forward_from=pkt.src)
+                self.send_msg(pkt.dest, msg, fp, forward_from=pkt.src)
                 return
 
             self.log_debug("received signaling message from %s | %s", pkt.src.name, msg)
-            f(self, msg, fib_entry)
+            f(self, msg, fp)
 
         return classic_cmd_handler(cmd)(wrapper)
 
@@ -94,13 +94,13 @@ class ForwarderModule(LogSelfMixin, ClassicCommandModule):
         log.debug("%s: sending control message to controller | %s", self, msg)
         self.node.send_cpacket(ctrl, ClassicPacket(msg, src=self.node, dest=ctrl))
 
-    def send_msg(self, dest: Node, msg: Mapping, fib_entry: FibEntry, *, forward_from: Node | None = None):
+    def send_msg(self, dest: Node, msg: Mapping, fp: FibPath, *, forward_from: Node | None = None):
         """
-        Send/forward a signaling message along the path specified in FIB entry.
+        Send/forward a signaling message along the path specified in FIB path entry.
         """
-        dest_idx = fib_entry.route.index(dest.name)
-        nh_idx = fib_entry.own_idx + 1 if dest_idx > fib_entry.own_idx else fib_entry.own_idx - 1
-        next_hop = self.network.get_node(fib_entry.route[nh_idx])
+        dest_idx = fp.route.index(dest.name)
+        nh_idx = fp.own_idx + 1 if dest_idx > fp.own_idx else fp.own_idx - 1
+        next_hop = self.network.get_node(fp.route[nh_idx])
 
         pkt = ClassicPacket(msg, src=forward_from or self.node, dest=dest)
         log.debug(

--- a/mqns/network/fw/fw_nb.py
+++ b/mqns/network/fw/fw_nb.py
@@ -5,7 +5,7 @@ from mqns.entity.memory import PathDirection
 from mqns.entity.qchannel import QuantumChannel
 from mqns.network.fw.fib import FibEntry
 from mqns.network.fw.fw_module import ForwarderModule, fw_control_cmd_handler
-from mqns.network.fw.message import InstallPathMsg, UninstallPathMsg
+from mqns.network.fw.message import PathDeleteMsg, PathInsertMsg, PathInstructions
 from mqns.network.fw.mux import MuxScheme
 from mqns.simulator import Time, func_to_event
 
@@ -25,36 +25,45 @@ class ForwarderNorthbound(ForwarderModule):
         self.mux = fw.mux
         self._fib_erase_delay = self.simulator.time(time_slot=4 * self.memory.t_cohere.time_slot)
 
-    @fw_control_cmd_handler("INSTALL_PATH")
-    def handle_install_path(self, msg: InstallPathMsg) -> None:
-        """Process an INSTALL_PATH control command."""
-        path_id = msg["path_id"]
-        instructions = msg["instructions"]
-        self.mux.validate_path_instructions(instructions)
+    @fw_control_cmd_handler("PATH_INSERT")
+    def handle_path_insert(self, msg: PathInsertMsg) -> None:
+        """Process a PATH_INSERT control command."""
+        req_id = msg["req_id"]
+        for inst in msg["paths"]:
+            self._path_insert(req_id, inst)
+
+    def _path_insert(self, req_id: int, inst: PathInstructions) -> None:
+        route = inst["route"]
+        if self.node.name not in route:
+            # PATH_INSERT command may contain a path that does not traverse this node.
+            # These paths are silently skipped.
+            return
+
+        path_id = inst["path_id"]
+        self.mux.validate_path_instructions(inst)
 
         # Insert FIB entry.
-        route = instructions["route"]
-        if "swap_cutoff" in instructions:
-            swap_cutoff = [None if t < 0 else self.simulator.time(time_slot=t) for t in instructions["swap_cutoff"]]
+        if "swap_cutoff" in inst:
+            swap_cutoff = [None if t < 0 else self.simulator.time(time_slot=t) for t in inst["swap_cutoff"]]
         else:
             swap_cutoff: list[Time | None] = [None] * (2 * (len(route) - 2))
         fib_entry = FibEntry(
-            req_id=instructions["req_id"],
+            req_id=req_id,
             path_id=path_id,
             route=route,
             own_idx=route.index(self.node.name),
-            swap=instructions["swap"],
+            swap=inst["swap"],
             swap_cutoff=swap_cutoff,
-            purif=instructions["purif"],
+            purif=inst["purif"],
         )
         self.fib.insert_or_replace(fib_entry)
 
         # Identify left/right channels, allocate qubits and process LinkLayer changes.
         if ch := self._find_adj(fib_entry, -1):
-            self.mux.install_path_adj(instructions, fib_entry, PathDirection.L, ch)
+            self.mux.install_path_adj(inst, fib_entry, PathDirection.L, ch)
             self.install_path_adj(fib_entry, PathDirection.L, ch)
         if ch := self._find_adj(fib_entry, +1):
-            self.mux.install_path_adj(instructions, fib_entry, PathDirection.R, ch)
+            self.mux.install_path_adj(inst, fib_entry, PathDirection.R, ch)
             self.install_path_adj(fib_entry, PathDirection.R, ch)
 
     @abstractmethod
@@ -63,11 +72,14 @@ class ForwarderNorthbound(ForwarderModule):
         Process LinkLayer changes for an adjacency after a path has been installed.
         """
 
-    @fw_control_cmd_handler("UNINSTALL_PATH")
-    def handle_uninstall_path(self, msg: UninstallPathMsg) -> None:
-        """Process an UNINSTALL_PATH control command."""
-        path_id = msg["path_id"]
+    @fw_control_cmd_handler("PATH_DELETE")
+    def handle_path_delete(self, msg: PathDeleteMsg) -> None:
+        """Process a PATH_DELETE control command."""
+        rg = self.fib.by_req_id[msg["req_id"]]
+        for path_id in list(rg.path_ids):
+            self._path_delete(path_id)
 
+    def _path_delete(self, path_id: int) -> None:
         # Retrieve and erase FIB entry.
         fib_entry = self.fib.get(path_id)
         fib_entry.active_until = self.simulator.tc

--- a/mqns/network/fw/fw_nb.py
+++ b/mqns/network/fw/fw_nb.py
@@ -3,11 +3,11 @@ from typing import TYPE_CHECKING
 
 from mqns.entity.memory import PathDirection
 from mqns.entity.qchannel import QuantumChannel
-from mqns.network.fw.fib import FibEntry
+from mqns.network.fw.fib import FibPath, FibRequest
 from mqns.network.fw.fw_module import ForwarderModule, fw_control_cmd_handler
 from mqns.network.fw.message import PathDeleteMsg, PathInsertMsg, PathInstructions
 from mqns.network.fw.mux import MuxScheme
-from mqns.simulator import Time, func_to_event
+from mqns.simulator import Time
 
 if TYPE_CHECKING:
     from mqns.network.fw.forwarder import Forwarder
@@ -28,18 +28,22 @@ class ForwarderNorthbound(ForwarderModule):
     @fw_control_cmd_handler("PATH_INSERT")
     def handle_path_insert(self, msg: PathInsertMsg) -> None:
         """Process a PATH_INSERT control command."""
-        req_id = msg["req_id"]
-        for inst in msg["paths"]:
-            self._path_insert(req_id, inst)
+        paths = [(inst, self._path_convert(inst)) for inst in msg["paths"] if self.node.name in inst["route"]]
 
-    def _path_insert(self, req_id: int, inst: PathInstructions) -> None:
+        fr = FibRequest(msg["req_id"], [entry for _, entry in paths])
+        self.fib.insert_req(fr)
+
+        # Identify left/right channels, allocate qubits and process LinkLayer changes.
+        for inst, entry in paths:
+            if ch := self._find_adj(entry, -1):
+                self.mux.install_path_adj(inst, entry, PathDirection.L, ch)
+                self.install_path_adj(entry, PathDirection.L, ch)
+            if ch := self._find_adj(entry, +1):
+                self.mux.install_path_adj(inst, entry, PathDirection.R, ch)
+                self.install_path_adj(entry, PathDirection.R, ch)
+
+    def _path_convert(self, inst: PathInstructions) -> FibPath:
         route = inst["route"]
-        if self.node.name not in route:
-            # PATH_INSERT command may contain a path that does not traverse this node.
-            # These paths are silently skipped.
-            return
-
-        path_id = inst["path_id"]
         self.mux.validate_path_instructions(inst)
 
         # Insert FIB entry.
@@ -47,27 +51,17 @@ class ForwarderNorthbound(ForwarderModule):
             swap_cutoff = [None if t < 0 else self.simulator.time(time_slot=t) for t in inst["swap_cutoff"]]
         else:
             swap_cutoff: list[Time | None] = [None] * (2 * (len(route) - 2))
-        fib_entry = FibEntry(
-            req_id=req_id,
-            path_id=path_id,
+        return FibPath(
+            path_id=inst["path_id"],
             route=route,
             own_idx=route.index(self.node.name),
             swap=inst["swap"],
             swap_cutoff=swap_cutoff,
             purif=inst["purif"],
         )
-        self.fib.insert_or_replace(fib_entry)
-
-        # Identify left/right channels, allocate qubits and process LinkLayer changes.
-        if ch := self._find_adj(fib_entry, -1):
-            self.mux.install_path_adj(inst, fib_entry, PathDirection.L, ch)
-            self.install_path_adj(fib_entry, PathDirection.L, ch)
-        if ch := self._find_adj(fib_entry, +1):
-            self.mux.install_path_adj(inst, fib_entry, PathDirection.R, ch)
-            self.install_path_adj(fib_entry, PathDirection.R, ch)
 
     @abstractmethod
-    def install_path_adj(self, fib_entry: FibEntry, dir: PathDirection, ch: QuantumChannel) -> None:
+    def install_path_adj(self, fp: FibPath, dir: PathDirection, ch: QuantumChannel) -> None:
         """
         Process LinkLayer changes for an adjacency after a path has been installed.
         """
@@ -75,33 +69,26 @@ class ForwarderNorthbound(ForwarderModule):
     @fw_control_cmd_handler("PATH_DELETE")
     def handle_path_delete(self, msg: PathDeleteMsg) -> None:
         """Process a PATH_DELETE control command."""
-        rg = self.fib.by_req_id[msg["req_id"]]
-        for path_id in list(rg.path_ids):
-            self._path_delete(path_id)
-
-    def _path_delete(self, path_id: int) -> None:
-        # Retrieve and erase FIB entry.
-        fib_entry = self.fib.get(path_id)
-        fib_entry.active_until = self.simulator.tc
-        self.simulator.add_event(func_to_event(fib_entry.active_until + self._fib_erase_delay, self.fib.erase, path_id))
+        fr = self.fib.delete_req(msg["req_id"], delay=self._fib_erase_delay)
 
         # Identify left/right channels, deallocate qubits and process LinkLayer changes.
-        if ch := self._find_adj(fib_entry, -1):
-            self.mux.uninstall_path_adj(fib_entry, PathDirection.L, ch)
-            self.uninstall_path_adj(fib_entry, PathDirection.L, ch)
-        if ch := self._find_adj(fib_entry, +1):
-            self.mux.uninstall_path_adj(fib_entry, PathDirection.R, ch)
-            self.uninstall_path_adj(fib_entry, PathDirection.R, ch)
+        for fp in fr.paths:
+            if ch := self._find_adj(fp, -1):
+                self.mux.uninstall_path_adj(fp, PathDirection.L, ch)
+                self.uninstall_path_adj(fp, PathDirection.L, ch)
+            if ch := self._find_adj(fp, +1):
+                self.mux.uninstall_path_adj(fp, PathDirection.R, ch)
+                self.uninstall_path_adj(fp, PathDirection.R, ch)
 
     @abstractmethod
-    def uninstall_path_adj(self, fib_entry: FibEntry, dir: PathDirection, ch: QuantumChannel) -> None:
+    def uninstall_path_adj(self, fp: FibPath, dir: PathDirection, ch: QuantumChannel) -> None:
         """
         Process LinkLayer changes for an adjacency after a path has been installed.
         """
 
-    def _find_adj(self, fib_entry: FibEntry, route_offset: int) -> QuantumChannel | None:
-        neigh_idx = fib_entry.own_idx + route_offset
-        if neigh_idx in (-1, len(fib_entry.route)):  # no left/right neighbor if own node is the left/right end node
+    def _find_adj(self, fp: FibPath, route_offset: int) -> QuantumChannel | None:
+        neigh_idx = fp.own_idx + route_offset
+        if neigh_idx in (-1, len(fp.route)):  # no left/right neighbor if own node is the left/right end node
             return None
-        neigh = self.network.get_node(fib_entry.route[neigh_idx])
+        neigh = self.network.get_node(fp.route[neigh_idx])
         return self.node.get_qchannel(neigh)

--- a/mqns/network/fw/fw_nb.py
+++ b/mqns/network/fw/fw_nb.py
@@ -5,7 +5,7 @@ from mqns.entity.memory import PathDirection
 from mqns.entity.qchannel import QuantumChannel
 from mqns.network.fw.fib import FibPath, FibRequest
 from mqns.network.fw.fw_module import ForwarderModule, fw_control_cmd_handler
-from mqns.network.fw.message import PathDeleteMsg, PathInsertMsg, PathInstructions
+from mqns.network.fw.message import PathDeleteMsg, PathInsertMsg, PathInstructions, PathReachEprCountMsg
 from mqns.network.fw.mux import MuxScheme
 from mqns.simulator import Time
 
@@ -30,7 +30,7 @@ class ForwarderNorthbound(ForwarderModule):
         """Process a PATH_INSERT control command."""
         paths = [(inst, self._path_convert(inst)) for inst in msg["paths"] if self.node.name in inst["route"]]
 
-        fr = FibRequest(msg["req_id"], [entry for _, entry in paths])
+        fr = FibRequest(msg["req_id"], [entry for _, entry in paths], epr_count=msg.get("epr_count", -1))
         self.fib.insert_req(fr)
 
         # Identify left/right channels, allocate qubits and process LinkLayer changes.
@@ -92,3 +92,10 @@ class ForwarderNorthbound(ForwarderModule):
             return None
         neigh = self.network.get_node(fp.route[neigh_idx])
         return self.node.get_qchannel(neigh)
+
+    def send_reach_epr_count(self, fr: FibRequest) -> None:
+        msg = PathReachEprCountMsg(
+            cmd="PATH_REACH_EPR_COUNT",
+            req_id=fr.req_id,
+        )
+        self.send_ctrl(msg)

--- a/mqns/network/fw/fw_purif.py
+++ b/mqns/network/fw/fw_purif.py
@@ -1,6 +1,6 @@
 from mqns.entity.memory import MemoryQubit, QubitState
 from mqns.entity.node import QNode
-from mqns.network.fw.fib import FibEntry
+from mqns.network.fw.fib import FibPath
 from mqns.network.fw.fw_module import ForwarderModule, fw_signaling_cmd_handler
 from mqns.network.fw.message import PurifResponseMsg, PurifSolicitMsg
 
@@ -15,14 +15,14 @@ class ForwarderPurifProc(ForwarderModule):
     Part of ``Forwarder`` logic related to purification procedure.
     """
 
-    def start(self, mq0: MemoryQubit, mq1: MemoryQubit, fib_entry: FibEntry, partner: QNode):
+    def start(self, mq0: MemoryQubit, mq1: MemoryQubit, fp: FibPath, partner: QNode):
         """
         Initiate purification protocol.
 
         Args:
             mq0: first memory qubit, which would be kept if purification succeeds.
             mq1: second memory qubit, which is consumed during purification.
-            fib_entry: FIB entry.
+            fp: FIB path entry.
             partner: quantum node with which entanglements are shared.
         """
         # read qubits to set fidelity at this time
@@ -44,20 +44,20 @@ class ForwarderPurifProc(ForwarderModule):
         # send purif_solicit to partner
         msg: PurifSolicitMsg = {
             "cmd": "PURIF_SOLICIT",
-            "path_id": fib_entry.path_id,
+            "path_id": fp.path_id,
             "purif_node": self.node.name,
             "partner": partner.name,
             "key0": _qubit_p_key(mq0),
             "key1": _qubit_p_key(mq1),
             "round": mq0.purif_rounds,
         }
-        self.send_msg(partner, msg, fib_entry)
+        self.send_msg(partner, msg, fp)
 
         mq0.state = QubitState.PENDING
         self.fw.release_qubit(mq1)
 
     @fw_signaling_cmd_handler("PURIF_SOLICIT")
-    def handle_solicit(self, msg: PurifSolicitMsg, fib_entry: FibEntry):
+    def handle_solicit(self, msg: PurifSolicitMsg, fp: FibPath):
         """
         Process a PURIF_SOLICIT message from primary node as part of the purification protocol.
 
@@ -65,10 +65,6 @@ class ForwarderPurifProc(ForwarderModule):
         2. Attempt purification.
         3. If successful, update the EPR and send a PURIF_RESPONSE with result=True.
         4. Otherwise, mark both qubits for release and reply with result=False.
-
-        Args:
-            msg: Message containing purification parameters and EPR names.
-            fib_entry: FIB entry associated with path_id in the message.
 
         Notes:
             If EPR purification succeeds, if the qubit has completed the required rounds of purifications,
@@ -115,7 +111,7 @@ class ForwarderPurifProc(ForwarderModule):
             self.fw_cnt.increment_n_purif(mq0.purif_rounds)
             mq0.purif_rounds += 1
             mq0.state = QubitState.PURIF
-            self.fw.qubit_is_purif(mq0, fib_entry, primary)
+            self.fw.qubit_is_purif(mq0, fp, primary)
         else:
             # in case of purification failure, release mq0
             self.fw.release_qubit(mq0, need_remove=True)
@@ -131,10 +127,10 @@ class ForwarderPurifProc(ForwarderModule):
             "key1": p_key1,
             "result": result,
         }
-        self.send_msg(primary, resp, fib_entry)
+        self.send_msg(primary, resp, fp)
 
     @fw_signaling_cmd_handler("PURIF_RESPONSE")
-    def handle_response(self, msg: PurifResponseMsg, fib_entry: FibEntry):
+    def handle_response(self, msg: PurifResponseMsg, fp: FibPath):
         """
         Process a PURIF_RESPONSE message indicating the outcome of a purification attempt.
 
@@ -147,11 +143,6 @@ class ForwarderPurifProc(ForwarderModule):
         If the purification failed:
 
         1. Release the qubit.
-
-        Args:
-            msg: Response message containing the result and identifiers of the purified EPRs.
-            fib_entry: FIB entry associated with path_id in the message.
-
         """
         qubit, epr = self.memory.read(msg["key0"], has=self.epr_type)
         # TODO: handle the exception case when an EPR is decohered and not found in memory
@@ -175,4 +166,4 @@ class ForwarderPurifProc(ForwarderModule):
         self.fw_cnt.increment_n_purif(qubit.purif_rounds)
         qubit.purif_rounds += 1
         qubit.state = QubitState.PURIF
-        self.fw.qubit_is_purif(qubit, fib_entry, self.network.get_node(msg["partner"]))
+        self.fw.qubit_is_purif(qubit, fp, self.network.get_node(msg["partner"]))

--- a/mqns/network/fw/fw_swap.py
+++ b/mqns/network/fw/fw_swap.py
@@ -7,7 +7,7 @@ from mqns.models.core import QuantumModel
 from mqns.models.delay import DelayModel
 from mqns.models.epr import Entanglement
 from mqns.models.error import ErrorModel
-from mqns.network.fw.fib import FibEntry, FibSwapGroup
+from mqns.network.fw.fib import FibPath, FibSwapGroup
 from mqns.network.fw.fw_module import ForwarderModule, fw_signaling_cmd_handler
 from mqns.network.fw.message import SwapUpdateMsg
 from mqns.simulator import Event, Time, func_to_event
@@ -59,7 +59,7 @@ class _SwapHerald(NamedTuple):
 class _SwapParsedUpdate(NamedTuple):
     """SWAP_UPDATE parsed in own node context."""
 
-    fib_entry: FibEntry
+    fp: FibPath
     expiry: int
     q_paths: Sequence[int]
 
@@ -125,9 +125,9 @@ class _SwapTask:
     has_expire_event = False
     """Whether ``ForwarderSwapProc._u_expire_task`` is scheduled."""
 
-    def __init__(self, proc: "ForwarderSwapProc", fib_entry: FibEntry):
+    def __init__(self, proc: "ForwarderSwapProc", fp: FibPath):
         self.proc = proc
-        self.sg = unwrap(fib_entry.sg)
+        self.sg = unwrap(fp.sg)
 
     def begin_local_swap(self, la: _SwapArm, ra: _SwapArm) -> None:
         """
@@ -235,8 +235,8 @@ class _SwapTask:
         if not self.q_paths or self.sg.path_id in self.q_paths:
             return
 
-        fib_entry = self.proc.fib.get(self.q_paths[0])
-        sg = unwrap(fib_entry.sg)
+        fp = self.proc.fib.get_path(self.q_paths[0])
+        sg = unwrap(fp.sg)
         if sg.l_adj == self.sg.r_adj or sg.r_adj == self.sg.l_adj:
             self.l_complete, self.r_complete = self.r_complete, self.l_complete
             self.lc_paths, self.rc_paths = self.rc_paths, self.lc_paths
@@ -437,27 +437,27 @@ class ForwarderSwapProc(ForwarderModule):
         Send heralding messages.
         """
         for h in heralds:
-            fib_entry = None
+            fp = None
             for p in h.paths:
-                fe = self.fib.get(p)
-                if h.dest in fe.route:
-                    fib_entry = fe
+                fib_path = self.fib.get_path(p)
+                if h.dest in fib_path.route:
+                    fp = fib_path
                     break
 
-            if not fib_entry:
+            if not fp:
                 raise RuntimeError(f"{self}: cannot herald {h.dest} among paths {h.paths} | {h.su}")
 
-            h.su["path_id"] = fib_entry.path_id
-            self.send_msg(self.network.get_node(h.dest), h.su, fib_entry)
+            h.su["path_id"] = fp.path_id
+            self.send_msg(self.network.get_node(h.dest), h.su, fp)
 
-    def start(self, mq0: MemoryQubit, mq1: MemoryQubit, fib_entry: FibEntry):
+    def start(self, mq0: MemoryQubit, mq1: MemoryQubit, fp: FibPath):
         """
         Start swapping between two memory qubits.
 
         Args:
             mq0: Left qubit.
             mq1: Right qubit.
-            fib_entry: FIB entry.
+            fp: FIB path entry.
         """
         assert mq0.addr != mq1.addr
         assert mq0.qchannel is not mq1.qchannel
@@ -466,7 +466,7 @@ class ForwarderSwapProc(ForwarderModule):
         arms = [_SwapArm.new(mq0), _SwapArm.new(mq1)]
 
         # Record local swap start in SwapTask.
-        task, task_from = self._s_get_task(fib_entry, arms)
+        task, task_from = self._s_get_task(fp, arms)
         task.begin_local_swap(*arms)
         task_saved = self._s_put_task(task, arms)
 
@@ -478,17 +478,17 @@ class ForwarderSwapProc(ForwarderModule):
         # Schedule swap completion event.
         # If the FIB entry is being uninstalled, swap delay is bypassed and local swap is deemed failed.
         now = self.simulator.tc
-        if fib_entry.is_active(now):
+        if fp.req.is_active(now):
             finish_time = now + self.delay.calculate()
         else:
             finish_time = now
         error_time = finish_time if self.error_at_finish else now
-        self.simulator.add_event(func_to_event(finish_time, self._s_finish, arms, fib_entry, error_time, task))
+        self.simulator.add_event(func_to_event(finish_time, self._s_finish, arms, fp, error_time, task))
 
         self.log_debug("SWAP_START %s retrieved-from=%s saved-at=%s finish-time=%s", task, task_from, task_saved, finish_time)
 
     def _s_get_task(
-        self, fib_entry: FibEntry, arms: Sequence[_SwapArm], task_via_event: _SwapTask | None = None
+        self, fp: FibPath, arms: Sequence[_SwapArm], task_via_event: _SwapTask | None = None
     ) -> tuple[_SwapTask, str]:
         task: _SwapTask | None = None
         task_from: list[str] = []
@@ -501,7 +501,7 @@ class ForwarderSwapProc(ForwarderModule):
 
         if task_via_event:
             return task_via_event, "event"
-        return _SwapTask(self, fib_entry), "constructor"
+        return _SwapTask(self, fp), "constructor"
 
     def _s_put_task(self, task: _SwapTask, arms: Sequence[_SwapArm]) -> list[str]:
         task_saved: list[str] = []
@@ -513,7 +513,7 @@ class ForwarderSwapProc(ForwarderModule):
             task_saved.append(f"task_by_qubit[{arm.o_key}]")
         return task_saved
 
-    def _s_finish(self, arms: Sequence[_SwapArm], fib_entry: FibEntry, error_t: Time, task_via_event: _SwapTask):
+    def _s_finish(self, arms: Sequence[_SwapArm], fp: FibPath, error_t: Time, task_via_event: _SwapTask):
         """
         Complete swapping between two memory qubits.
 
@@ -535,19 +535,19 @@ class ForwarderSwapProc(ForwarderModule):
             phy_eprs.append(phy)
 
         # If the FIB entry is being uninstalled, local swap is deemed failed.
-        if not fib_entry.is_active(self.simulator.tc):
+        if not fp.req.is_active(self.simulator.tc):
             phy_eprs.clear()
 
         # Attempt physical swap.
         new_epr, outcome_str, local_success = self._s_physical_swap(error_t, phy_eprs)
-        self.log_debug("%s rank=%s | %s x %s = %s", outcome_str, fib_entry.own_swap_rank, arms[0], arms[1], new_epr)
+        self.log_debug("%s rank=%s | %s x %s = %s", outcome_str, fp.own_swap_rank, arms[0], arms[1], new_epr)
 
         # Release consumed qubits.
         for arm in alive_arms:
             self.fw.release_qubit(arm.mq)
 
         # Record local swap outcome in SwapTask, and then send heralding if allowed.
-        task, task_from = self._s_get_task(fib_entry, arms, task_via_event)
+        task, task_from = self._s_get_task(fp, arms, task_via_event)
         heralds = task.end_local_swap(min(local_expiry) if local_success else 0)
         task_saved = self._s_put_task(task, arms)
         if task_saved:
@@ -617,13 +617,9 @@ class ForwarderSwapProc(ForwarderModule):
             self.handle_update(su)
 
     @fw_signaling_cmd_handler("SWAP_UPDATE")
-    def receive_update(self, msg: SwapUpdateMsg, fib_entry: FibEntry) -> None:
+    def receive_update(self, msg: SwapUpdateMsg, fp: FibPath) -> None:
         """
         Receive an SWAP_UPDATE signaling message.
-
-        Args:
-            msg: The SWAP_UPDATE message.
-            fib_entry: FIB entry associated with path_id in the message.
         """
         ends = msg["ends"]
         if ends[0] == self.node.name:
@@ -635,17 +631,17 @@ class ForwarderSwapProc(ForwarderModule):
 
         swapper = msg["swapper"]
         q_paths = msg["q_paths"]
-        if partner not in fib_entry.route and q_paths:
+        if partner not in fp.route and q_paths:
             for path_id in q_paths:
-                fe = self.fib.get(path_id)
+                fe = self.fib.get_path(path_id)
                 if swapper in fe.route and partner in fe.route:
-                    fib_entry = fe
+                    fp = fe
                     break
-        _, swapper_rank = fib_entry.find_index_and_swap_rank(swapper)
+        _, swapper_rank = fp.find_index_and_swap_rank(swapper)
 
         self.handle_update(
             _SwapParsedUpdate(
-                fib_entry=fib_entry,
+                fp=fp,
                 expiry=msg["expiry"],
                 q_paths=q_paths,
                 swapper=swapper,
@@ -671,13 +667,13 @@ class ForwarderSwapProc(ForwarderModule):
 
         # If the swapper has a lower rank, it indicates the completion of a lower-ranked swap task.
         # Save its outcome into memory, so that this node can start purification and own-rank swapping,
-        if su.swapper_rank < su.fib_entry.own_swap_rank:
+        if su.swapper_rank < su.fp.own_swap_rank:
             self._u_lower(su, qubit_pair)
             return
 
         # If the swapper has the same rank, it is part of the swap task that is potentially parallel.
         # qubit_pair would be None, if own node has already swapped.
-        assert su.swapper_rank == su.fib_entry.own_swap_rank
+        assert su.swapper_rank == su.fp.own_swap_rank
         self._u_same(su, qubit_pair)
 
     def _u_lower(
@@ -729,7 +725,7 @@ class ForwarderSwapProc(ForwarderModule):
             raise ValueError(f"new_phy does not match node {self.node.name} | {new_phy}")
         assert partner.name == su.partner
 
-        assert su.partner in su.fib_entry.route
+        assert su.partner in su.fp.route
 
         # Store new EPR.
         qubit.partner = partner, su.p_key
@@ -746,7 +742,7 @@ class ForwarderSwapProc(ForwarderModule):
         # Progress toward purification and this-rank swap.
         qubit.purif_rounds = 0
         qubit.state = QubitState.PURIF
-        self.fw.qubit_is_purif(qubit, su.fib_entry, partner)
+        self.fw.qubit_is_purif(qubit, su.fp, partner)
 
     def _u_same(
         self,
@@ -756,7 +752,7 @@ class ForwarderSwapProc(ForwarderModule):
         """Process SWAP_UPDATE sent from a same-ranked node."""
 
         # Retrieve SwapTask.
-        task, task_from = self._u_get_task(su.fib_entry, su.o_key)
+        task, task_from = self._u_get_task(su.fp, su.o_key)
 
         # If qubit does not exist, it means own node had swap failure previously and already notified both sides,
         # but the remote swap occurred while the outgoing SWAP_UPDATE is still in flight.
@@ -790,10 +786,10 @@ class ForwarderSwapProc(ForwarderModule):
         self.log_debug("SWAP_UPDATE_SAME %s retrieved-from=%s saved-at=%s", task, task_from, task_saved)
         self._heralds(heralds)
 
-    def _u_get_task(self, fib_entry: FibEntry, qubit_key: str) -> tuple[_SwapTask, str]:
+    def _u_get_task(self, fp: FibPath, qubit_key: str) -> tuple[_SwapTask, str]:
         if t := self.task_by_qubit.pop(qubit_key, None):
             return t, f"task_by_qubit[qubit_key:={qubit_key}]"
-        return _SwapTask(self, fib_entry), "constructor"
+        return _SwapTask(self, fp), "constructor"
 
     def sched_expire_task(self, task: _SwapTask) -> None:
         if task.has_expire_event:

--- a/mqns/network/fw/message.py
+++ b/mqns/network/fw/message.py
@@ -10,19 +10,19 @@ type MultiplexingVector = Sequence[tuple[int, int] | str]
 
 class PathInstructions(TypedDict):
     """
-    Instructions from the controller to forwarders regarding a routing path.
+    Swapping and purification instructions for the forwarders.
     """
 
-    req_id: int
+    path_id: int
     """
-    Request identifier -- nonnegative integer to uniquely identify the src-dst pair within the network.
+    Path identifier -- nonnegative integer to identify this path.
     """
 
     route: list[str]
     """
     Path vector -- a list of node names, in the order they appear in the path.
 
-    There must a qchannel and a cchannel between adjacent nodes.
+    There must a quantum channel and a classical channel between each pair of adjacent nodes.
     """
 
     swap: SwapSequence
@@ -83,7 +83,7 @@ class PathInstructions(TypedDict):
     """
 
 
-def validate_path_instructions(instructions: PathInstructions) -> None:
+def validate_path_instructions(inst: PathInstructions) -> None:
     def check_purif_segment(segment_name: str) -> bool:
         try:
             idx0, idx1 = (route.index(node_name) for node_name in segment_name.split("-"))
@@ -91,33 +91,68 @@ def validate_path_instructions(instructions: PathInstructions) -> None:
         except ValueError:
             return False
 
-    route = instructions["route"]
+    route = inst["route"]
     if len(route) == 0:
         raise ValueError("route is empty")
 
-    if len(instructions["swap"]) != len(route):
+    if len(inst["swap"]) != len(route):
         raise ValueError("swapping order does not match route length")
 
-    if "swap_cutoff" in instructions and len(instructions["swap_cutoff"]) != 2 * (len(route) - 2):
+    if "swap_cutoff" in inst and len(inst["swap_cutoff"]) != 2 * (len(route) - 2):
         raise ValueError("swap_cutoff does not match route length")
 
-    if "m_v" in instructions and len(instructions["m_v"]) != len(route) - 1:
+    if "m_v" in inst and len(inst["m_v"]) != len(route) - 1:
         raise ValueError("multiplexing vector does not match route length")
 
-    for segment_name in instructions["purif"].keys():
+    for segment_name in inst["purif"].keys():
         if not check_purif_segment(segment_name):
             raise ValueError(f"purif segment {segment_name} does not exist in route")
 
 
-class InstallPathMsg(TypedDict):
-    cmd: Literal["INSTALL_PATH"]
-    path_id: int
-    instructions: PathInstructions
+class PathInsertMsg(TypedDict):
+    """
+    Path insertion command from controller to forwarders.
+
+    In Proactive-Centralized mode, this command installs one or more routing paths,
+    which is persisted until they are deleted via ``PathDeleteMsg``.
+
+    In Reactive-Centralized mode, this command gives specific swapping instructions,
+    which is valid for one time slot and automatically deleted after the slot.
+
+    This command is not allowed for any modes other than described above.
+    """
+
+    cmd: Literal["PATH_INSERT"]
+    req_id: int
+    """
+    Request identifier -- nonnegative integer to identify a request between a src-dst pair.
+
+    Each routing path belongs to a request, which identifies the src-dst pair along with other attributes.
+    All routing paths that belong to the same request must be sent in the same ``PathInsertMsg``.
+    However, it is possible for multiple requests to have the same src-dst pair.
+    """
+
+    paths: list[PathInstructions]
+    """
+    Routing paths, nonempty list.
+    """
 
 
-class UninstallPathMsg(TypedDict):
-    cmd: Literal["UNINSTALL_PATH"]
-    path_id: int
+class PathDeleteMsg(TypedDict):
+    """
+    Path deletion command from controller to forwarders.
+
+    In Proactive-Centralized mode, this command deletes the routing paths
+    installed with ``PathInsertMsg``.
+
+    This command is not allowed for any modes other than described above.
+    """
+
+    cmd: Literal["PATH_DELETE"]
+    req_id: int
+    """
+    Request identifier -- nonnegative integer to identify a request between a src-dst pair.
+    """
 
 
 class CutoffDiscardMsg(TypedDict):

--- a/mqns/network/fw/message.py
+++ b/mqns/network/fw/message.py
@@ -132,6 +132,14 @@ class PathInsertMsg(TypedDict):
     However, it is possible for multiple requests to have the same src-dst pair.
     """
 
+    epr_count: NotRequired[int]
+    """
+    How many entangled pairs are desired.
+
+    If this is nonnegative, each end-node forwarder must send ``PathReachEprCountMsg`` when
+    sufficient quantity of entangled pairs have been delivered for consumption.
+    """
+
     paths: list[PathInstructions]
     """
     Routing paths, nonempty list.
@@ -149,6 +157,18 @@ class PathDeleteMsg(TypedDict):
     """
 
     cmd: Literal["PATH_DELETE"]
+    req_id: int
+    """
+    Request identifier -- nonnegative integer to identify a request between a src-dst pair.
+    """
+
+
+class PathReachEprCountMsg(TypedDict):
+    """
+    Reaching ``epr_count`` report message from end-node forwarder to controller.
+    """
+
+    cmd: Literal["PATH_REACH_EPR_COUNT"]
     req_id: int
     """
     Request identifier -- nonnegative integer to identify a request between a src-dst pair.

--- a/mqns/network/fw/mux.py
+++ b/mqns/network/fw/mux.py
@@ -4,7 +4,7 @@ from mqns.entity.memory import MemoryQubit, PathDirection, QubitState
 from mqns.entity.node import QNode
 from mqns.entity.qchannel import QuantumChannel
 from mqns.models.epr import Entanglement
-from mqns.network.fw.fib import FibEntry
+from mqns.network.fw.fib import FibPath
 from mqns.network.fw.fw_module import ForwarderModule
 from mqns.network.fw.message import PathInstructions
 
@@ -17,24 +17,24 @@ class MuxScheme(ForwarderModule, ABC):
         """Validate install_path instructions are compatible."""
 
     @abstractmethod
-    def install_path_adj(self, inst: PathInstructions, fib_entry: FibEntry, dir: PathDirection, ch: QuantumChannel) -> None:
+    def install_path_adj(self, inst: PathInstructions, fp: FibPath, dir: PathDirection, ch: QuantumChannel) -> None:
         """
         Store information about adjacent quantum channel and allocate resources.
 
         Args:
             instructions: Path instructions.
-            fib_entry: FIB entry derived from path instructions.
+            fp: FIB path entry.
             direction: Direction of adjacency.
             qchannel: Quantum channel to the neighbor.
         """
 
     @abstractmethod
-    def uninstall_path_adj(self, fib_entry: FibEntry, dir: PathDirection, ch: QuantumChannel) -> None:
+    def uninstall_path_adj(self, fp: FibPath, dir: PathDirection, ch: QuantumChannel) -> None:
         """
         Erase information about adjacent quantum channel and deallocate resources.
 
         Args:
-            fib_entry: FIB entry.
+            fp: FIB path entry.
             direction: Direction of adjacency.
             qchannel: Quantum channel to the neighbor.
         """
@@ -52,7 +52,7 @@ class MuxScheme(ForwarderModule, ABC):
         """
 
     @abstractmethod
-    def qubit_is_entangled(self, mq: MemoryQubit, epr: Entanglement, neighbor: QNode) -> FibEntry | None:
+    def qubit_is_entangled(self, mq: MemoryQubit, epr: Entanglement, neighbor: QNode) -> FibPath | None:
         """
         Handle a qubit entering ENTANGLED state, i.e. having an elementary entanglement.
 
@@ -69,19 +69,14 @@ class MuxScheme(ForwarderModule, ABC):
         """
 
     @abstractmethod
-    def find_swap_with(
-        self,
-        mq0: MemoryQubit,
-        epr0: Entanglement,
-        fib_entry: FibEntry | None,
-    ) -> tuple[MemoryQubit, FibEntry] | None:
+    def find_swap_with(self, mq0: MemoryQubit, epr0: Entanglement, fp: FibPath | None) -> tuple[MemoryQubit, FibPath] | None:
         """
         Choose another qubit to swap with a qubit entering ELIGIBLE state and ready to swap.
 
         Args:
             mq0: The qubit entering ELIGIBLE state.
             epr0: The entanglement stored in the qubit.
-            fib_entry: FIB entry found by ``MuxScheme.qubit_is_entangled`` or used in last round of purification.
+            fp: FIB path entry found by ``MuxScheme.qubit_is_entangled`` or used in last round of purification.
 
         Returns:
             None: Do not swap.

--- a/mqns/network/fw/mux.py
+++ b/mqns/network/fw/mux.py
@@ -13,7 +13,7 @@ class MuxScheme(ForwarderModule, ABC):
     """Path multiplexing scheme."""
 
     @abstractmethod
-    def validate_path_instructions(self, instructions: PathInstructions) -> None:
+    def validate_path_instructions(self, inst: PathInstructions) -> None:
         """Validate install_path instructions are compatible."""
 
     @abstractmethod

--- a/mqns/network/fw/mux_buffer_space.py
+++ b/mqns/network/fw/mux_buffer_space.py
@@ -4,7 +4,7 @@ from mqns.entity.memory import MemoryQubit, PathDirection, QubitState
 from mqns.entity.node import QNode
 from mqns.entity.qchannel import QuantumChannel
 from mqns.models.epr import Entanglement
-from mqns.network.fw.fib import FibEntry
+from mqns.network.fw.fib import FibPath
 from mqns.network.fw.message import PathInstructions, validate_path_instructions
 from mqns.network.fw.mux import MuxScheme
 from mqns.network.fw.select import (
@@ -32,14 +32,14 @@ class MuxSchemeFibBase(MuxScheme):
         """
 
         def __call__(
-            self, candidates: list[MemoryEprTuple], fw: "Forwarder", mq0: MemoryEprTuple, fib_entry: FibEntry, /
+            self, candidates: list[MemoryEprTuple], fw: "Forwarder", mq0: MemoryEprTuple, fp: FibPath, /
         ) -> MemoryEprTuple:
             """
             Args:
                 candidates: List of qubits from ``ch1``, guaranteed to have two or more items.
                 fw: The forwarder instance.
                 mq0: The qubit from ``ch0``.
-                fib_entry: The FIB entry.
+                fp: FIB path entry.
 
             Returns:
                 One item from ``candidates``.
@@ -66,11 +66,11 @@ class MuxSchemeFibBase(MuxScheme):
         self._select_swap_qubit = parse_select(type(self), "SelectSwapQubit_", select_swap_qubit)
 
     def select_swap_candidate(
-        self, mq0: MemoryQubit, epr0: Entanglement, fib_entry: FibEntry, candidates: MemoryEprIterator
-    ) -> tuple[MemoryQubit, FibEntry] | None:
-        assert fib_entry
-        mt1 = call_select(candidates, self._select_swap_qubit, self.fw, (mq0, epr0), fib_entry)
-        return None if mt1 is None else (mt1[0], fib_entry)
+        self, mq0: MemoryQubit, epr0: Entanglement, fp: FibPath, candidates: MemoryEprIterator
+    ) -> tuple[MemoryQubit, FibPath] | None:
+        assert fp
+        mt1 = call_select(candidates, self._select_swap_qubit, self.fw, (mq0, epr0), fp)
+        return None if mt1 is None else (mt1[0], fp)
 
 
 class MuxSchemeBufferSpace(MuxSchemeFibBase):
@@ -95,11 +95,11 @@ class MuxSchemeBufferSpace(MuxSchemeFibBase):
         assert "m_v" in inst
 
     @override
-    def install_path_adj(self, inst: PathInstructions, fib_entry: FibEntry, dir: PathDirection, ch: QuantumChannel) -> None:
+    def install_path_adj(self, inst: PathInstructions, fp: FibPath, dir: PathDirection, ch: QuantumChannel) -> None:
         assert "m_v" in inst
         mv = inst["m_v"]
         mv_offset, ch_side = (-1, 1) if dir == PathDirection.L else (0, 0)
-        mv_index = fib_entry.own_idx + mv_offset
+        mv_index = fp.own_idx + mv_offset
         mv_element = mv[mv_index]
 
         if isinstance(mv_element, str):
@@ -107,22 +107,22 @@ class MuxSchemeBufferSpace(MuxSchemeFibBase):
             qubit, _ = next(self.memory.find(lambda q, _: q.key == mv_element), (None, None))
             if qubit is None:
                 raise ValueError(f"m_v[{mv_index}] refers to non-existent qubit {mv_element}")
-            qubit.path_id, qubit.path_direction = fib_entry.path_id, dir
+            qubit.path_id, qubit.path_direction = fp.path_id, dir
             addrs = [qubit.addr]
         else:
             # allocate memory qubit(s) assigned to the channel (typically used in proactive forwarding)
             n_qubits = mv_element[ch_side]
             addrs = self.memory.allocate(
                 ch,
-                fib_entry.path_id,
+                fp.path_id,
                 dir,
                 n="all" if n_qubits == 0 else n_qubits,
             )
         self.fw.log_debug("allocating %s qubits: %s", dir, addrs)
 
     @override
-    def uninstall_path_adj(self, fib_entry: FibEntry, dir: PathDirection, ch: QuantumChannel) -> None:
-        qubits = self.memory.find(lambda q, _: q.path_id == fib_entry.path_id, qchannel=ch)
+    def uninstall_path_adj(self, fp: FibPath, dir: PathDirection, ch: QuantumChannel) -> None:
+        qubits = self.memory.find(lambda q, _: q.path_id == fp.path_id, qchannel=ch)
         addrs = [q[0].addr for q in qubits]
         self.fw.log_debug("deallocating %s qubits: %s", dir, addrs)
         # If some qubits are currently ACTIVE or RESERVED IN LinkLayer, deallocation would occur
@@ -140,23 +140,18 @@ class MuxSchemeBufferSpace(MuxSchemeFibBase):
         return [mq.path_id]
 
     @override
-    def qubit_is_entangled(self, mq: MemoryQubit, epr: Entanglement, neighbor: QNode) -> FibEntry | None:
+    def qubit_is_entangled(self, mq: MemoryQubit, epr: Entanglement, neighbor: QNode) -> FibPath | None:
         _ = epr, neighbor
         mq.state = QubitState.PURIF
-        return self.fib.get(unwrap_cast(mq.path_id))
+        return self.fib.get_path(unwrap_cast(mq.path_id))
 
     @override
-    def find_swap_with(
-        self,
-        mq0: MemoryQubit,
-        epr0: Entanglement,
-        fib_entry: FibEntry | None,
-    ) -> tuple[MemoryQubit, FibEntry] | None:
-        assert fib_entry
+    def find_swap_with(self, mq0: MemoryQubit, epr0: Entanglement, fp: FibPath | None) -> tuple[MemoryQubit, FibPath] | None:
+        assert fp
         return self.select_swap_candidate(
             mq0,
             epr0,
-            fib_entry,
+            fp,
             self.memory.find(
                 lambda q, _: (
                     self.qubits_swappable(mq0, q)  # basic condition met

--- a/mqns/network/fw/mux_buffer_space.py
+++ b/mqns/network/fw/mux_buffer_space.py
@@ -90,9 +90,9 @@ class MuxSchemeBufferSpace(MuxSchemeFibBase):
         super().__init__(select_swap_qubit)
 
     @override
-    def validate_path_instructions(self, instructions: PathInstructions) -> None:
-        validate_path_instructions(instructions)
-        assert "m_v" in instructions
+    def validate_path_instructions(self, inst: PathInstructions) -> None:
+        validate_path_instructions(inst)
+        assert "m_v" in inst
 
     @override
     def install_path_adj(self, inst: PathInstructions, fib_entry: FibEntry, dir: PathDirection, ch: QuantumChannel) -> None:

--- a/mqns/network/fw/mux_dynamic_epr.py
+++ b/mqns/network/fw/mux_dynamic_epr.py
@@ -6,7 +6,7 @@ import numpy as np
 from mqns.entity.memory import MemoryQubit, QubitState
 from mqns.entity.node import QNode
 from mqns.models.epr import Entanglement
-from mqns.network.fw.fib import Fib, FibEntry
+from mqns.network.fw.fib import Fib, FibPath
 from mqns.network.fw.mux_buffer_space import MuxSchemeFibBase
 from mqns.network.fw.mux_statistical import MuxSchemeDynamicBase
 from mqns.network.fw.select import call_select, parse_select
@@ -18,9 +18,9 @@ def _select_path_random(path_ids: list[int], epr: Entanglement, fib: Fib) -> int
     return rng.choice(path_ids)
 
 
-def _select_path_swap_weighted(path_ids: list[int], epr: Entanglement, fib: Fib) -> FibEntry:
+def _select_path_swap_weighted(path_ids: list[int], epr: Entanglement, fib: Fib) -> FibPath:
     _ = epr
-    entries = [fib.get(pid) for pid in path_ids]
+    entries = [fib.get_path(pid) for pid in path_ids]
     # fewer swaps (shorter route) means higher weight
     weights = np.array([1.0 / (1 + len(e.swap)) for e in entries])
     weights /= np.sum(weights)
@@ -32,7 +32,7 @@ class MuxSchemeDynamicEpr(MuxSchemeFibBase, MuxSchemeDynamicBase):
     Dynamic EPR Allocation multiplexing scheme.
     """
 
-    type SelectPath = Callable[[list[int], Entanglement, Fib], int | FibEntry]
+    type SelectPath = Callable[[list[int], Entanglement, Fib], int | FibPath]
     """
     Path selection strategy.
     Function to select a path for an elementary entanglement.
@@ -71,7 +71,7 @@ class MuxSchemeDynamicEpr(MuxSchemeFibBase, MuxSchemeDynamicBase):
         self._select_path = parse_select(type(self), "SelectPath_", select_path)
 
     @override
-    def qubit_is_entangled(self, mq: MemoryQubit, epr: Entanglement, neighbor: QNode) -> FibEntry | None:
+    def qubit_is_entangled(self, mq: MemoryQubit, epr: Entanglement, neighbor: QNode) -> FibPath | None:
         _ = neighbor
         # TODO: if paths have different swap policies
         #       -> consider only paths for which this qubit may be eligible ??
@@ -82,31 +82,26 @@ class MuxSchemeDynamicEpr(MuxSchemeFibBase, MuxSchemeDynamicBase):
             # For ease of implementation, this choice is made at either primary or secondary node,
             # whichever receives the EPR notification earlier.
             selected_path = call_select(unwrap_cast(mq.epr_path_ids), self._select_path, epr, self.fib)
-            fib_entry = selected_path if type(selected_path) is FibEntry else self.fib.get(unwrap_cast(selected_path))
-            epr.affectionated_path_id = fib_entry.path_id
+            fp = selected_path if type(selected_path) is FibPath else self.fib.get_path(unwrap_cast(selected_path))
+            epr.affectionated_path_id = fp.path_id
         else:
-            fib_entry = self.fib.get(epr.affectionated_path_id)
+            fp = self.fib.get_path(epr.affectionated_path_id)
 
-        mq.epr_path_ids = [fib_entry.path_id]
+        mq.epr_path_ids = [fp.path_id]
         mq.state = QubitState.PURIF
-        return fib_entry
+        return fp
 
     @override
-    def find_swap_with(
-        self,
-        mq0: MemoryQubit,
-        epr0: Entanglement,
-        fib_entry: FibEntry | None,
-    ) -> tuple[MemoryQubit, FibEntry] | None:
-        assert fib_entry
+    def find_swap_with(self, mq0: MemoryQubit, epr0: Entanglement, fp: FibPath | None) -> tuple[MemoryQubit, FibPath] | None:
+        assert fp
         return self.select_swap_candidate(
             mq0,
             epr0,
-            fib_entry,
+            fp,
             self.memory.find(
                 lambda q, _: (
                     self.qubits_swappable(mq0, q)  # basic condition met
-                    and fib_entry.path_id in unwrap_cast(q.epr_path_ids)  # has compatible path_id
+                    and fp.path_id in unwrap_cast(q.epr_path_ids)  # has compatible path_id
                 ),
                 has=self.epr_type,
             ),

--- a/mqns/network/fw/mux_statistical.py
+++ b/mqns/network/fw/mux_statistical.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 class MuxSchemeDynamicBase(MuxScheme):
     def __init__(self):
         super().__init__()
-        self.qchannel_paths_map = defaultdict[str, list[int]](lambda: [])
+        self.qchannel_paths_map = defaultdict[str, list[int]](list)
         """stores path-qchannel relationship"""
 
     @override

--- a/mqns/network/fw/mux_statistical.py
+++ b/mqns/network/fw/mux_statistical.py
@@ -30,9 +30,9 @@ class MuxSchemeDynamicBase(MuxScheme):
         """stores path-qchannel relationship"""
 
     @override
-    def validate_path_instructions(self, instructions: PathInstructions):
-        validate_path_instructions(instructions)
-        assert "m_v" not in instructions
+    def validate_path_instructions(self, inst: PathInstructions):
+        validate_path_instructions(inst)
+        assert "m_v" not in inst
 
     @override
     def install_path_adj(self, inst: PathInstructions, fib_entry: FibEntry, dir: PathDirection, ch: QuantumChannel) -> None:
@@ -102,16 +102,16 @@ class MuxSchemeStatistical(MuxSchemeDynamicBase):
         self._select_path = parse_select(type(self), "SelectPath_", select_path)
 
     @override
-    def validate_path_instructions(self, instructions: PathInstructions):
-        super().validate_path_instructions(instructions)
+    def validate_path_instructions(self, inst: PathInstructions):
+        super().validate_path_instructions(inst)
 
         # swap sequence must be [1, 0, 0, .., 0, 0, 1]
-        s0, *s1, s2 = instructions["swap"]
+        s0, *s1, s2 = inst["swap"]
         assert s0 == 1 == s2
         assert all((s == 0 for s in s1))
 
         # purif scheme must be empty / zeros
-        assert all((r == 0 for r in instructions["purif"].values()))
+        assert all((r == 0 for r in inst["purif"].values()))
 
     @override
     def qubit_is_entangled(self, mq: MemoryQubit, epr: Entanglement, neighbor: QNode) -> FibEntry | None:

--- a/mqns/network/fw/mux_statistical.py
+++ b/mqns/network/fw/mux_statistical.py
@@ -6,7 +6,7 @@ from mqns.entity.memory import MemoryQubit, PathDirection, QubitState
 from mqns.entity.node import QNode
 from mqns.entity.qchannel import QuantumChannel
 from mqns.models.epr import Entanglement
-from mqns.network.fw.fib import FibEntry
+from mqns.network.fw.fib import FibPath
 from mqns.network.fw.message import PathInstructions, validate_path_instructions
 from mqns.network.fw.mux import MuxScheme
 from mqns.network.fw.select import (
@@ -35,15 +35,15 @@ class MuxSchemeDynamicBase(MuxScheme):
         assert "m_v" not in inst
 
     @override
-    def install_path_adj(self, inst: PathInstructions, fib_entry: FibEntry, dir: PathDirection, ch: QuantumChannel) -> None:
+    def install_path_adj(self, inst: PathInstructions, fp: FibPath, dir: PathDirection, ch: QuantumChannel) -> None:
         _ = inst, dir
-        self.qchannel_paths_map[ch.name].append(fib_entry.path_id)
+        self.qchannel_paths_map[ch.name].append(fp.path_id)
 
     @override
-    def uninstall_path_adj(self, fib_entry: FibEntry, dir: PathDirection, ch: QuantumChannel) -> None:
+    def uninstall_path_adj(self, fp: FibPath, dir: PathDirection, ch: QuantumChannel) -> None:
         _ = dir
         paths = self.qchannel_paths_map[ch.name]
-        paths.remove(fib_entry.path_id)
+        paths.remove(fp.path_id)
         if len(paths) == 0:
             del self.qchannel_paths_map[ch.name]
 
@@ -73,7 +73,7 @@ class MuxSchemeStatistical(MuxSchemeDynamicBase):
     SelectSwapQubit_oldest: SelectSwapQubit = select_swap_qubit_oldest
     SelectSwapQubit_newest: SelectSwapQubit = select_swap_qubit_newest
 
-    type SelectPath = Callable[[list[int], "Forwarder", Entanglement, Entanglement], int | FibEntry]
+    type SelectPath = Callable[[list[int], "Forwarder", Entanglement, Entanglement], int | FibPath]
 
     SelectPath_random: SelectPath = select_random
 
@@ -114,15 +114,15 @@ class MuxSchemeStatistical(MuxSchemeDynamicBase):
         assert all((r == 0 for r in inst["purif"].values()))
 
     @override
-    def qubit_is_entangled(self, mq: MemoryQubit, epr: Entanglement, neighbor: QNode) -> FibEntry | None:
+    def qubit_is_entangled(self, mq: MemoryQubit, epr: Entanglement, neighbor: QNode) -> FibPath | None:
         if self.coordinated_decisions and epr.affectionated_path_id >= 0:
             assert epr.affectionated_path_id in unwrap_cast(mq.epr_path_ids)
             mq.epr_path_ids = [epr.affectionated_path_id]
 
         def calc_rank_diff(path_id: int):
-            fib_entry = self.fib.get(path_id)
-            _, p_rank = fib_entry.find_index_and_swap_rank(neighbor.name)
-            return fib_entry.own_swap_rank - p_rank
+            fp = self.fib.get_path(path_id)
+            _, p_rank = fp.find_index_and_swap_rank(neighbor.name)
+            return fp.own_swap_rank - p_rank
 
         rank_diff = [calc_rank_diff(path_id) for path_id in unwrap_cast(mq.epr_path_ids)]
         assert min(rank_diff) == max(rank_diff)  # failure means one node is both repeater and end node, unsupported
@@ -137,12 +137,7 @@ class MuxSchemeStatistical(MuxSchemeDynamicBase):
         return None
 
     @override
-    def find_swap_with(
-        self,
-        mq0: MemoryQubit,
-        epr0: Entanglement,
-        fib_entry: FibEntry | None,
-    ) -> tuple[MemoryQubit, FibEntry] | None:
+    def find_swap_with(self, mq0: MemoryQubit, epr0: Entanglement, fp: FibPath | None) -> tuple[MemoryQubit, FibPath] | None:
         mq0_path_ids = set(unwrap_cast(mq0.epr_path_ids))
 
         candidates = self.memory.find(
@@ -177,7 +172,7 @@ class MuxSchemeStatistical(MuxSchemeDynamicBase):
             epr1,
         )
         assert selected_path is not None, "select_path did not find path"
-        fib_entry = selected_path if type(selected_path) is FibEntry else self.fib.get(selected_path)
+        fp = selected_path if type(selected_path) is FibPath else self.fib.get_path(selected_path)
         if self.coordinated_decisions:
-            epr0.affectionated_path_id = epr1.affectionated_path_id = fib_entry.path_id
-        return mq1, fib_entry
+            epr0.affectionated_path_id = epr1.affectionated_path_id = fp.path_id
+        return mq1, fp

--- a/mqns/network/fw/routing.py
+++ b/mqns/network/fw/routing.py
@@ -89,7 +89,7 @@ class RoutingPath(ABC):
 
         Returns:
             A generator of path instructions.
-            They will be installed into the nodes.
+            The ``path_id`` field shall be overwritten by the caller.
         """
 
     def _make_path_instructions(
@@ -100,8 +100,8 @@ class RoutingPath(ABC):
         m_v: MultiplexingVector | None = None,
     ) -> PathInstructions:
         swap = parse_swap_sequence(self.swap, route)
-        instructions: PathInstructions = {
-            "req_id": self.req_id,
+        inst: PathInstructions = {
+            "path_id": -1,
             "route": route,
             "swap": swap,
             "purif": self.purif,
@@ -109,15 +109,15 @@ class RoutingPath(ABC):
 
         if self.swap_cutoff is not None:
             accuracy = net.simulator.accuracy
-            instructions["swap_cutoff"] = [-1 if t < 0 else Time.sec_to_time_slot(t, accuracy) for t in self.swap_cutoff]
+            inst["swap_cutoff"] = [-1 if t < 0 else Time.sec_to_time_slot(t, accuracy) for t in self.swap_cutoff]
 
         if m_v is None:
             m_v = self._compute_mv(net, route)
         if m_v is not None:
-            instructions["m_v"] = m_v
+            inst["m_v"] = m_v
 
-        validate_path_instructions(instructions)
-        return instructions
+        validate_path_instructions(inst)
+        return inst
 
     def _compute_mv(self, net: QuantumNetwork, route: Sequence[str]) -> MultiplexingVector | None:
         _ = net

--- a/mqns/network/network/__init__.py
+++ b/mqns/network/network/__init__.py
@@ -1,5 +1,5 @@
 from mqns.network.network.network import QuantumNetwork
-from mqns.network.network.request import Request, RequestActiveEvent, RequestInitArgs
+from mqns.network.network.request import Request, RequestActiveEvent, RequestInactiveEvent, RequestInitArgs
 from mqns.network.network.timing import TimingMode, TimingModeAsync, TimingModeSync, TimingPhase, sync_phase_handler
 from mqns.network.network.traffic_matrix import MatrixTrafficGenerator, MatrixTrafficGeneratorInitArgs, TrafficMatrixMapping
 from mqns.network.network.traffic_random import generate_random_requests
@@ -11,6 +11,7 @@ __all__ = [
     "QuantumNetwork",
     "Request",
     "RequestActiveEvent",
+    "RequestInactiveEvent",
     "RequestInitArgs",
     "sync_phase_handler",
     "TimingMode",

--- a/mqns/network/network/network.py
+++ b/mqns/network/network/network.py
@@ -40,7 +40,7 @@ from mqns.network.topology import ClassicTopology, Topology
 from mqns.simulator import Simulator, Time
 
 
-def _save_channel[C: BaseChannel](l: list[C], d: dict[tuple[str, str], C], ch: C):
+def _save_channel[C: BaseChannel](l: list[C], d: dict[tuple[str, str], C], ch: C) -> None:
     l.append(ch)
     if len(ch.node_list) != 2:
         return
@@ -48,7 +48,7 @@ def _save_channel[C: BaseChannel](l: list[C], d: dict[tuple[str, str], C], ch: C
     d[(a, b)] = ch
 
 
-def _get_channel[C: BaseChannel](l: list[C], d: dict[tuple[str, str], C], q: tuple[str, ...]):
+def _get_channel[C: BaseChannel](l: list[C], d: dict[tuple[str, str], C], q: tuple[str, ...]) -> C:
     if len(q) == 1:
         name = q[0]
         for ch in l:
@@ -56,7 +56,10 @@ def _get_channel[C: BaseChannel](l: list[C], d: dict[tuple[str, str], C], q: tup
                 return ch
         raise LookupError(f"channel {name} does not exist") from None
 
-    a, b = sorted(q)
+    a, b = q
+    if a > b:
+        a, b = b, a
+
     try:
         return d[(a, b)]
     except KeyError:
@@ -77,11 +80,11 @@ class QuantumNetwork:
     ):
         """
         Args:
-            topo: topology builder.
-            classic_topo: classic topology parameter, passed to topology builder.
-            route: routing algorithm, defaults to dijkstra.
-            timing: network-wide application timing mode.
-            epr_type: network-wide entanglement type.
+            topo: Topology builder.
+            classic_topo: Classic topology parameter, passed to topology builder.
+            route: Routing algorithm, defaults to dijkstra.
+            timing: Network-wide application timing mode.
+            epr_type: Network-wide entanglement type.
         """
         assert getattr(epr_type, "__final__", False) is True, f"entanglement type {epr_type} must be marked @final"
 
@@ -111,7 +114,7 @@ class QuantumNetwork:
         self.requests: list[Request] = []
         """Requested end-to-end entanglements."""
 
-    def _populate_from_topo(self, topo: Topology, classic_topo: ClassicTopology | None):
+    def _populate_from_topo(self, topo: Topology, classic_topo: ClassicTopology | None) -> None:
         nodes, qchannels = topo.build()
         if classic_topo is not None:
             cchannels = topo.add_cchannels(classic_topo=classic_topo, nl=nodes, ll=qchannels)
@@ -134,13 +137,12 @@ class QuantumNetwork:
         """
         assert not hasattr(self, "simulator"), "function only available prior to self.install()"
 
-    def install(self, simulator: Simulator):
+    def install(self, simulator: Simulator) -> None:
         """
-        Install all nodes (including channels, memories and applications) in this network
+        Install all nodes (including channels, memories and applications) in this network.
 
         Args:
-            simulator: the simulator
-
+            simulator: The simulator.
         """
         self.simulator = simulator
         """Simulator instance."""
@@ -159,7 +161,7 @@ class QuantumNetwork:
         for req in self.requests:
             self._install_request(req)
 
-    def add_node(self, node: QNode):
+    def add_node(self, node: QNode) -> None:
         """
         Add a QNode into this network.
         """
@@ -181,7 +183,7 @@ class QuantumNetwork:
         except KeyError:
             raise LookupError(f"node {name} does not exist") from None
 
-    def set_controller(self, controller: Controller):
+    def set_controller(self, controller: Controller) -> None:
         """
         Set the controller of this network.
         """
@@ -200,7 +202,7 @@ class QuantumNetwork:
             raise LookupError("network does not have a controller")
         return self.controller
 
-    def add_qchannel(self, qchannel: QuantumChannel):
+    def add_qchannel(self, qchannel: QuantumChannel) -> None:
         """
         Add a QuantumChannel into this network.
         """
@@ -228,7 +230,7 @@ class QuantumNetwork:
     def get_qchannel(self, *q: str) -> QuantumChannel:
         return _get_channel(self.qchannels, self._qchannel_by_ends, q)
 
-    def add_cchannel(self, cchannel: ClassicChannel):
+    def add_cchannel(self, cchannel: ClassicChannel) -> None:
         """
         Add a ClassicChannel into this network.
         """
@@ -256,8 +258,8 @@ class QuantumNetwork:
     def get_cchannel(self, *q: str) -> ClassicChannel:
         return _get_channel(self.cchannels, self._cchannel_by_ends, q)
 
-    def build_route(self):
-        """Build static route tables for each nodes"""
+    def build_route(self) -> None:
+        """Build static route tables."""
         self.route.build(self.nodes, self.qchannels)
 
     def query_route(self, src: str, dst: str, /, error_on_empty=True) -> list[RouteQueryResult[QNode]]:
@@ -269,8 +271,8 @@ class QuantumNetwork:
             dst: Destination node.
             error_on_empty: If true, raise RuntimeError if there's no route.
 
-
-        Returns: list of route paths, sorted by priority.
+        Returns:
+            List of route paths, sorted by priority.
         """
         routes = self.route.query(self.get_node(src), self.get_node(dst))
         if error_on_empty and not routes:
@@ -286,7 +288,7 @@ class QuantumNetwork:
         t = self.simulator.tc
         return (req for req in self.requests if req.is_active(t))
 
-    def add_request(self, *reqs: Request):
+    def add_request(self, *reqs: Request) -> None:
         """
         Add one or more requests to the network.
         """
@@ -296,11 +298,11 @@ class QuantumNetwork:
             for req in reqs:
                 self._install_request(req)
 
-    def _install_request(self, req: Request):
-        for key in "since", "until":
-            t: Time | float = getattr(req, f"active_{key}_input")
-            delattr(req, f"active_{key}_input")
-            setattr(req, f"active_{key}", t if isinstance(t, Time) else self.simulator.time(sec=t))
+    def _install_request(self, req: Request) -> None:
+        req.active_since = Time.from_time_or_sec(req.active_since_input, accuracy=self.simulator.accuracy)
+        req.active_until = Time.from_time_or_sec(req.active_until_input, accuracy=self.simulator.accuracy)
+        del req.active_since_input
+        del req.active_until_input
 
         if not self.controller:
             return

--- a/mqns/network/network/network.py
+++ b/mqns/network/network/network.py
@@ -25,7 +25,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from typing import cast, overload
+from typing import TYPE_CHECKING, cast, overload
 
 from mqns.entity.base_channel import BaseChannel
 from mqns.entity.cchannel import ClassicChannel
@@ -37,6 +37,9 @@ from mqns.network.network.timing import TimingMode, TimingModeAsync
 from mqns.network.route import DijkstraRouteAlgorithm, RouteAlgorithm, RouteQueryResult
 from mqns.network.topology import ClassicTopology, Topology
 from mqns.simulator import Simulator, Time
+
+if TYPE_CHECKING:
+    from mqns.network.fw.routing import RoutingPath
 
 
 def _save_channel[C: BaseChannel](l: list[C], d: dict[tuple[str, str], C], ch: C) -> None:
@@ -278,10 +281,11 @@ class QuantumNetwork:
             raise RuntimeError(f"no route from {src} to {dst}")
         return routes
 
-    def add_request(self, *reqs: Request) -> None:
+    def add_request(self, *args: "Request|RoutingPath") -> None:
         """
         Add one or more requests to the network.
         """
+        reqs = [(req if isinstance(req, Request) else Request(req)) for req in args]
         self.requests.extend(reqs)
 
         if hasattr(self, "simulator"):
@@ -289,10 +293,8 @@ class QuantumNetwork:
                 self._install_request(req)
 
     def _install_request(self, req: Request) -> None:
-        req.active_since = Time.from_time_or_sec(req.active_since_input, accuracy=self.simulator.accuracy)
-        req.active_until = Time.from_time_or_sec(req.active_until_input, accuracy=self.simulator.accuracy)
-        del req.active_since_input
-        del req.active_until_input
+        req.active_since = Time.from_time_or_sec(req.active_since, accuracy=self.simulator.accuracy)
+        req.active_until = Time.from_time_or_sec(req.active_until, accuracy=self.simulator.accuracy)
 
         if not self.controller:
             return

--- a/mqns/network/network/network.py
+++ b/mqns/network/network/network.py
@@ -25,7 +25,6 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from collections.abc import Iterable
 from typing import cast, overload
 
 from mqns.entity.base_channel import BaseChannel
@@ -33,7 +32,7 @@ from mqns.entity.cchannel import ClassicChannel
 from mqns.entity.node import Controller, Node, QNode
 from mqns.entity.qchannel import QuantumChannel
 from mqns.models.epr import Entanglement, WernerStateEntanglement
-from mqns.network.network.request import Request, RequestActiveEvent
+from mqns.network.network.request import Request, RequestActiveEvent, RequestInactiveEvent
 from mqns.network.network.timing import TimingMode, TimingModeAsync
 from mqns.network.route import DijkstraRouteAlgorithm, RouteAlgorithm, RouteQueryResult
 from mqns.network.topology import ClassicTopology, Topology
@@ -279,15 +278,6 @@ class QuantumNetwork:
             raise RuntimeError(f"no route from {src} to {dst}")
         return routes
 
-    @property
-    def active_requests(self) -> Iterable[Request]:
-        """
-        List requests that are active at current timestamp.
-        See ``Request.is_active()`` for the criteria of determining whether a request is active.
-        """
-        t = self.simulator.tc
-        return (req for req in self.requests if req.is_active(t))
-
     def add_request(self, *reqs: Request) -> None:
         """
         Add one or more requests to the network.
@@ -308,8 +298,8 @@ class QuantumNetwork:
             return
 
         t_enter = self.simulator.tc if req.active_since is Time.MIN else req.active_since
-        self.simulator.add_event(RequestActiveEvent(self.controller, req, True, t=t_enter))
+        self.simulator.add_event(RequestActiveEvent(self.controller, req, t=t_enter))
 
         if req.active_until is not Time.MAX:
-            req.inactive_event = RequestActiveEvent(self.controller, req, False, t=req.active_until)
+            req.inactive_event = RequestInactiveEvent(self.controller, req, t=req.active_until)
             self.simulator.add_event(req.inactive_event)

--- a/mqns/network/network/request.py
+++ b/mqns/network/network/request.py
@@ -28,6 +28,21 @@ class RequestInitArgs(TypedDict, total=False):
     This attribute is not supported for any modes other than described above.
     """
 
+    epr_count: int
+    """
+    How many entangled pairs are desired.
+    Use ``-1`` or omit this attribute to indicate no limitation.
+
+    If this quantity of EPRs have been delivered to end-node applications, the network considers
+    this request fulfilled and may release its resources.
+
+    In Proactive-Centralized mode, the ``ProactiveRoutingController`` sends ``ConsumeCountBeginMsg``
+    to both end-nodes, the ``ProactiveForwarder`` at each end-node replies with ``ConsumeCountEndMsg``.
+    After receiving both replies, the controller uninstalls the path(s).
+
+    This attribute is not supported for any modes other than described above.
+    """
+
 
 class Request:
     """Requests entanglement pairs between a source and a destination."""
@@ -51,6 +66,15 @@ class Request:
     """
     Event when the request becomes inactive.
     This field is assigned by the controller.
+    """
+
+    epr_count: Final[int]
+    """
+    How many entangled pairs are desired, ``-1`` means no restriction.
+    """
+    epr_count_await: set[str] = {"#epr_count_disabled"}  # see .is_active() for explanation of class-level default
+    """
+    Which end nodes have not reported reaching ``epr_count``.
     """
 
     rp: "RoutingPath|None" = None
@@ -77,6 +101,11 @@ class Request:
             self.rp = arg1
             self.src, self.dst = self.rp.src, self.rp.dst
         self.active_since, self.active_until = kwargs.get("active_period", (Time.MIN, Time.MAX))
+        self.epr_count = kwargs.get("epr_count", -1)
+        if self.epr_count > 0:
+            self.epr_count_await = {self.src, self.dst}
+        else:
+            assert self.epr_count == -1
         self.rp_args = {}
 
     @overload
@@ -121,8 +150,13 @@ class Request:
         """
         Determine if the request is active, subject to these conditions:
 
+        * ``epr_count`` has not been reached.
         * Time point ``t`` is within active period.
         """
+        if not self.epr_count_await:
+            # If .epr_count is enabled, .epr_count_await becomes empty when both end-nodes reports reaching the count.
+            # If .epr_count is disabled, class-level default is a non-empty set so that `not .epr_count_await` remains False.
+            return False
         if t < cast(Time, self.active_since):
             return False
         if t >= cast(Time, self.active_until):
@@ -135,7 +169,11 @@ class Request:
         return self.rp.req_id if self.rp else self.rp_args.get("req_id", -1)
 
     def __repr__(self) -> str:
-        return f"Request({self.src}-{self.dst}, active_period={self.active_since}-{self.active_until})"
+        return (
+            f"Request({self.src}-{self.dst}, "
+            f"active_period={self.active_since}-{self.active_until}), "
+            f"epr_count={self.epr_count})"
+        )
 
 
 @final

--- a/mqns/network/network/request.py
+++ b/mqns/network/network/request.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Final, Self, TypedDict, Unpack, final, overload, override
+from typing import TYPE_CHECKING, Final, Self, TypedDict, Unpack, cast, final, overload, override
 
 from mqns.entity.node import Controller, NodePair, split_node_pair
 from mqns.simulator import Event, Time
@@ -15,7 +15,7 @@ class RequestInitArgs(TypedDict, total=False):
     active_period: tuple[Time | float, Time | float]
     """
     Time period in which the request is active / valid.
-    Use ``Time.SENTINEL`` to indicate no restriction on either side.
+    Use ``Time.MIN`` and ``Time.MAX`` to indicate no restriction.
 
     In Proactive-Centralized mode, the ``ProactiveRoutingController`` installs routing path(s)
     upon entering the active period and uninstalls them upon leaving the active period.
@@ -37,28 +37,46 @@ class Request:
     dst: Final[str]
     """Destination node name."""
 
-    active_since: Time
+    active_since: Time | float
     """
     Active period lower bound (inclusive), ``Time.MIN`` means no restriction.
-    This field becomes valid when the request is added to a network and a simulator is installed into the network.
+    This field is guaranteed to be ``Time`` after the request is added to a network and a simulator is installed.
     """
-    active_until: Time
+    active_until: Time | float
     """
     Active period upper bound (exclusive), ``Time.MAX`` means no restriction.
-    This field becomes valid when the request is added to a network and a simulator is installed into the network.
+    This field is guaranteed to be ``Time`` after the request is added to a network and a simulator is installed.
     """
-
     inactive_event: "RequestInactiveEvent|None" = None
-    """Event when the request becomes inactive."""
+    """
+    Event when the request becomes inactive.
+    This field is assigned by the controller.
+    """
 
     rp: "RoutingPath|None" = None
     """Routing path specified by scenario or assigned by controller."""
     rp_args: "RoutingPathInitArgs"
     """Routing path parameters specified by scenario and used by controller."""
 
+    @overload
     def __init__(self, np: NodePair, /, **kwargs: Unpack[RequestInitArgs]):
-        self.src, self.dst = split_node_pair(np)
-        self.active_since_input, self.active_until_input = kwargs.get("active_period", (Time.MIN, Time.MAX))
+        """
+        Construct from src-dst node pair.
+        """
+
+    @overload
+    def __init__(self, rp: "RoutingPath", /, **kwargs: Unpack[RequestInitArgs]):
+        """
+        Construct from ``RoutingPath``, equivalent to calling ``.path(rp)``.
+        """
+
+    def __init__(self, arg1: "NodePair|RoutingPath", /, **kwargs: Unpack[RequestInitArgs]):
+        if isinstance(arg1, str | tuple):
+            self.src, self.dst = split_node_pair(cast(NodePair, arg1))
+        else:
+            self.rp = arg1
+            self.src, self.dst = self.rp.src, self.rp.dst
+        self.active_since, self.active_until = kwargs.get("active_period", (Time.MIN, Time.MAX))
         self.rp_args = {}
 
     @overload
@@ -105,9 +123,9 @@ class Request:
 
         * Time point ``t`` is within active period.
         """
-        if t < self.active_since:
+        if t < cast(Time, self.active_since):
             return False
-        if t >= self.active_until:
+        if t >= cast(Time, self.active_until):
             return False
         return True
 
@@ -117,10 +135,7 @@ class Request:
         return self.rp.req_id if self.rp else self.rp_args.get("req_id", -1)
 
     def __repr__(self) -> str:
-        return f"Request({self.src}-{self.dst}, active_period={self._repr_active('since')}-{self._repr_active('until')})"
-
-    def _repr_active(self, key: str) -> Any:
-        return getattr(self, f"active_{key}", None) or getattr(self, f"active_{key}_input", None)
+        return f"Request({self.src}-{self.dst}, active_period={self.active_since}-{self.active_until})"
 
 
 @final

--- a/mqns/network/network/request.py
+++ b/mqns/network/network/request.py
@@ -48,7 +48,7 @@ class Request:
     This field becomes valid when the request is added to a network and a simulator is installed into the network.
     """
 
-    inactive_event: "RequestActiveEvent|None" = None
+    inactive_event: "RequestInactiveEvent|None" = None
     """Event when the request becomes inactive."""
 
     rp: "RoutingPath|None" = None
@@ -125,13 +125,26 @@ class Request:
 
 @final
 class RequestActiveEvent(Event):
-    """Event when a request enters or exits active_period."""
+    """Event when a request becomes active."""
 
-    def __init__(self, node: Controller, req: Request, enter: bool, *, t: Time):
-        super().__init__(t, f"RequestActiveEvent({req}, {enter})")
+    def __init__(self, node: Controller, req: Request, *, t: Time):
+        super().__init__(t, f"{req}")
         self.node = node
         self.req = req
-        self.enter = enter
+
+    @override
+    def invoke(self) -> None:
+        self.node.handle(self)
+
+
+@final
+class RequestInactiveEvent(Event):
+    """Event when a request becomes inactive."""
+
+    def __init__(self, node: Controller, req: Request, *, t: Time):
+        super().__init__(t, f"{req}")
+        self.node = node
+        self.req = req
 
     @override
     def invoke(self) -> None:

--- a/mqns/network/network/traffic_matrix.py
+++ b/mqns/network/network/traffic_matrix.py
@@ -86,8 +86,7 @@ class MatrixTrafficGenerator:
         Install this traffic generator into a simulator.
         """
         self.simulator = simulator
-        if not isinstance(self._duration, Time):
-            self._duration = Time.from_sec(self._duration, accuracy=simulator.accuracy)
+        self._duration = Time.from_time_or_sec(self._duration, accuracy=simulator.accuracy)
 
         match self._sched:
             case "eager":

--- a/mqns/network/network/traffic_matrix.py
+++ b/mqns/network/network/traffic_matrix.py
@@ -1,5 +1,5 @@
 from collections.abc import Iterator, Mapping
-from typing import Literal, TypedDict, Unpack
+from typing import Literal, TypedDict, Unpack, cast
 
 import numpy as np
 
@@ -22,14 +22,14 @@ Missing node pairs have zero probability.
 class MatrixTrafficGeneratorInitArgs(TypedDict, total=False):
     sched: Literal["never", "eager", "lazy"]
     """
-    Scheduling method in ``MatrixTrafficGenerator.install()``.
+    How should ``MatrixTrafficGenerator.install()`` schedule the requests.
 
     * "never": Do not schedule requests automatically.
-                Requests may be retrieved with ``.iter()`` method.
+      Requests may be retrieved with ``.iter()`` method.
     * "eager": Schedule all requests upfront.
-                This is incompatible with continuous simulation.
+      This is incompatible with continuous simulation.
     * "lazy": Schedule the first request, then schedule the next request
-                upon the previous request's arrival. This is the default.
+      upon the previous request's arrival. This is the default.
     """
 
     rate: float
@@ -38,9 +38,15 @@ class MatrixTrafficGeneratorInitArgs(TypedDict, total=False):
     This is expected number of requests per second.
     """
 
-    duration: float
+    duration: Time | float
     """
     Request active period duration, defaults to 1 second.
+    """
+
+    epr_count: int
+    """
+    Desired quantity of entangled pairs per request, defaults to 1.
+    ``-1`` means infinity (subject to ``duration``); ``0`` is invalid.
     """
 
 
@@ -66,7 +72,8 @@ class MatrixTrafficGenerator:
 
         self._sched = kwargs.get("sched", "lazy")
         self._scale = 1 / kwargs.get("rate", 1.0)
-        self._duration: Time | float = kwargs.get("duration", 1.0)
+        self._duration = kwargs.get("duration", 1.0)
+        self._epr_count = kwargs.get("epr_count", 1)
 
     def _convert_tm_map(self, tm: TrafficMatrixMapping):
         n = len(self.node_names)
@@ -114,7 +121,11 @@ class MatrixTrafficGenerator:
         Build request with specified arrival time.
         """
         src, dst = self.tm.sample()
-        return Request((self.node_names[src], self.node_names[dst]), active_period=(t, t + self._duration))
+        return Request(
+            (self.node_names[src], self.node_names[dst]),
+            active_period=(t, t + self._duration),
+            epr_count=self._epr_count,
+        )
 
     def _sched_eager(self):
         assert not self.simulator.is_continuous, "sched=eager is incompatible with continuous simulation"
@@ -126,4 +137,4 @@ class MatrixTrafficGenerator:
             return
 
         self.net.add_request(req)
-        self.simulator.add_event(func_to_event(req.active_since, self._sched_lazy, it))
+        self.simulator.add_event(func_to_event(cast(Time, req.active_since), self._sched_lazy, it))

--- a/mqns/network/proactive/controller.py
+++ b/mqns/network/proactive/controller.py
@@ -41,7 +41,7 @@ class ProactiveRoutingController(RoutingController):
                 if isinstance(self.net.route, YenRouteAlgorithm)
                 else RoutingPathSingle(req.src, req.dst, **req.rp_args)
             )
-        self.install_path(req.rp)
+        self.install_path(req.rp, epr_count=req.epr_count)
 
     @event_handler
     def handle_request_inactive(self, event: RequestInactiveEvent) -> None:

--- a/mqns/network/proactive/controller.py
+++ b/mqns/network/proactive/controller.py
@@ -16,10 +16,11 @@
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 
-from mqns.network.fw import RoutingController, RoutingPath, RoutingPathMulti, RoutingPathSingle
-from mqns.network.network import Request, RequestActiveEvent
+from mqns.network.fw import RoutingController, RoutingPathMulti, RoutingPathSingle
+from mqns.network.network import RequestActiveEvent, RequestInactiveEvent
 from mqns.network.route import YenRouteAlgorithm
 from mqns.simulator import event_handler
+from mqns.utils import unwrap
 
 
 class ProactiveRoutingController(RoutingController):
@@ -27,23 +28,22 @@ class ProactiveRoutingController(RoutingController):
     Centralized control plane for proactive routing.
     Works with ``ProactiveForwarder`` on quantum nodes.
 
-    This controller does not pick up requests from ``QuantumNetwork.requests`` list.
-    If desired, scenario script should manually pass requests to ``ProactiveRoutingController.install_path()``.
+    This controller is compatible with both SYNC and SYNC timing modes.
+    It can automatically pick up requests added through ``QuantumNetwork``.
     """
 
     @event_handler
-    def handle_request(self, event: RequestActiveEvent) -> None:
+    def handle_request_active(self, event: RequestActiveEvent) -> None:
         req = event.req
-        if event.enter:
-            req.rp = self._path_from_request(req)
-            self.install_path(req.rp)
-        else:
-            assert req.rp
-            self.uninstall_path(req.rp)
+        if req.rp is None:
+            req.rp = (
+                RoutingPathMulti(req.src, req.dst, **req.rp_args)
+                if isinstance(self.net.route, YenRouteAlgorithm)
+                else RoutingPathSingle(req.src, req.dst, **req.rp_args)
+            )
+        self.install_path(req.rp)
 
-    def _path_from_request(self, req: Request) -> RoutingPath:
-        if req.rp:
-            return req.rp
-        if isinstance(self.net.route, YenRouteAlgorithm):
-            return RoutingPathMulti(req.src, req.dst, **req.rp_args)
-        return RoutingPathSingle(req.src, req.dst, **req.rp_args)
+    @event_handler
+    def handle_request_inactive(self, event: RequestInactiveEvent) -> None:
+        req = event.req
+        self.uninstall_path(unwrap(req.rp))

--- a/mqns/network/proactive/forwarder.py
+++ b/mqns/network/proactive/forwarder.py
@@ -19,7 +19,7 @@ from typing import Unpack, override
 
 from mqns.entity.memory import PathDirection
 from mqns.entity.qchannel import QuantumChannel
-from mqns.network.fw import FibPath, Forwarder, ForwarderInitKwargs, ForwarderNorthbound
+from mqns.network.fw import FibPath, FibRequest, Forwarder, ForwarderInitKwargs, ForwarderNorthbound
 from mqns.network.protocol.event import PathActivateEvent, PathDeactivateEvent
 
 
@@ -70,3 +70,7 @@ class ProactiveForwarder(Forwarder):
     def install(self, node):
         super().install(node)
         self.nb.install(self)
+
+    @override
+    def request_reached_epr_count(self, fr: FibRequest) -> None:
+        self.nb.send_reach_epr_count(fr)

--- a/mqns/network/proactive/forwarder.py
+++ b/mqns/network/proactive/forwarder.py
@@ -19,37 +19,37 @@ from typing import Unpack, override
 
 from mqns.entity.memory import PathDirection
 from mqns.entity.qchannel import QuantumChannel
-from mqns.network.fw import FibEntry, Forwarder, ForwarderInitKwargs, ForwarderNorthbound
+from mqns.network.fw import FibPath, Forwarder, ForwarderInitKwargs, ForwarderNorthbound
 from mqns.network.protocol.event import PathActivateEvent, PathDeactivateEvent
 
 
 class ProactiveForwarderNorthbound(ForwarderNorthbound):
     @override
-    def install_path_adj(self, fib_entry: FibEntry, dir: PathDirection, ch: QuantumChannel) -> None:
+    def install_path_adj(self, fp: FibPath, dir: PathDirection, ch: QuantumChannel) -> None:
         self.simulator.add_event(
             PathActivateEvent(
                 self.node,
                 ch,
-                self._ll_path_id(fib_entry),
+                self._ll_path_id(fp),
                 t=self.simulator.tc,
                 is_primary=dir is PathDirection.R,
             )
         )
 
     @override
-    def uninstall_path_adj(self, fib_entry: FibEntry, dir: PathDirection, ch: QuantumChannel) -> None:
+    def uninstall_path_adj(self, fp: FibPath, dir: PathDirection, ch: QuantumChannel) -> None:
         _ = dir
         self.simulator.add_event(
             PathDeactivateEvent(
                 self.node,
                 ch,
-                self._ll_path_id(fib_entry),
+                self._ll_path_id(fp),
                 t=self.simulator.tc,
             )
         )
 
-    def _ll_path_id(self, fib_entry: FibEntry) -> int | None:
-        return fib_entry.path_id if self.mux.qubit_has_path_id() else None
+    def _ll_path_id(self, fp: FibPath) -> int | None:
+        return fp.path_id if self.mux.qubit_has_path_id() else None
 
 
 class ProactiveForwarder(Forwarder):

--- a/mqns/network/proactive/forwarder.py
+++ b/mqns/network/proactive/forwarder.py
@@ -39,14 +39,18 @@ class ProactiveForwarderNorthbound(ForwarderNorthbound):
     @override
     def uninstall_path_adj(self, fp: FibPath, dir: PathDirection, ch: QuantumChannel) -> None:
         _ = dir
-        self.simulator.add_event(
-            PathDeactivateEvent(
-                self.node,
-                ch,
-                self._ll_path_id(fp),
-                t=self.simulator.tc,
-            )
+        event = PathDeactivateEvent(
+            self.node,
+            ch,
+            self._ll_path_id(fp),
+            t=self.simulator.tc,
         )
+        # Give PathDeactivateEvent a lower priority so that it occurs after QubitEntangledEvent.
+        # Otherwise, in S-R-D topology, if R receives QubitEntangledEvent before path deactivation and performs a swap,
+        # but S processes path deactivation first so its forwarder never gets QubitEntangledEvent, S would
+        # receive SWAP_UPDATE message without ever receiving the qubit, and the physical deposit would be leaked.
+        event.priority = 1000
+        self.simulator.add_event(event)
 
     def _ll_path_id(self, fp: FibPath) -> int | None:
         return fp.path_id if self.mux.qubit_has_path_id() else None

--- a/mqns/network/protocol/link_layer.py
+++ b/mqns/network/protocol/link_layer.py
@@ -356,21 +356,21 @@ class LinkLayer(ClassicCommandDispatcherMixin, Application[QNode]):
             return
 
         # If the path on a channel is being deactivated, reset qubits owned by LinkLayer.
-        addrs: list[int] = []
+        resets: list[tuple[int, str | None]] = []
         for mq, _ in self.memory.find(
             lambda q, _: q.state in (QubitState.ACTIVE, QubitState.RESERVED) and q.path_id == path_id, qchannel=ch
         ):
+            resets.append((mq.addr, mq.key))
             mq.state = QubitState.RAW
-            addrs.append(mq.addr)
 
         del ac.paths[path_id]
         self.log_debug(
-            "PATH_DEACTIVATE_%s %s path=%s partner=%s reset-addrs=%s",
+            "PATH_DEACTIVATE_%s %s path=%s partner=%s reset-qubits=%s",
             PathActivateEvent.ROLE_STR[ac.is_primary],
             ch.name,
             path_id,
             partner.name,
-            addrs,
+            resets,
         )
         if len(ac.paths) > 0:
             return

--- a/mqns/network/reactive/controller.py
+++ b/mqns/network/reactive/controller.py
@@ -15,15 +15,21 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import itertools
-from collections import defaultdict, deque
 from typing import cast, override
 
 from mqns.entity.cchannel import ClassicCommandDispatcherMixin, ClassicPacket, classic_cmd_handler
-from mqns.network.fw import RoutingController, RoutingPathStatic
-from mqns.network.network import Request, TimingModeSync, TimingPhase, sync_phase_handler
+from mqns.network.fw import RoutingController
+from mqns.network.network import (
+    Request,
+    RequestActiveEvent,
+    RequestInactiveEvent,
+    TimingModeSync,
+    TimingPhase,
+    sync_phase_handler,
+)
 from mqns.network.reactive.message import LinkStateMsg
-from mqns.simulator import func_to_event
+from mqns.network.reactive.routing import ReactiveRoutingPath, ReactiveRoutingPathDef, TopoLinkState
+from mqns.simulator import event_handler, func_to_event
 from mqns.utils import json_encodable
 
 
@@ -47,14 +53,16 @@ class ReactiveRoutingController(ClassicCommandDispatcherMixin, RoutingController
     Works with ``ReactiveForwarder`` on quantum nodes.
 
     This controller is only compatible with SYNC timing mode.
-    It can automatically pick up requests from ``QuantumNetwork.requests`` list.
+    It can automatically pick up requests added through ``QuantumNetwork``.
+
+    The requests added to the network must not contain:
+
+    * predefined ``RoutingPath``
+    * multiplexing vector
+    * purification scheme
     """
 
     def __init__(self):
-        """
-        Args:
-            swap: Swapping policy applied to all paths.
-        """
         super().__init__(mv_auto="max")
 
         self.cnt = ReactiveRoutingControllerCounters()
@@ -62,12 +70,15 @@ class ReactiveRoutingController(ClassicCommandDispatcherMixin, RoutingController
         Counters.
         """
 
-        self._tls = defaultdict[tuple[str, str], deque[str]](deque)
+        self._tls = TopoLinkState()
         """
         Topology link state.
+        """
 
-        Key: node names, sorted.
-        Value: entanglement reservation keys.
+        self._reqs: dict[int, Request] = {}
+        """
+        Active requests.
+        Key: request identifier.
         """
 
     @override
@@ -76,11 +87,23 @@ class ReactiveRoutingController(ClassicCommandDispatcherMixin, RoutingController
 
         if self.node.timing.is_async():
             raise TypeError("ReactiveRoutingController only works with SYNC timing mode")
-        self.timing = cast(TimingModeSync, self.node.timing)
-        self.d_rtg = self.simulator.time(time_slot=self.timing.t_rtg.time_slot // 2)
+        timing = cast(TimingModeSync, self.node.timing)
+        self.d_rtg = self.simulator.time(time_slot=timing.t_rtg.time_slot // 2)
+
+    @event_handler
+    def handle_request_active(self, event: RequestActiveEvent) -> None:
+        req = event.req
+        if req.rp:
+            raise TypeError("ReactiveRoutingController disallows predefined RoutingPath in Request")
+        req.rp = ReactiveRoutingPath(req)
+        self._reqs[req.req_id] = req
+
+    @event_handler
+    def handle_request_inactive(self, event: RequestInactiveEvent) -> None:
+        del self._reqs[event.req.req_id]
 
     @sync_phase_handler(TimingPhase.ROUTING, True)
-    def handle_sync_phase(self) -> None:
+    def sync_routing_enter(self) -> None:
         """
         In SYNC timing mode, enter ROUTING phase.
         """
@@ -103,51 +126,46 @@ class ReactiveRoutingController(ClassicCommandDispatcherMixin, RoutingController
         self.cnt.n_ls += 1
 
         for entry in msg["ls"]:
-            n0, n1 = entry["node"], entry["neighbor"]
-            if n0 < n1:
-                self._tls[(n0, n1)].append(entry["qubit"])
+            self._tls.add(entry)
 
         return True
 
     def do_routing(self):
         """
-        Attempt to satisfy each active request in ``QuantumNetwork.requests`` list with available entanglements.
+        Attempt to satisfy each active request with available entanglements.
         Repeat multiple rounds until no more requests can be satisfied.
         """
-        some_satisfied = True
-        while some_satisfied:
-            some_satisfied = False
-            for req in self.net.active_requests:
-                if self._try_satisfy(req):
-                    self.cnt.n_satisfy += 1
-                    some_satisfied = True
+        satisfied: dict[int, ReactiveRoutingPath] = {}
+        this_round_satisfied = True
+        while this_round_satisfied:
+            this_round_satisfied = False
+            for req in self._reqs.values():
+                path_def = self._try_satisfy(req)
+                if path_def is None:
+                    continue
 
-    def _try_satisfy(self, req: Request) -> bool:
+                try:
+                    rp = satisfied[req.req_id]
+                except KeyError:
+                    rp = cast(ReactiveRoutingPath, req.rp)
+                    rp.paths.clear()
+                    satisfied[req.req_id] = rp
+
+                rp.paths.append(path_def)
+                self.cnt.n_satisfy += 1
+                this_round_satisfied = True
+
+        for rp in satisfied.values():
+            self.install_path(rp)
+
+    def _try_satisfy(self, req: Request) -> ReactiveRoutingPathDef | None:
         """
         Attempt to satisfy an active request with available entanglements.
         If the routing algorithm returns multiple routes, they will be tried in order.
         """
         routes = self.net.query_route(req.src, req.dst, error_on_empty=False)
         for route in routes:
-            if (qubits := self._try_consume(route.path)) is None:
+            if (qubits := self._tls.try_consume(route.path)) is None:
                 continue
-
-            self.install_path(RoutingPathStatic(route.path, **(req.rp_args | {"m_v": qubits})))
-            return True
-
-        return False
-
-    def _try_consume(self, route: list[str]) -> list[str] | None:
-        """
-        Attempt to match a computed route with available entanglements.
-        The entanglements are removed from ``self._tls`` only if every link along the path has an entanglement.
-        """
-        link_etgs: list[deque[str]] = []
-
-        for n0, n1 in itertools.pairwise(route):
-            etgs = self._tls.get((n0, n1) if n0 < n1 else (n1, n0))
-            if etgs is None or len(etgs) == 0:
-                return None
-            link_etgs.append(etgs)
-
-        return [etgs.popleft() for etgs in link_etgs]
+            return route.path, qubits
+        return None

--- a/mqns/network/reactive/controller.py
+++ b/mqns/network/reactive/controller.py
@@ -17,7 +17,7 @@
 
 from typing import cast, override
 
-from mqns.entity.cchannel import ClassicCommandDispatcherMixin, ClassicPacket, classic_cmd_handler
+from mqns.entity.cchannel import ClassicPacket, classic_cmd_handler
 from mqns.network.fw import RoutingController
 from mqns.network.network import (
     Request,
@@ -47,7 +47,7 @@ class ReactiveRoutingControllerCounters:
         return f"ls={self.n_ls} satisfy={self.n_satisfy}"
 
 
-class ReactiveRoutingController(ClassicCommandDispatcherMixin, RoutingController):
+class ReactiveRoutingController(RoutingController):
     """
     Centralized control plane for reactive routing.
     Works with ``ReactiveForwarder`` on quantum nodes.
@@ -113,14 +113,14 @@ class ReactiveRoutingController(ClassicCommandDispatcherMixin, RoutingController
         self.simulator.add_event(func_to_event(self.simulator.tc + self.d_rtg, self.do_routing))
 
     @classic_cmd_handler("LS")
-    def handle_ls(self, pkt: ClassicPacket, msg: LinkStateMsg):
+    def handle_ls(self, pkt: ClassicPacket, msg: LinkStateMsg) -> None:
         """
         Process received link_states from ReactiveForwarder.
         """
 
         if not self.node.timing.is_routing():  # should be in SYNC timing mode ROUTING phase
             self.log_warning("received LS message from %s outside of ROUTING phase | %s", pkt.src.name, msg)
-            return True
+            return
 
         self.log_debug("received LS message from %s | %s", pkt.src.name, msg)
         self.cnt.n_ls += 1
@@ -128,9 +128,7 @@ class ReactiveRoutingController(ClassicCommandDispatcherMixin, RoutingController
         for entry in msg["ls"]:
             self._tls.add(entry)
 
-        return True
-
-    def do_routing(self):
+    def do_routing(self) -> None:
         """
         Attempt to satisfy each active request with available entanglements.
         Repeat multiple rounds until no more requests can be satisfied.

--- a/mqns/network/reactive/controller.py
+++ b/mqns/network/reactive/controller.py
@@ -119,10 +119,10 @@ class ReactiveRoutingController(ClassicCommandDispatcherMixin, RoutingController
         """
 
         if not self.node.timing.is_routing():  # should be in SYNC timing mode ROUTING phase
-            self.log_warning("received LS message from %s outside of ROUTING phase | %s", pkt.src, msg)
+            self.log_warning("received LS message from %s outside of ROUTING phase | %s", pkt.src.name, msg)
             return True
 
-        self.log_debug("received LS message from %s | %s", pkt.src, msg)
+        self.log_debug("received LS message from %s | %s", pkt.src.name, msg)
         self.cnt.n_ls += 1
 
         for entry in msg["ls"]:

--- a/mqns/network/reactive/forwarder.py
+++ b/mqns/network/reactive/forwarder.py
@@ -19,7 +19,7 @@ from typing import Unpack, override
 
 from mqns.entity.memory import PathDirection
 from mqns.entity.qchannel import QuantumChannel
-from mqns.network.fw import FibEntry, Forwarder, ForwarderInitKwargs, ForwarderNorthbound
+from mqns.network.fw import FibPath, Forwarder, ForwarderInitKwargs, ForwarderNorthbound
 from mqns.network.network import TimingPhase, sync_phase_handler
 from mqns.network.protocol.event import PathActivateEvent
 from mqns.network.reactive.message import LinkStateEntry, LinkStateMsg
@@ -27,16 +27,16 @@ from mqns.network.reactive.message import LinkStateEntry, LinkStateMsg
 
 class ReactiveForwarderNorthbound(ForwarderNorthbound):
     @override
-    def install_path_adj(self, fib_entry: FibEntry, dir: PathDirection, ch: QuantumChannel) -> None:
+    def install_path_adj(self, fp: FibPath, dir: PathDirection, ch: QuantumChannel) -> None:
         _ = dir, ch
         if not self.node.timing.is_routing():
             self.log_warning(
-                "received INSTALL_PATH message for path %s outside of ROUTING phase; t_rtg is too short?", fib_entry.path_id
+                "received INSTALL_PATH message for path %s outside of ROUTING phase; t_rtg is too short?", fp.path_id
             )
 
     @override
-    def uninstall_path_adj(self, fib_entry: FibEntry, dir: PathDirection, ch: QuantumChannel) -> None:
-        _ = fib_entry, dir, ch
+    def uninstall_path_adj(self, fp: FibPath, dir: PathDirection, ch: QuantumChannel) -> None:
+        _ = fp, dir, ch
         raise ValueError(f"{self} should not receive PATH_DELETE command")
 
     def send_link_state(self):
@@ -103,5 +103,6 @@ class ReactiveForwarder(Forwarder):
         """
         In SYNC timing mode, exit INTERNAL phase.
         """
-        # Clear path assignments, as these are only useful for one slot.
+        # Clear FIB and path assignments, as these are only useful for one slot.
+        self.fib.clear()
         self.memory.deallocate(*(qubit.addr for qubit, _ in self.memory.find(lambda q, _: q.path_id is not None)))

--- a/mqns/network/reactive/forwarder.py
+++ b/mqns/network/reactive/forwarder.py
@@ -37,7 +37,7 @@ class ReactiveForwarderNorthbound(ForwarderNorthbound):
     @override
     def uninstall_path_adj(self, fib_entry: FibEntry, dir: PathDirection, ch: QuantumChannel) -> None:
         _ = fib_entry, dir, ch
-        raise ValueError(f"{self} should not receive UNINSTALL_PATH command")
+        raise ValueError(f"{self} should not receive PATH_DELETE command")
 
     def send_link_state(self):
         """

--- a/mqns/network/reactive/routing.py
+++ b/mqns/network/reactive/routing.py
@@ -1,0 +1,83 @@
+import itertools
+from collections import defaultdict, deque
+from collections.abc import Iterator
+from typing import override
+
+from mqns.network.fw import RoutingPath
+from mqns.network.fw.message import PathInstructions
+from mqns.network.network import QuantumNetwork, Request
+from mqns.network.reactive.message import LinkStateEntry
+
+
+class TopoLinkState:
+    """
+    Topology link state -- controller's view of available EPRs in the network.
+    """
+
+    def __init__(self):
+        self.d = defaultdict[tuple[str, str], deque[str]](deque)
+        """
+        Key: node names, sorted.
+        Value: entanglement reservation keys.
+        """
+
+    def clear(self) -> None:
+        self.d.clear()
+
+    def add(self, entry: LinkStateEntry) -> None:
+        """
+        Save a link state entry.
+        """
+        n0 = entry["node"]
+        n1 = entry["neighbor"]
+        if n0 < n1:
+            self.d[(n0, n1)].append(entry["qubit"])
+
+    def try_consume(self, route: list[str]) -> list[str] | None:
+        """
+        Attempt to match a computed route with available entanglements.
+        The entanglements are removed this table only if every link along the path has an entanglement.
+        """
+        link_etgs: list[deque[str]] = []
+
+        for n0, n1 in itertools.pairwise(route):
+            etgs = self.d.get((n0, n1) if n0 < n1 else (n1, n0))
+            if not etgs:
+                return None
+            link_etgs.append(etgs)
+
+        return [etgs.popleft() for etgs in link_etgs]
+
+
+type ReactiveRoutingPathDef = tuple[list[str], list[str]]
+"""
+Path computed by ``ReactiveRoutingController``.
+
+* [0]: List of nodes.
+* [1]: EPR key on each link.
+"""
+
+
+class ReactiveRoutingPath(RoutingPath):
+    """
+    Store paths computed by ``ReactiveRoutingController`` for a src-dst pair.
+    """
+
+    def __init__(self, req: Request):
+        super().__init__(req.src, req.dst, **req.rp_args)
+
+        self.paths: list[ReactiveRoutingPathDef] = []
+        """List of computed paths with specific EPRs."""
+
+        # Clear unsupported fields.
+        self.m_v = 0
+        self.purif = {}
+
+    def reset(self) -> None:
+        self.path_id = -1
+        self.paths.clear()
+
+    @override
+    def compute_paths(self, net: QuantumNetwork) -> Iterator[PathInstructions]:
+        for route, qubits in self.paths:
+            yield self._make_path_instructions(net, route, m_v=qubits)

--- a/mqns/simulator/time.py
+++ b/mqns/simulator/time.py
@@ -16,7 +16,7 @@
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import functools
-from typing import Final, final
+from typing import ClassVar, Final, final
 
 _ACCURACY0_STRS: dict[int, str] = {
     0: "(sentinel)",
@@ -34,11 +34,11 @@ class Time:
 
     __slots__ = ("time_slot", "accuracy")
 
-    SENTINEL: "Time"
+    SENTINEL: ClassVar["Time"]
     """Invalid Time instance as placeholder."""
-    MIN: "Time"
+    MIN: ClassVar["Time"]
     """Minimum value, compares less than all other instances."""
-    MAX: "Time"
+    MAX: ClassVar["Time"]
     """Maximum value, compares greater than all other instances."""
 
     def __init__(self, time_slot: int, *, accuracy: int):
@@ -65,10 +65,17 @@ class Time:
         Construct Time from seconds.
 
         Args:
-            sec: seconds.
-            accuracy: how many time slots per second.
+            sec: Seconds.
+            accuracy: How many time slots per second.
         """
         return Time(Time.sec_to_time_slot(sec, accuracy), accuracy=accuracy)
+
+    @staticmethod
+    def from_time_or_sec(sec: "Time|float", *, accuracy: int) -> "Time":
+        """
+        Construct Time from seconds, unless it's already Time instance.
+        """
+        return sec if type(sec) is Time else Time.from_sec(sec, accuracy=accuracy)
 
     @property
     def sec(self) -> float:
@@ -92,7 +99,9 @@ class Time:
     def __lt__(self, other: "Time") -> bool:
         """
         Less than comparison operator.
-        Two Time instances can be compared only if they have the same accuracy.
+
+        Two Time instances can be compared only if they have the same accuracy,
+        unless either instance is ``Time.MIN`` and ``Time.MAX``.
         """
         if self.accuracy == other.accuracy:
             return self.time_slot < other.time_slot
@@ -110,7 +119,7 @@ class Time:
         Add a duration and returns a new Time object.
 
         Args:
-            ts: either a Time object with same accuracy, or a duration number in seconds.
+            ts: Either a Time object with same accuracy, or a duration number in seconds.
         """
         if type(ts) is Time:
             assert ts.accuracy == self.accuracy
@@ -124,7 +133,7 @@ class Time:
         Subtract a duration and returns a new Time object.
 
         Args:
-            ts: either a Time object with same accuracy, or a duration number in seconds.
+            ts: Either a Time object with same accuracy, or a duration number in seconds.
         """
         if type(ts) is Time:
             assert ts.accuracy == self.accuracy

--- a/mqns/utils/random.py
+++ b/mqns/utils/random.py
@@ -8,6 +8,20 @@ Real rng instance.
 This may be re-assigned.
 """
 
+_FAST_METHODS = (
+    "choice",
+    "exponential",
+    "geometric",
+    "integers",
+    "normal",
+    "random",
+    "shuffle",
+    "uniform",
+)
+"""
+Method names on ``rng`` to avoid getattr overhead.
+"""
+
 
 class RngUtils:
     def reseed(self, seed: int | None):
@@ -17,6 +31,9 @@ class RngUtils:
         global _rng
         _rng = npr.default_rng(npr.PCG64(seed))
 
+        if isinstance(self, RngProxy):
+            self._update_fast_methods()
+
 
 class RngProxy(RngUtils):
     """
@@ -25,6 +42,10 @@ class RngProxy(RngUtils):
 
     def __getattr__(self, name: str) -> Any:
         return getattr(_rng, name)
+
+    def _update_fast_methods(self) -> None:
+        for method in _FAST_METHODS:
+            self.__dict__[method] = getattr(_rng, method)
 
 
 class RngPublic(npr.Generator, RngUtils):
@@ -37,3 +58,5 @@ rng = cast(RngPublic, RngProxy())
 """
 Global random number generator.
 """
+
+cast(RngProxy, rng)._update_fast_methods()

--- a/mqns/utils/types.py
+++ b/mqns/utils/types.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from collections.abc import Callable
+from operator import attrgetter
 from typing import Any, cast
 
 
@@ -13,9 +14,9 @@ def unwrap[T](var: T | None) -> T:
 
 def unwrap_cast[T](var: T | None) -> T:
     """
-    Cast a variable to non-None null.
+    Cast a variable to non-None type.
     """
-    return cast(T, var)
+    return var  # type: ignore
 
 
 class DecoratorDispatchBuilder[K, F: Callable]:
@@ -71,8 +72,9 @@ class DecoratorDispatchBuilder[K, F: Callable]:
         for attr_name, attr_type in cls.__annotations__.items():
             if not (isinstance(attr_type, type) and issubclass(attr_type, nested_base)):
                 continue
+            attr_get = attrgetter(attr_name)
             for k, l in cast(dict[K, list[F]], getattr(attr_type, self.classvar_name)).items():
-                d[k] += (self._make_wrapper(attr_name, func) for func in l)
+                d[k] += (self._make_wrapper(attr_get, func) for func in l)
 
     def _gather_base(self, d: defaultdict[K, list[F]], base: type) -> None:
         if b := cast(dict[K, list[F]], base.__dict__.get(self.classvar_name)):
@@ -85,8 +87,8 @@ class DecoratorDispatchBuilder[K, F: Callable]:
                 d[key].append(func)
 
     @staticmethod
-    def _make_wrapper(attr_name: str, f: Callable) -> Any:
+    def _make_wrapper(attr_get: attrgetter, f: Callable) -> Any:
         def nested_decorated_method_wrapper(self: Any, *args, **kwargs):
-            return f(getattr(self, attr_name), *args, **kwargs)
+            return f(attr_get(self), *args, **kwargs)
 
         return nested_decorated_method_wrapper

--- a/tests/fw/fw_common.py
+++ b/tests/fw/fw_common.py
@@ -18,10 +18,9 @@ from mqns.network.fw import (
     MultiplexingVectorInput,
     MuxSchemeBufferSpace,
     RoutingController,
-    RoutingPath,
 )
 from mqns.network.fw.fw_swap import ForwarderSwapProc
-from mqns.network.network import QuantumNetwork, Request, TimingMode, TimingModeAsync, TimingPhase, sync_phase_handler
+from mqns.network.network import QuantumNetwork, TimingMode, TimingModeAsync, TimingPhase, sync_phase_handler
 from mqns.network.proactive import ProactiveForwarder, ProactiveRoutingController
 from mqns.network.protocol.consumer import Consumer
 from mqns.network.protocol.event import QubitEntangledEvent, QubitReleasedEvent
@@ -312,25 +311,6 @@ def check_fw_counters(net: QuantumNetwork, **kwargs: Iterable[int | Iterable[int
             if actual != expected and (not isinstance(expected, Iterable) or actual not in expected):
                 errors.append(f"{node}.{key} = {actual} != {expected}")
     assert not errors, "\n".join(errors)
-
-
-def install_path(
-    net: QuantumNetwork,
-    rp: RoutingPath,
-    *,
-    t_install: float | None = None,
-    t_uninstall: float | None = None,
-) -> RoutingPath:
-    """
-    Install and/or uninstall a routing path at specific times.
-    """
-    net.add_request(
-        Request(
-            (rp.src, rp.dst),
-            active_period=(Time.MIN if t_install is None else t_install, Time.MAX if t_uninstall is None else t_uninstall),
-        ).path(rp)
-    )
-    return rp
 
 
 _provide_entanglements_autoid = AutoIncrementIdentifier("Tpe_")

--- a/tests/fw/fw_common.py
+++ b/tests/fw/fw_common.py
@@ -27,7 +27,7 @@ from mqns.network.protocol.consumer import Consumer
 from mqns.network.protocol.event import QubitEntangledEvent, QubitReleasedEvent
 from mqns.network.protocol.link_layer import LinkLayer
 from mqns.network.reactive import ReactiveForwarder, ReactiveRoutingController
-from mqns.network.route import RouteAlgorithm, YenRouteAlgorithm
+from mqns.network.route import DijkstraRouteAlgorithm, RouteAlgorithm, YenRouteAlgorithm
 from mqns.network.topology import ClassicTopology, GridTopology, LinearTopology, Topology, TopologyInitKwargs, TreeTopology
 from mqns.simulator import Simulator, Time, event_handler, func_to_event
 from mqns.utils import AutoIncrementIdentifier, log, rng
@@ -108,7 +108,7 @@ class BuildNetworkArgs(TypedDict, total=False):
     has_link_layer: bool  # whether to include full LinkLayer application, defaults to False
 
 
-def _make_topo_args(d: BuildNetworkArgs, *, memory_capacity_factor: int) -> TopologyInitKwargs:
+def _make_topo_args(d: BuildNetworkArgs, *, node_max_degree: int) -> TopologyInitKwargs:
     nodes_apps: list[Application[QNode]] = []
     if d.get("has_link_layer", False):
         nodes_apps.append(LinkLayer())
@@ -133,7 +133,7 @@ def _make_topo_args(d: BuildNetworkArgs, *, memory_capacity_factor: int) -> Topo
         cchannel_args=d.get("cchannel_args", dflt_cchannel_args),
         memory_args={
             "t_cohere": d.get("t_cohere", 5.0),
-            "capacity": memory_capacity_factor * ch_capacity,
+            "capacity": node_max_degree * ch_capacity,
         },
     )
 
@@ -187,7 +187,7 @@ def build_linear_network(
 ) -> tuple[QuantumNetwork, Simulator]:
     topo = LinearTopology(
         n_nodes,
-        **_make_topo_args(kwargs, memory_capacity_factor=2),
+        **_make_topo_args(kwargs, node_max_degree=2),
     )
     return _build_network_finish(topo, kwargs)
 
@@ -226,48 +226,65 @@ def build_tree_network(
     topo = TreeTopology(
         nodes_number=nnodes,
         children_number=2,
-        **_make_topo_args(kwargs, memory_capacity_factor=3),
+        **_make_topo_args(kwargs, node_max_degree=3),
     )
     return _build_network_finish(topo, kwargs)
 
 
-def build_rect_network(
+def build_grid_network(
+    shape: tuple[int, int] = (2, 2),
+    *,
+    k_paths=-1,
     **kwargs: Unpack[BuildNetworkArgs],
 ) -> tuple[QuantumNetwork, Simulator]:
     """
-    Build the following topology:
+    Build a grid topology with specified shape.
+
+    The default parameters build the 2x2 rectangle topology:
 
         A---B
         |   |
         C---D
 
-    The network uses Yen routing algorithm with 2 paths.
+    Args:
+        shape: Grid shape, width and height.
+        k_paths: If positive, use ``YenRouteAlgorithm``; otherwise, use ``DijkstraRouteAlgorithm``.
     """
     topo = GridTopology(
-        (2, 2),
-        **_make_topo_args(kwargs, memory_capacity_factor=2),
+        shape,
+        **_make_topo_args(kwargs, node_max_degree=2 if max(shape) == 2 else 4),
     )
-    return _build_network_finish(topo, kwargs, route=YenRouteAlgorithm(k_paths=2))
+    route = YenRouteAlgorithm(k_paths=k_paths) if k_paths > 0 else DijkstraRouteAlgorithm()
+    return _build_network_finish(topo, kwargs, route=route)
 
 
-def collect_cpacket_counts(monkeypatch: pytest.MonkeyPatch, *, inc_controller=False) -> Mapping[str, int]:
+def collect_cpacket_counts(monkeypatch: pytest.MonkeyPatch, *, cp=False, dp=False, cmd=False) -> Mapping[str, int]:
     """
     Gather classic packet counts between node pairs.
+
+    Args:
+        cp: Whether to include control plane traffic.
+        dp: Whether to include data plane traffic.
+        cmd: Whether to include command name.
 
     Returns: Mapping from node name(s) to number of packets, with these entries:
 
     * "src-dst": Packets sent from src to dst.
     * "src-*": Packets sent from src to any destination.
     * "*-dst": Packets sent to dst from any source.
+    * "src-dst:CMD", "src-*:CMD", "*-dst:CMD": Packets with specific command name, if ``cmd`` is True.
     """
     orig_send_cpacket = Node.send_cpacket
     d = defaultdict[str, int](lambda: 0)
 
     def send_cpacket(self: Node, next_hop: Node, pkt: ClassicPacket):
-        if self == pkt.src and (inc_controller or Controller not in (type(pkt.src), type(pkt.dest))):
-            d[f"{pkt.src.name}-{pkt.dest.name}"] += 1
-            d[f"{pkt.src.name}-*"] += 1
-            d[f"*-{pkt.dest.name}"] += 1
+        if self is pkt.src and (cp if (Controller in (type(pkt.src), type(pkt.dest))) else dp):
+            prefixes = [f"{pkt.src.name}-{pkt.dest.name}", f"{pkt.src.name}-*", f"*-{pkt.dest.name}"]
+            suffixes = [""]
+            if cmd and isinstance(msg := pkt.get(), dict) and "cmd" in msg:
+                suffixes.append(f":{msg['cmd']}")
+            for prefix, suffix in itertools.product(prefixes, suffixes):
+                d[prefix + suffix] += 1
         orig_send_cpacket(self, next_hop, pkt)
 
     monkeypatch.setattr(Node, "send_cpacket", send_cpacket)

--- a/tests/fw/test_p_integ.py
+++ b/tests/fw/test_p_integ.py
@@ -5,6 +5,7 @@ Test suite for ProactiveForwarder integrated with LinkLayer.
 import pytest
 
 from mqns.entity.memory import QuantumMemory
+from mqns.entity.qchannel import LinkArch, LinkArchAlways, LinkArchDimBk, LinkArchSr
 from mqns.entity.timer import Timer
 from mqns.models.epr import Entanglement, MixedStateEntanglement, WernerStateEntanglement
 from mqns.network.fw import (
@@ -23,7 +24,14 @@ from mqns.network.protocol.consumer import RequestCounters
 from mqns.network.protocol.link_layer import LinkLayer
 from mqns.simulator import Time
 
-from .fw_common import build_grid_network, build_linear_network, build_tree_network, collect_cpacket_counts, print_node_counters
+from .fw_common import (
+    build_grid_network,
+    build_linear_network,
+    build_tree_network,
+    collect_cpacket_counts,
+    dflt_qchannel_args,
+    print_node_counters,
+)
 
 
 @pytest.mark.parametrize("epr_type", [WernerStateEntanglement, MixedStateEntanglement])
@@ -58,11 +66,13 @@ def test_4_swap(epr_type: type[Entanglement], timing: TimingMode, swap: SwapSequ
     ],
 )
 @pytest.mark.parametrize("route_len", [3, 5])
-def test_tree2_bidir(mux: MuxScheme, swap: SwapSequenceInput, end_time: float, route_len: int):
+@pytest.mark.parametrize("LA", [LinkArchDimBk, LinkArchSr])
+def test_tree2_bidir(mux: MuxScheme, swap: SwapSequenceInput, end_time: float, route_len: int, LA: type[LinkArch]):
     """Test bidirectional paths in tree topology."""
     net, simulator = build_tree_network(
         t_cohere=1.0,
         ch_capacity=2,
+        qchannel_args=dflt_qchannel_args | {"link_arch": LinkArchAlways(LA())},
         fw={"p_swap": 1, "mux": mux},
         swap_table_leak_tol=256,
         end_time=end_time,
@@ -142,9 +152,16 @@ def test_rect2_path_delete():
         # Currently allocation logic cannot accommodate multi-path and multi-request simultaneously.
     ],
 )
-def test_rect3_epr_count(monkeypatch: pytest.MonkeyPatch, k_paths: int, n_requests: int):
+@pytest.mark.parametrize("LA", [LinkArchDimBk, LinkArchSr])
+def test_rect3_epr_count(monkeypatch: pytest.MonkeyPatch, k_paths: int, n_requests: int, LA: type[LinkArch]):
     """Test Request.epr_count in 3x3 rectangle topology."""
-    net, simulator = build_grid_network((3, 3), k_paths=k_paths, swap_table_leak_tol=256, has_link_layer=True)
+    net, simulator = build_grid_network(
+        (3, 3),
+        k_paths=k_paths,
+        qchannel_args=dflt_qchannel_args | {"link_arch": LinkArchAlways(LA())},
+        swap_table_leak_tol=256,
+        has_link_layer=True,
+    )
 
     requests: list[Request] = [
         Request("A-B", epr_count=7),

--- a/tests/fw/test_p_integ.py
+++ b/tests/fw/test_p_integ.py
@@ -23,7 +23,7 @@ from mqns.network.protocol.consumer import RequestCounters
 from mqns.network.protocol.link_layer import LinkLayer
 from mqns.simulator import Time
 
-from .fw_common import build_grid_network, build_linear_network, build_tree_network, print_node_counters
+from .fw_common import build_grid_network, build_linear_network, build_tree_network, collect_cpacket_counts, print_node_counters
 
 
 @pytest.mark.parametrize("epr_type", [WernerStateEntanglement, MixedStateEntanglement])
@@ -40,7 +40,7 @@ def test_4_swap(epr_type: type[Entanglement], timing: TimingMode, swap: SwapSequ
     simulator.run()
     print_node_counters(net)
 
-    # The main purpose of integrated test is to verify that the forwarder can return released qubits back to LinkLayer
+    # The main purpose of this test is to verify that the forwarder can return released qubits back to LinkLayer
     # for re-generating elementary entanglements.
     # Hence, these numeric bounds are much smaller than usual values, but must be greater than the memory capacity.
     assert fwB.cnt.n_swapped >= 16
@@ -132,3 +132,35 @@ def test_rect2_path_delete():
     assert counters[8][4] == counters[9][4]
 
     QuantumMemory.check_leaks(net.nodes)
+
+
+@pytest.mark.parametrize(
+    ("k_paths", "n_requests"),
+    [
+        (-1, 3),
+        (2, 1),
+        # Currently allocation logic cannot accommodate multi-path and multi-request simultaneously.
+    ],
+)
+def test_rect3_epr_count(monkeypatch: pytest.MonkeyPatch, k_paths: int, n_requests: int):
+    """Test Request.epr_count in 3x3 rectangle topology."""
+    net, simulator = build_grid_network((3, 3), k_paths=k_paths, swap_table_leak_tol=256, has_link_layer=True)
+
+    requests: list[Request] = [
+        Request("A-B", epr_count=7),
+        Request("C-F", epr_count=5),
+        Request("G-I", epr_count=3),
+    ][:n_requests]
+    net.add_request(*requests)
+
+    cpacket_cnt = collect_cpacket_counts(monkeypatch, cp=True, cmd=True)
+    simulator.run()
+    print_node_counters(net)
+    print("cpacket_cnt", cpacket_cnt)
+
+    for req in requests:
+        assert req.epr_count <= RequestCounters.of(net, req).n_consumed < req.epr_count + 3
+        for target in req.src, req.dst:
+            assert cpacket_cnt[f"ctrl-{target}:PATH_INSERT"] == 1
+            assert cpacket_cnt[f"ctrl-{target}:PATH_DELETE"] == 1
+            assert cpacket_cnt[f"{target}-ctrl:PATH_REACH_EPR_COUNT"] == 1

--- a/tests/fw/test_p_integ.py
+++ b/tests/fw/test_p_integ.py
@@ -17,12 +17,13 @@ from mqns.network.fw import (
     RoutingPathStatic,
     SwapSequenceInput,
 )
-from mqns.network.network import TimingMode, TimingModeAsync, TimingModeSync
+from mqns.network.network import Request, TimingMode, TimingModeAsync, TimingModeSync
 from mqns.network.proactive import ProactiveForwarder
 from mqns.network.protocol.consumer import RequestCounters
 from mqns.network.protocol.link_layer import LinkLayer
+from mqns.simulator import Time
 
-from .fw_common import build_grid_network, build_linear_network, build_tree_network, install_path, print_node_counters
+from .fw_common import build_grid_network, build_linear_network, build_tree_network, print_node_counters
 
 
 @pytest.mark.parametrize("epr_type", [WernerStateEntanglement, MixedStateEntanglement])
@@ -35,7 +36,7 @@ def test_4_swap(epr_type: type[Entanglement], timing: TimingMode, swap: SwapSequ
     )
     _, fwB, fwC, _ = (node.get_app(ProactiveForwarder) for node in net.nodes)
 
-    rp = install_path(net, RoutingPathSingle("A", "D", swap=swap))
+    net.add_request(rp := RoutingPathSingle("A", "D", swap=swap))
     simulator.run()
     print_node_counters(net)
 
@@ -75,25 +76,25 @@ def test_tree2_bidir(mux: MuxScheme, swap: SwapSequenceInput, end_time: float, r
         swap=swap,
         swap_cutoff=[0.01, 0.01] * (route_len - 2),
     )
-    rp0 = install_path(net, RoutingPathStatic("DBACF"[-route_len:], **rp_args), t_install=0.010)
-    rp1 = install_path(net, RoutingPathStatic("GCABE"[:route_len], **rp_args), t_install=0.020)
+    net.add_request(req0 := Request(RoutingPathStatic("DBACF"[-route_len:], **rp_args), active_period=(0.010, Time.MAX)))
+    net.add_request(req1 := Request(RoutingPathStatic("GCABE"[:route_len], **rp_args), active_period=(0.020, Time.MAX)))
     simulator.run()
     print_node_counters(net)
 
-    rp0cnt = RequestCounters.of(net, rp0).n_consumed
-    rp1cnt = RequestCounters.of(net, rp1).n_consumed
+    consumed0 = RequestCounters.of(net, req0).n_consumed
+    consume1 = RequestCounters.of(net, req1).n_consumed
 
     if isinstance(mux, MuxSchemeDynamicEpr) and route_len == 5:
-        assert rp0cnt + rp1cnt > 0
-        if min(rp0cnt, rp1cnt) == 0:
+        assert consumed0 + consume1 > 0
+        if min(consumed0, consume1) == 0:
             pytest.xfail(reason="https://github.com/usnistgov/mqns/issues/60#issuecomment-5180421126")
 
-    assert rp0cnt > 0
-    assert rp1cnt > 0
+    assert consumed0 > 0
+    assert consume1 > 0
 
 
-def test_rect2_uninstall_path():
-    """Test uninstall_path in 2x2 rectangle topology."""
+def test_rect2_path_delete():
+    """Test PATH_DELETE in 2x2 rectangle topology."""
     net, simulator = build_grid_network(t_cohere=1.0, has_link_layer=True)
     _, fwB, fwC, _ = (node.get_app(ProactiveForwarder) for node in net.nodes)
     llA, llB, llC, _ = (node.get_app(LinkLayer) for node in net.nodes)
@@ -115,8 +116,8 @@ def test_rect2_uninstall_path():
     timer = Timer("save_counters", start_time=0.500, end_time=9.501, step_time=1.000, trigger_func=save_counters)
     timer.install(simulator)
 
-    install_path(net, RoutingPathStatic("ABD"), t_install=2, t_uninstall=6)
-    install_path(net, RoutingPathStatic("ACD"), t_install=4, t_uninstall=8)
+    net.add_request(Request(RoutingPathStatic("ABD"), active_period=(2, 6)))
+    net.add_request(Request(RoutingPathStatic("ACD"), active_period=(4, 8)))
     simulator.run()
 
     assert len(counters) == 10

--- a/tests/fw/test_p_integ.py
+++ b/tests/fw/test_p_integ.py
@@ -176,8 +176,10 @@ def test_rect3_epr_count(monkeypatch: pytest.MonkeyPatch, k_paths: int, n_reques
     print("cpacket_cnt", cpacket_cnt)
 
     for req in requests:
-        assert req.epr_count <= RequestCounters.of(net, req).n_consumed < req.epr_count + 3
+        assert RequestCounters.of(net, req).n_consumed == req.epr_count
         for target in req.src, req.dst:
             assert cpacket_cnt[f"ctrl-{target}:PATH_INSERT"] == 1
             assert cpacket_cnt[f"ctrl-{target}:PATH_DELETE"] == 1
             assert cpacket_cnt[f"{target}-ctrl:PATH_REACH_EPR_COUNT"] == 1
+
+    QuantumMemory.check_leaks(net.nodes)

--- a/tests/fw/test_p_integ.py
+++ b/tests/fw/test_p_integ.py
@@ -22,7 +22,7 @@ from mqns.network.proactive import ProactiveForwarder
 from mqns.network.protocol.consumer import RequestCounters
 from mqns.network.protocol.link_layer import LinkLayer
 
-from .fw_common import build_linear_network, build_rect_network, build_tree_network, install_path, print_node_counters
+from .fw_common import build_grid_network, build_linear_network, build_tree_network, install_path, print_node_counters
 
 
 @pytest.mark.parametrize("epr_type", [WernerStateEntanglement, MixedStateEntanglement])
@@ -94,7 +94,7 @@ def test_tree2_bidir(mux: MuxScheme, swap: SwapSequenceInput, end_time: float, r
 
 def test_rect2_uninstall_path():
     """Test uninstall_path in 2x2 rectangle topology."""
-    net, simulator = build_rect_network(t_cohere=1.0, has_link_layer=True)
+    net, simulator = build_grid_network(t_cohere=1.0, has_link_layer=True)
     _, fwB, fwC, _ = (node.get_app(ProactiveForwarder) for node in net.nodes)
     llA, llB, llC, _ = (node.get_app(LinkLayer) for node in net.nodes)
 

--- a/tests/fw/test_p_purif.py
+++ b/tests/fw/test_p_purif.py
@@ -8,12 +8,13 @@ import pytest
 
 from mqns.entity.memory import MemoryQubit, PathDirection, QuantumMemory, QubitState
 from mqns.network.fw import RoutingPathStatic
+from mqns.network.network import Request
 from mqns.network.proactive import ProactiveForwarder
 from mqns.network.protocol.consumer import RequestCounters
 from mqns.simulator import Time
 from mqns.utils import rng
 
-from .fw_common import build_linear_network, check_fw_counters, install_path, print_node_counters, provide_entanglements
+from .fw_common import build_linear_network, check_fw_counters, print_node_counters, provide_entanglements
 
 
 def force_purify_outcome(monkeypatch: pytest.MonkeyPatch, *success: bool):
@@ -61,7 +62,7 @@ def test_link_rounds(monkeypatch: pytest.MonkeyPatch, n_rounds: int, purif_succe
     fwA = net.get_node("A").get_app(ProactiveForwarder)
     fwB = net.get_node("B").get_app(ProactiveForwarder)
 
-    rp = install_path(net, RoutingPathStatic("AB", swap=[0, 0], purif={"A-B": n_rounds}))
+    net.add_request(rp := RoutingPathStatic("AB", swap=[0, 0], purif={"A-B": n_rounds}))
     provide_entanglements(*((1.001 + i / 1000, fwA, fwB) for i in range(n_etg)))
     force_purify_outcome(monkeypatch, *(True if i > 0 else False for i in purif_success))
     simulator.run()
@@ -85,16 +86,16 @@ _3u_swap = ([1.0000], [1.0100]), -1, {}, ([1.2115], [1.2110], [1.2110], [1.2115]
 
 
 @pytest.mark.parametrize(
-    ("t_uninstall", "etg_sec", "cutoff", "purif", "t_raw"),
+    ("t_delete", "etg_sec", "cutoff", "purif", "t_raw"),
     [
         # 1. t=1.0010, A-B.0 arrives.
         # 2. t=1.0020, A-B.1 arrives, B sends PURIF_SOLICIT, which would arrive at 1.0025.
-        # 3. t=1.0022, path is uninstalled.
+        # 3. t=1.0022, path is deleted.
         pytest.param(1.0022, *_3u_purif, id="purif-solicit", marks=xfail_memory),
         # 1. t=1.0010, A-B.0 arrives.
         # 2. t=1.0020, A-B.1 arrives, B sends PURIF_SOLICIT.
         # 3. t=1.0025, A receives PURIF_SOLICIT and sends PURIF_RESPONSE, which would arrive at 1.0030.
-        # 4. t=1.0027, path is uninstalled.
+        # 4. t=1.0027, path is deleted.
         pytest.param(1.0027, *_3u_purif, id="purif-response", marks=xfail_memory),
         # 1. t=1.0010, A-B.0 arrives, B-C arrives.
         # 2. t=1.0020, A-B.1 arrives, B sends PURIF_SOLICIT.
@@ -102,46 +103,46 @@ _3u_swap = ([1.0000], [1.0100]), -1, {}, ([1.2115], [1.2110], [1.2110], [1.2115]
         # 4. t=1.0030, B receives PURIF_RESPONSE and starts swapping.
         # 5. t=1.2030, B finishes swapping and sends SWAP_UPDATE.
         # 6. t=1.2035, A and C process SWAP_UPDATE message.
-        # 7. t=1.2037, path is uninstalled.
+        # 7. t=1.2037, path is deleted.
         pytest.param(1.2037, *_3u_purif_swap, id="purif-complete"),
         # 1. t=1.0010, A-B arrives, discard scheduled at 1.0050.
-        # 2. t=1.0012, path is uninstalled.
+        # 2. t=1.0012, path is deleted.
         # 3. t=1.0050, B discards A-B and sends CUTOFF_DISCARD to A.
         # 4. t=1.0055, A processes CUTOFF_DISCARD message.
         pytest.param(1.0012, *_3u_cutoff, id="cutoff-waiting"),
         # 1. t=1.0010, A-B arrives, discard scheduled at 1.0050.
         # 2. t=1.0050, B discards A-B and sends CUTOFF_DISCARD to A.
-        # 3. t=1.0052, path is uninstalled.
+        # 3. t=1.0052, path is deleted.
         # 4. t=1.0055, A processes CUTOFF_DISCARD message.
         pytest.param(1.0052, *_3u_cutoff, id="cutoff-inflight"),
         # 1. t=1.0010, A-B arrives, discard scheduled at 1.0050.
         # 2. t=1.0050, B discards A-B and sends CUTOFF_DISCARD to A.
         # 3. t=1.0055, A processes CUTOFF_DISCARD message.
-        # 4. t=1.0057, path is uninstalled.
+        # 4. t=1.0057, path is deleted.
         pytest.param(1.0057, *_3u_cutoff, id="cutoff-complete"),
         # 1. t=1.0010, A-B arrives.
         # 2. t=1.0110, B-C arrives, B starts swapping.
-        # 3. t=1.1000, path is uninstalled.
+        # 3. t=1.1000, path is deleted.
         # 4. t=1.2110, B aborts the swap and sends SWAP_UPDATE.
         # 5. t=1.2115, A and C process SWAP_UPDATE message.
         pytest.param(1.1000, *_3u_swap, id="swap-waiting"),
         # 1. t=1.0010, A-B arrives.
         # 2. t=1.0110, B-C arrives, B starts swapping.
         # 3. t=1.2110, B finishes swapping and sends SWAP_UPDATE.
-        # 4. t=1.2112, path is uninstalled.
+        # 4. t=1.2112, path is deleted.
         # 5. t=1.2115, A and C process SWAP_UPDATE message.
         pytest.param(1.2112, *_3u_swap, id="swap-inflight"),
         # 1. t=1.0010, A-B arrives.
         # 2. t=1.0110, B-C arrives, B starts swapping.
         # 3. t=1.2110, B finishes swapping and sends SWAP_UPDATE.
         # 4. t=1.2115, A and C process SWAP_UPDATE message.
-        # 4. t=1.2117, path is uninstalled.
+        # 4. t=1.2117, path is deleted.
         pytest.param(1.2117, *_3u_swap, id="swap-complete"),
     ],
 )
-def test_3_uninstall(
+def test_3_path_delete(
     monkeypatch: pytest.MonkeyPatch,
-    t_uninstall: float,
+    t_delete: float,
     etg_sec: tuple[Iterable[float], Iterable[float]],
     cutoff: float,
     purif: Mapping[str, int],
@@ -153,7 +154,12 @@ def test_3_uninstall(
     chBC = net.get_qchannel("B", "C")
     fwA, fwB, fwC = (node.get_app(ProactiveForwarder) for node in net.nodes)
 
-    install_path(net, RoutingPathStatic("ABC", path_id=0, swap_cutoff=[cutoff, -1], purif=purif), t_uninstall=t_uninstall)
+    net.add_request(
+        Request(
+            RoutingPathStatic("ABC", path_id=0, swap_cutoff=[cutoff, -1], purif=purif),
+            active_period=(Time.MIN, t_delete),
+        )
+    )
     provide_entanglements(
         (etg_sec[0], fwA, fwB),
         (etg_sec[1], fwB, fwC),
@@ -190,9 +196,12 @@ def test_4_l2r(monkeypatch: pytest.MonkeyPatch):
     net, simulator = build_linear_network(4, ch_capacity=8, fw={"p_swap": 1.0})
     fwA, fwB, fwC, fwD = (node.get_app(ProactiveForwarder) for node in net.nodes)
 
-    rp = install_path(
-        net,
-        RoutingPathStatic("ABCD", swap=[2, 0, 1, 2], purif={"A-B": 1, "B-C": 1, "C-D": 1, "A-C": 1, "A-D": 1}),
+    net.add_request(
+        rp := RoutingPathStatic(
+            "ABCD",
+            swap=[2, 0, 1, 2],
+            purif={"A-B": 1, "B-C": 1, "C-D": 1, "A-C": 1, "A-D": 1},
+        ),
     )
     provide_entanglements(
         (1.001, fwA, fwB),  # \

--- a/tests/fw/test_p_purif.py
+++ b/tests/fw/test_p_purif.py
@@ -77,7 +77,7 @@ def test_link_rounds(monkeypatch: pytest.MonkeyPatch, n_rounds: int, purif_succe
     assert RequestCounters.of(net, rp).n_consumed == n_eligible
 
 
-xfail_memory = pytest.mark.xfail(reason="UNINSTALL_PATH cleanup not implemented", raises=MemoryError, strict=True)
+xfail_memory = pytest.mark.xfail(reason="PATH_DELETE cleanup not implemented", raises=MemoryError, strict=True)
 _3u_purif = ([1.0000, 1.0010], []), -1, {"A-B": 1}, ([1.0025], [1.0020], [], [])
 _3u_purif_swap = ([1.0000, 1.0010], [1.0000]), *_3u_purif[1:-1], ([1.0025, 1.2035], [1.0020, 1.2030], [1.2030], [1.2035])
 _3u_cutoff = ([1.0000], []), 0.004, {}, ([1.0055], [1.0050], [], [])
@@ -147,7 +147,7 @@ def test_3_uninstall(
     purif: Mapping[str, int],
     t_raw: tuple[Sequence[float], ...],
 ):
-    """Test UNINSTALL_PATH cleanup during cut-off/swap/purify on 3-node topology."""
+    """Test PATH_DELETE cleanup during cut-off/swap/purify on 3-node topology."""
     net, simulator = build_linear_network(3, t_cohere=5.0, ch_capacity=2, fw={"p_swap": 1.0, "swap_delay": 0.2}, end_time=5.0)
     chAB = net.get_qchannel("A", "B")
     chBC = net.get_qchannel("B", "C")

--- a/tests/fw/test_p_swap.py
+++ b/tests/fw/test_p_swap.py
@@ -49,8 +49,8 @@ def test_3_disabled():
 
     def check_fib_entries():
         for fw in (fwA, fwB, fwC):
-            fib_entry = fw.fib.get(rp.path_id)
-            assert fib_entry.is_swap_disabled is True
+            fp = fw.fib.get_path(rp.path_id)
+            assert fp.sg is None
 
     simulator.add_event(func_to_event(simulator.time(sec=2.0), check_fib_entries))
     provide_entanglements(
@@ -602,7 +602,7 @@ def test_rect2_multipath(has_etg: tuple[int, int, int, int], n_swapped: tuple[in
     net.add_request(rp := RoutingPathMulti("A", "D"))
 
     def check_fib_entries():
-        routes = {"-".join(fwA.fib.get(path_id).route) for path_id in (rp.path_id, rp.path_id + 1)}
+        routes = {"-".join(fwA.fib.get_path(path_id).route) for path_id in (rp.path_id, rp.path_id + 1)}
         assert routes == {"A-B-D", "A-C-D"}
 
     simulator.add_event(func_to_event(simulator.time(sec=2.0), check_fib_entries))

--- a/tests/fw/test_p_swap.py
+++ b/tests/fw/test_p_swap.py
@@ -35,7 +35,6 @@ from .fw_common import (
     build_tree_network,
     check_fw_counters,
     collect_cpacket_counts,
-    install_path,
     print_node_counters,
     provide_entanglements,
 )
@@ -46,7 +45,7 @@ def test_3_disabled():
     net, simulator = build_linear_network(3, fw={"p_swap": 1.0})
     fwA, fwB, fwC = (node.get_app(ProactiveForwarder) for node in net.nodes)
 
-    rp = install_path(net, RoutingPathStatic("ABC", swap=[0, 0, 0]))
+    net.add_request(rp := RoutingPathStatic("ABC", swap=[0, 0, 0]))
 
     def check_fib_entries():
         for fw in (fwA, fwB, fwC):
@@ -85,7 +84,7 @@ def test_3_ssq(ssq: MuxSchemeBufferSpace.SelectSwapQubit | None, addrs: list[int
     )
     fwA, fwB, fwC = (node.get_app(ProactiveForwarder) for node in net.nodes)
 
-    install_path(net, RoutingPathStatic("ABC"))
+    net.add_request(RoutingPathStatic("ABC"))
     provide_entanglements(
         (1.000, fwA, fwB),  # decohere at 1.090
         (1.001, fwA, fwB),  # decohere at 1.091
@@ -138,7 +137,7 @@ def test_3_decohere(swap_delay: float, n_consumed: int):
     net, simulator = build_linear_network(3, t_cohere=0.002, fw={"p_swap": 1.0, "swap_delay": swap_delay}, end_time=2)
     fwA, fwB, fwC = (node.get_app(ProactiveForwarder) for node in net.nodes)
 
-    rp = install_path(net, RoutingPathStatic("ABC"))
+    net.add_request(rp := RoutingPathStatic("ABC"))
     provide_entanglements(
         (1, fwA, fwB),
         (1, fwB, fwC),
@@ -186,7 +185,7 @@ def test_3_waittime(etg_sec: tuple[float, float], swap_delay: float, n_consumed:
     net, simulator = build_linear_network(3, t_cohere=0.006, fw={"p_swap": 1.0, "swap_delay": swap_delay}, end_time=1.010)
     fwA, fwB, fwC = (node.get_app(ProactiveForwarder) for node in net.nodes)
 
-    rp = install_path(net, RoutingPathStatic("ABC", swap_cutoff=[0.002, 0.004]))
+    net.add_request(rp := RoutingPathStatic("ABC", swap_cutoff=[0.002, 0.004]))
     provide_entanglements(
         (etg_sec[0], fwA, fwB),
         (etg_sec[1], fwB, fwC),
@@ -240,7 +239,7 @@ def test_4_sync(t_ext: float, expected: tuple[int, int, int, int]):
     net, simulator = build_linear_network(4, t_cohere=0.015000, fw={"p_swap": 1.0}, timing=timing, end_time=0.029999)
     fwA, fwB, fwC, fwD = (node.get_app(ProactiveForwarder) for node in net.nodes)
 
-    rp = install_path(net, RoutingPathStatic("ABCD", swap=[2, 0, 1, 2]))
+    net.add_request(rp := RoutingPathStatic("ABCD", swap=[2, 0, 1, 2]))
     provide_entanglements(
         ([0.001000] * 3, (fwA, fwB, fwC, fwD)),
     )
@@ -261,7 +260,7 @@ def test_4_asap(ps3: int, etg_ms: tuple[int, int, int]):
     fwA, fwB, fwC, fwD = (node.get_app(ProactiveForwarder) for node in net.nodes)
     fwC.swap.ps = ps3
 
-    rp = install_path(net, RoutingPathStatic("ABCD"))
+    net.add_request(rp := RoutingPathStatic("ABCD"))
     provide_entanglements(
         (etg_ms, (fwA, fwB, fwC, fwD)),
         transform_t=lambda ms: 1 + ms / 1000,
@@ -374,7 +373,7 @@ def test_4_delayed(
     timer = Timer("save_counters", start_time=1.018, end_time=1.088, step_time=0.010, trigger_func=save_counter)
     timer.install(simulator)
 
-    rp = install_path(net, RoutingPathStatic("ABCD"))
+    net.add_request(rp := RoutingPathStatic("ABCD"))
     provide_entanglements(
         (1.000, fwA, fwB),
         (1.000, fwC, fwD),
@@ -433,7 +432,7 @@ def test_4_decohere(swap_delay: float, n_consumed: int):
     net, simulator = build_linear_network(4, t_cohere=0.003, fw={"p_swap": 1.0, "swap_delay": swap_delay}, end_time=2)
     fwA, fwB, fwC, fwD = (node.get_app(ProactiveForwarder) for node in net.nodes)
 
-    rp = install_path(net, RoutingPathStatic("ABCD"))
+    net.add_request(rp := RoutingPathStatic("ABCD"))
     provide_entanglements(
         ([1.000] * 3, (fwA, fwB, fwC, fwD)),
     )
@@ -460,7 +459,7 @@ def test_5_asap(
     fwA, fwB, fwC, fwD, fwE = (node.get_app(ProactiveForwarder) for node in net.nodes)
     fwC.swap.ps = ps3
 
-    rp = install_path(net, RoutingPathStatic("ABCDE"))
+    net.add_request(rp := RoutingPathStatic("ABCDE"))
     provide_entanglements(
         (etg_ms, (fwA, fwB, fwC, fwD, fwE)),
         transform_t=lambda ms: 1 + ms / 1000,
@@ -492,7 +491,7 @@ def test_5_sequential(swap: Sequence[int], su_lower: Sequence[int], etg_ms: tupl
     net, simulator = build_linear_network(5, fw={"p_swap": 1.0})
     fwA, fwB, fwC, fwD, fwE = (node.get_app(ProactiveForwarder) for node in net.nodes)
 
-    rp = install_path(net, RoutingPathStatic("ABCDE", swap=swap))
+    net.add_request(rp := RoutingPathStatic("ABCDE", swap=swap))
     provide_entanglements(
         (etg_ms, (fwA, fwB, fwC, fwD, fwE)),
         transform_t=lambda ms: 1 + ms / 1000,
@@ -567,7 +566,7 @@ def test_5_decohere(
     fwA, fwB, fwC, fwD, fwE = (node.get_app(ProactiveForwarder) for node in net.nodes)
 
     swap_cutoff = None if cutoffD is None else [-1, -1, -1, -1, cutoffD, cutoffD]
-    rp = install_path(net, RoutingPathStatic("ABCDE", swap_cutoff=swap_cutoff))
+    net.add_request(rp := RoutingPathStatic("ABCDE", swap_cutoff=swap_cutoff))
     provide_entanglements(
         (etg_ms, (fwA, fwB, fwC, fwD, fwE)),
         transform_t=lambda ms: 1 + ms / 1000,
@@ -600,7 +599,7 @@ def test_rect2_multipath(has_etg: tuple[int, int, int, int], n_swapped: tuple[in
     net, simulator = build_grid_network(k_paths=2, fw={"p_swap": 1.0})
     fwA, fwB, fwC, fwD = (node.get_app(ProactiveForwarder) for node in net.nodes)
 
-    rp = install_path(net, RoutingPathMulti("A", "D"))
+    net.add_request(rp := RoutingPathMulti("A", "D"))
 
     def check_fib_entries():
         routes = {"-".join(fwA.fib.get(path_id).route) for path_id in (rp.path_id, rp.path_id + 1)}
@@ -659,8 +658,8 @@ def test_tree2_dynepr(t_edge_etg: float, selected_path: tuple[int, int], n_consu
     )
     fwA, fwB, fwC, fwD, fwE, fwF, fwG = (node.get_app(ProactiveForwarder) for node in net.nodes)
 
-    rp0 = install_path(net, RoutingPathStatic("DBACF"))
-    rp1 = install_path(net, RoutingPathStatic("EBACG"))
+    net.add_request(rp0 := RoutingPathStatic("DBACF"))
+    net.add_request(rp1 := RoutingPathStatic("EBACG"))
 
     provide_entanglements(
         (t_edge_etg, fwD, fwB),
@@ -740,8 +739,8 @@ def test_tree2_statistical(
     )
     fwA, fwB, fwC, fwD, fwE, fwF, fwG = (node.get_app(ProactiveForwarder) for node in net.nodes)
 
-    rp0 = install_path(net, RoutingPathStatic("DBACF"))
-    rp1 = install_path(net, RoutingPathStatic("EBACG"))
+    net.add_request(rp0 := RoutingPathStatic("DBACF"))
+    net.add_request(rp1 := RoutingPathStatic("EBACG"))
 
     edges = ((fwD, fwB), (fwE, fwB), (fwB, fwA), (fwA, fwC), (fwC, fwF), (fwC, fwG))
     provide_entanglements(
@@ -826,8 +825,8 @@ def test_tree3_statistical(
     )
     fws = {node.name: node.get_app(ProactiveForwarder) for node in net.nodes}
 
-    rp0 = install_path(net, RoutingPathStatic(path0))
-    rp1 = install_path(net, RoutingPathStatic(path1))
+    net.add_request(rp0 := RoutingPathStatic(path0))
+    net.add_request(rp1 := RoutingPathStatic(path1))
 
     def expand_etgs():
         for t, edges in enumerate(etgs.split(":")):

--- a/tests/fw/test_p_swap.py
+++ b/tests/fw/test_p_swap.py
@@ -30,8 +30,8 @@ from mqns.utils import unwrap, unwrap_cast
 
 from .fw_common import (
     QubitReleaseReset,
+    build_grid_network,
     build_linear_network,
-    build_rect_network,
     build_tree_network,
     check_fw_counters,
     collect_cpacket_counts,
@@ -381,7 +381,7 @@ def test_4_delayed(
         (1.010, fwB, fwC),
         fidelity=1,
     )
-    cpacket_cnt = collect_cpacket_counts(monkeypatch)
+    cpacket_cnt = collect_cpacket_counts(monkeypatch, dp=True)
     simulator.run()
     print_node_counters(net)
     QuantumMemory.check_leaks(net.nodes)
@@ -595,9 +595,9 @@ def test_5_decohere(
         ((1, 1, 1, 1), (1, 1), 2),
     ],
 )
-def test_rect_multipath(has_etg: tuple[int, int, int, int], n_swapped: tuple[int, int], n_consumed: int):
-    """Test swapping in rectangular topology with a multi-path request."""
-    net, simulator = build_rect_network(fw={"p_swap": 1.0})
+def test_rect2_multipath(has_etg: tuple[int, int, int, int], n_swapped: tuple[int, int], n_consumed: int):
+    """Test swapping in 2x2 rectangular topology with a multi-path request."""
+    net, simulator = build_grid_network(k_paths=2, fw={"p_swap": 1.0})
     fwA, fwB, fwC, fwD = (node.get_app(ProactiveForwarder) for node in net.nodes)
 
     rp = install_path(net, RoutingPathMulti("A", "D"))

--- a/tests/fw/test_r_swap.py
+++ b/tests/fw/test_r_swap.py
@@ -19,6 +19,7 @@ from .fw_common import (
     build_linear_network,
     build_tree_network,
     check_fw_counters,
+    collect_cpacket_counts,
     print_node_counters,
     provide_entanglements,
 )
@@ -139,20 +140,26 @@ def test_tree2_two():
     ("req_active", "etgAB", "etgBC", "cnt"),
     [
         # Request is active in both slots, EPRs arrive in first slot, request satisfied.
-        ((0, 0.020), [0.001], [0.002], (3, 1)),
+        ((0, 0.020), [0.001], [0.002], (3, 1, 1)),
         # Request is active in both slots, EPRs arrive in second slot, request satisfied.
-        ((0, 0.020), [0.011], [0.012], (3, 1)),
+        ((0, 0.020), [0.011], [0.012], (3, 1, 1)),
         # Request is active in both slots, EPRs arrive in both slots, request satisfied twice.
-        ((0, 0.020), [0.001, 0.011], [0.002, 0.012], (6, 2)),
+        ((0, 0.020), [0.001, 0.011], [0.002, 0.012], (6, 2, 2)),
         # Request is active in both slots, EPRs arrive in separate slots, request unsatisfied.
-        ((0, 0.020), [0.001], [0.012], (4, 0)),
+        ((0, 0.020), [0.001], [0.012], (4, 0, 0)),
         # Request is active in first slot, EPRs arrive in second slot, request unsatisfied.
-        ((0, 0.010), [0.011], [0.012], (3, 0)),
+        ((0, 0.010), [0.011], [0.012], (3, 0, 0)),
         # Request is active in first slot, EPRs arrive twice in first slot, request satisfied twice.
-        ((0, 0.010), [0.001, 0.003], [0.002, 0.004], (3, 2)),
+        ((0, 0.010), [0.001, 0.003], [0.002, 0.004], (3, 2, 1)),
     ],
 )
-def test_3_minimal(req_active: tuple[float, float], etgAB: list[float], etgBC: list[float], cnt: tuple[int, int]):
+def test_3_minimal(
+    monkeypatch: pytest.MonkeyPatch,
+    req_active: tuple[float, float],
+    etgAB: list[float],
+    etgBC: list[float],
+    cnt: tuple[int, int, int],
+):
     """Test 3-node minimal swap, two time slots."""
     net, simulator = build_linear_network(
         3,
@@ -170,13 +177,18 @@ def test_3_minimal(req_active: tuple[float, float], etgAB: list[float], etgBC: l
         *((t, fwA, fwB) for t in etgAB),
         *((t, fwB, fwC) for t in etgBC),
     )
+    cpacket_cnt = collect_cpacket_counts(monkeypatch, cp=True, cmd=True)
     simulator.run()
     print(ctrl.cnt)
     print_node_counters(net)
+    print("cpacket_cnt", cpacket_cnt)
 
-    assert (ctrl.cnt.n_ls, ctrl.cnt.n_satisfy) == cnt
+    assert ctrl.cnt.n_ls == cnt[0]
+    assert ctrl.cnt.n_satisfy == cnt[1]
     check_fw_counters(
         net,
         n_swapped=(0, cnt[1], 0),
     )
     assert RequestCounters.of(net, 1, "A-C").n_consumed == cnt[1]
+    assert cpacket_cnt["*-ctrl:LS"] == cnt[0]
+    assert cpacket_cnt["ctrl-*:INSTALL_PATH"] == cnt[1] * 3

--- a/tests/fw/test_r_swap.py
+++ b/tests/fw/test_r_swap.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 
 import pytest
 
-from mqns.entity.cchannel import ClassicCommandDispatcherMixin, ClassicPacket, classic_cmd_handler
+from mqns.entity.cchannel import ClassicPacket, classic_cmd_handler
 from mqns.network.fw import RoutingController, RoutingPathStatic
 from mqns.network.network import Request, TimingModeSync, TimingPhase, sync_phase_handler
 from mqns.network.protocol.consumer import RequestCounters
@@ -25,7 +25,7 @@ from .fw_common import (
 )
 
 
-class ManualController(ClassicCommandDispatcherMixin, RoutingController):
+class ManualController(RoutingController):
     def __init__(self):
         super().__init__(mv_auto="max")
 

--- a/tests/fw/test_r_swap.py
+++ b/tests/fw/test_r_swap.py
@@ -98,7 +98,7 @@ def test_tree2_two():
         assert len(ctrl.ls_pkts) == 7
         assert len(ctrl.ls_entries) == 16
 
-        qubits_by_channel = defaultdict[str, list[str]](lambda: [])
+        qubits_by_channel = defaultdict[str, list[str]](list)
         for entry in ctrl.ls_entries:
             qubits_by_channel[f"{entry['node']}{entry['neighbor']}"].append(entry["qubit"])
 

--- a/tests/fw/test_r_swap.py
+++ b/tests/fw/test_r_swap.py
@@ -191,4 +191,4 @@ def test_3_minimal(
     )
     assert RequestCounters.of(net, 1, "A-C").n_consumed == cnt[1]
     assert cpacket_cnt["*-ctrl:LS"] == cnt[0]
-    assert cpacket_cnt["ctrl-*:INSTALL_PATH"] == cnt[1] * 3
+    assert cpacket_cnt["ctrl-*:PATH_INSERT"] == cnt[2] * 3

--- a/tests/fw/test_simple.py
+++ b/tests/fw/test_simple.py
@@ -5,7 +5,7 @@ Test suite for simple data structure objects in forwarding.
 import pytest
 
 from mqns.network.fw import parse_swap_sequence
-from mqns.network.fw.fib import FibEntry
+from mqns.network.fw.fib import FibPath
 from mqns.network.fw.message import validate_path_instructions
 
 
@@ -110,8 +110,7 @@ def test_path_validation():
 def test_fib_swap_group(purif: str | None, own: str, expected: tuple[str, str, str, str] | None):
     nodes = "ABCDEFGHIJ"
     ranks = "3001012003"
-    entry = FibEntry(
-        req_id=0,
+    entry = FibPath(
         path_id=0,
         route=nodes,
         own_idx=nodes.index(own),

--- a/tests/fw/test_simple.py
+++ b/tests/fw/test_simple.py
@@ -48,41 +48,41 @@ def test_path_validation():
     mv3 = [(1, 1)] * 2
 
     with pytest.raises(ValueError, match="route is empty"):
-        validate_path_instructions({"req_id": 0, "route": [], "swap": [], "swap_cutoff": [], "purif": {}})
+        validate_path_instructions({"path_id": 0, "route": [], "swap": [], "swap_cutoff": [], "purif": {}})
 
     with pytest.raises(ValueError, match="swapping order"):
         validate_path_instructions(
-            {"req_id": 0, "route": ["A", "B", "C", "D", "E"], "swap": swap3, "swap_cutoff": scut3, "purif": {}}
+            {"path_id": 0, "route": ["A", "B", "C", "D", "E"], "swap": swap3, "swap_cutoff": scut3, "purif": {}}
         )
 
     with pytest.raises(ValueError, match="swap_cutoff"):
         validate_path_instructions(
-            {"req_id": 0, "route": route3, "swap": swap3, "swap_cutoff": [2000, 1000, 1000], "purif": {}}
+            {"path_id": 0, "route": route3, "swap": swap3, "swap_cutoff": [2000, 1000, 1000], "purif": {}}
         )
 
     with pytest.raises(ValueError, match="multiplexing vector"):
         validate_path_instructions(
-            {"req_id": 0, "route": route3, "swap": swap3, "swap_cutoff": scut3, "m_v": [(1, 1)] * 3, "purif": {}}
+            {"path_id": 0, "route": route3, "swap": swap3, "swap_cutoff": scut3, "m_v": [(1, 1)] * 3, "purif": {}}
         )
 
     with pytest.raises(ValueError, match="purif segment"):
         validate_path_instructions(
-            {"req_id": 0, "route": route3, "swap": swap3, "swap_cutoff": scut3, "m_v": mv3, "purif": {"P-Q": 1}}
+            {"path_id": 0, "route": route3, "swap": swap3, "swap_cutoff": scut3, "m_v": mv3, "purif": {"P-Q": 1}}
         )
 
     with pytest.raises(ValueError, match="purif segment"):
         validate_path_instructions(
-            {"req_id": 0, "route": route3, "swap": swap3, "swap_cutoff": scut3, "m_v": mv3, "purif": {"A-B-C": 1}}
+            {"path_id": 0, "route": route3, "swap": swap3, "swap_cutoff": scut3, "m_v": mv3, "purif": {"A-B-C": 1}}
         )
 
     with pytest.raises(ValueError, match="purif segment"):
         validate_path_instructions(
-            {"req_id": 0, "route": route3, "swap": swap3, "swap_cutoff": scut3, "m_v": mv3, "purif": {"B-B": 1}}
+            {"path_id": 0, "route": route3, "swap": swap3, "swap_cutoff": scut3, "m_v": mv3, "purif": {"B-B": 1}}
         )
 
     with pytest.raises(ValueError, match="purif segment"):
         validate_path_instructions(
-            {"req_id": 0, "route": route3, "swap": swap3, "swap_cutoff": scut3, "m_v": mv3, "purif": {"C-A": 1}}
+            {"path_id": 0, "route": route3, "swap": swap3, "swap_cutoff": scut3, "m_v": mv3, "purif": {"C-A": 1}}
         )
 
 

--- a/tests/network/test_network.py
+++ b/tests/network/test_network.py
@@ -9,6 +9,7 @@ from mqns.network.network import (
     MatrixTrafficGenerator,
     QuantumNetwork,
     RequestActiveEvent,
+    RequestInactiveEvent,
     TimingModeSync,
     TimingPhase,
     TrafficMatrixMapping,
@@ -102,12 +103,15 @@ class RequestCheckApp(Application[Controller]):
     def handle_request_active(self, event: RequestActiveEvent) -> None:
         req = event.req
         assert (req.src, req.dst) == ("A", "C")
-        assert req.is_active(event.t) is event.enter
+        assert req.is_active(event.t) is True
+        self.enters.append(len(self.net.requests))
 
-        if event.enter:
-            self.enters.append(len(self.net.requests))
-        else:
-            self.exits += 1
+    @event_handler
+    def handle_request_inactive(self, event: RequestInactiveEvent) -> None:
+        req = event.req
+        assert (req.src, req.dst) == ("A", "C")
+        assert req.is_active(event.t) is False
+        self.exits += 1
 
 
 def test_mtg_lazy():

--- a/tests/network/test_network.py
+++ b/tests/network/test_network.py
@@ -1,4 +1,5 @@
 import itertools
+from typing import cast
 
 import numpy as np
 import pytest
@@ -16,7 +17,7 @@ from mqns.network.network import (
     sync_phase_handler,
 )
 from mqns.network.topology import BasicTopology
-from mqns.simulator import Simulator, event_handler, func_to_event
+from mqns.simulator import Simulator, Time, event_handler, func_to_event
 
 
 class SyncCheckApp(Application[Node]):
@@ -73,6 +74,10 @@ def test_timing_mode_sync():
     ],
 )
 def test_mtg_eager(tm: TrafficMatrixInput | TrafficMatrixMapping, src_dst: NodePair):
+    """
+    Test MatrixTrafficGenerator with sched=eager.
+    Also validate each traffic matrix input format; the inputs are one-hot.
+    """
     topo = BasicTopology(3, nodes_naming="A")
     net = QuantumNetwork(topo)
 
@@ -87,7 +92,7 @@ def test_mtg_eager(tm: TrafficMatrixInput | TrafficMatrixMapping, src_dst: NodeP
         assert (req.src, req.dst) == src_dst
 
     for req0, req1 in itertools.pairwise(net.requests):
-        assert req0.active_since <= req1.active_until
+        assert cast(Time, req0.active_since) <= cast(Time, req1.active_until)
 
 
 class RequestCheckApp(Application[Controller]):
@@ -96,13 +101,16 @@ class RequestCheckApp(Application[Controller]):
     def __init__(self):
         super().__init__()
         self.enters: list[int] = []
-        """Length of ``net.requests`` upon entering each request."""
+        """Length of ``net.requests`` upon each ``RequestActiveEvent``."""
         self.exits = 0
+        """Count of ``RequestInactiveEvent``."""
 
     @event_handler
     def handle_request_active(self, event: RequestActiveEvent) -> None:
         req = event.req
         assert (req.src, req.dst) == ("A", "C")
+        assert (cast(Time, req.active_until) - cast(Time, req.active_since)).sec == pytest.approx(0.1, abs=1e-6)
+        assert req.epr_count == 2
         assert req.is_active(event.t) is True
         self.enters.append(len(self.net.requests))
 
@@ -115,12 +123,23 @@ class RequestCheckApp(Application[Controller]):
 
 
 def test_mtg_lazy():
+    """
+    Test MatrixTrafficGenerator with sched=lazy.
+    Also validate request attributes.
+    """
     topo = BasicTopology(3, nodes_naming="A")
     topo.controller = Controller("ctrl", apps=[app := RequestCheckApp()])
     net = QuantumNetwork(topo)
     app.net = net
 
-    mtg = MatrixTrafficGenerator(net, {"A-C": 1}, rate=10, sched="lazy")
+    mtg = MatrixTrafficGenerator(
+        net,
+        {"A-C": 1},
+        rate=10,
+        sched="lazy",
+        duration=0.1,
+        epr_count=2,
+    )
     s = Simulator(100, np.inf, need_synchronized=False, install_to=(net, mtg))
     s.add_event(func_to_event(s.time(sec=200), s.stop))
     s.run()

--- a/tests/protocol/test_link_layer.py
+++ b/tests/protocol/test_link_layer.py
@@ -22,7 +22,7 @@ class NetworkLayer(Application[QNode]):
         """If non-empty, ``QubitReleasedEvent`` would be emitted after specified duration for the next entanglement."""
         self.entangle: list[tuple[float, float]] = []
         """Entanglement events, each entry contains entanglement time and EPR creation time."""
-        self.path_entangle = defaultdict[int | None, list[float]](lambda: [])
+        self.path_entangle = defaultdict[int | None, list[float]](list)
         """Entanglement times per path_id."""
         self.decohere: list[float] = []
         """Decoherence events, each entry is event time."""

--- a/tests/protocol/test_link_layer.py
+++ b/tests/protocol/test_link_layer.py
@@ -127,10 +127,10 @@ def test_basic(epr_type: type[Entanglement]):
         # t=8.7, entanglement established
         # t=8.5 is assumed time of entanglement creation
         assert nl.entangle[2] == pytest.approx((8.7, 8.5), abs=1e-3)
-        # t=8.8, path is uninstalled
+        # t=8.8, path is deleted
         # t=12.6, qubits decohered 4.1 seconds since entanglement creation
         assert nl.decohere[1] == pytest.approx(12.6, abs=1e-3)
-        # no more entanglements because the path has been uninstalled
+        # no more entanglements because the path has been deleted
 
     ll_cnt_agg = LinkLayerCounters.aggregate(net.nodes)
     print("ll_cnt_agg", ll_cnt_agg)
@@ -138,7 +138,7 @@ def test_basic(epr_type: type[Entanglement]):
     assert ll_cnt_agg.n_attempts == 3
     # n_decoh is only incremented on the primary node.
     # Although there are two decoherence events in the simulation, l1.n_decoh is incremented only at t=8.3.
-    # For the t=12.6 event, the path is uninstalled, so that l1 cannot recognize itself as primary.
+    # For the t=12.6 event, the path is deleted, so that l1 cannot recognize itself as primary.
     assert ll_cnt_agg.n_decoh == 1
     assert ll_cnt_agg.decoh_ratio == pytest.approx(1 / 3, abs=1e-6)
 
@@ -192,28 +192,28 @@ def test_multiple_paths():
 
 
 @pytest.mark.parametrize(
-    ("uninstall_t", "qubits_state", "n_entangle"),
+    ("t_delete", "qubits_state", "n_entangle"),
     [
-        # don't uninstall, only check timeline states (expected qubits_state are ignored)
+        # don't delete, only check timeline states (expected qubits_state are ignored)
         (9.9, (QubitState.CONSUME, QubitState.CONSUME), (3, 3)),
-        # uninstall when RESERVE_REQ is in-flight
+        # path deleted when RESERVE_REQ is in-flight
         (0.2, (QubitState.RAW, QubitState.RAW), (0, 0)),
-        # uninstall when RESERVE_RES is in-flight
+        # path deleted when RESERVE_RES is in-flight
         (0.5, (QubitState.RAW, QubitState.RAW), (0, 0)),
-        # uninstall when LinkArch is waiting for t_notify_a
+        # path deleted when LinkArch is waiting for t_notify_a
         (0.8, (QubitState.RAW, QubitState.RAW), (0, 0)),
-        # uninstall when LinkArch is waiting for t_notify_b
+        # path deleted when LinkArch is waiting for t_notify_b
         (1.1, (QubitState.ENTANGLED1, QubitState.RAW), (1, 0)),
-        # uninstall when both qubits are owned by NetworkLayer
+        # path deleted when both qubits are owned by NetworkLayer
         (1.5, (QubitState.ENTANGLED1, QubitState.ENTANGLED1), (1, 1)),
-        # uninstall when one qubit is owned by NetworkLayer
+        # path deleted when one qubit is owned by NetworkLayer
         (4.3, (QubitState.RAW, QubitState.ENTANGLED1), (2, 2)),
         (6.1, (QubitState.ENTANGLED1, QubitState.RAW), (3, 3)),
     ],
 )
-def test_uninstall(uninstall_t: float, qubits_state: tuple[QubitState, QubitState], n_entangle: tuple[int, int]):
+def test_path_delete(t_delete: float, qubits_state: tuple[QubitState, QubitState], n_entangle: tuple[int, int]):
     """
-    Verify proper cleanups when the path is uninstalled in various steps.
+    Verify PATH_DELETE cleanup when deletion occurs in various steps.
     """
     topo = LinearTopology(
         nodes_number=2,
@@ -229,7 +229,7 @@ def test_uninstall(uninstall_t: float, qubits_state: tuple[QubitState, QubitStat
     simulator = Simulator(0.0, 6.5, install_to=(log, net))
 
     nl1, nl2 = (node.get_app(NetworkLayer) for node in net.nodes)
-    activate_path(0.1, uninstall_t, nl1, nl2, None)
+    activate_path(0.1, t_delete, nl1, nl2, None)
 
     def assert_states(expected: tuple[QubitState, QubitState]) -> None:
         mq1 = nl1.memory.read(0, must=True)
@@ -238,13 +238,13 @@ def test_uninstall(uninstall_t: float, qubits_state: tuple[QubitState, QubitStat
         assert actual == expected
 
     def check_states(t: float, expected0: QubitState, expected1: QubitState) -> None:
-        if t > uninstall_t:
+        if t > t_delete:
             return
         event = func_to_event(simulator.time(sec=t), assert_states, (expected0, expected1))
         event.priority = 10000
         simulator.add_event(event)
 
-    check_states(uninstall_t, *qubits_state)
+    check_states(t_delete, *qubits_state)
 
     # t=0.1, path is installed with n1 as primary and n2 as secondary
     # t=0.1, n1 sets qubit state to ACTIVE, sends RESERVE_REQ
@@ -369,8 +369,8 @@ def test_timing_mode_sync():
         # τ=0.1 for the channel between n2 and n3.
         # Entanglement (including reservation) requires 4τ i.e. 0.4 seconds.
         # No entanglement occurs in the first EXTERNAL phase window, because reservations are only initiated
-        # at the start of each EXTERNAL phase window, not when ManageActiveChannels arrives.
-        # The uninstall_path stop event takes effect for the EXTERNAL phase window starting at t=6.0.
+        # at the start of each EXTERNAL phase window, not when PathActivateEvent arrives.
+        # The PathDeactivateEvent takes effect for the EXTERNAL phase window starting at t=6.0.
         assert [t_notify for t_notify, _ in nl.entangle] == pytest.approx([1.4, 2.4, 3.4, 4.4, 5.4], abs=1e-3)
         # All qubits are cleared at the start of each EXTERNAL phase, before memory decoherence occurs.
         # Decoherence events are not emitted for cleared qubits.

--- a/tests/simulator/test_simulator.py
+++ b/tests/simulator/test_simulator.py
@@ -18,7 +18,7 @@ def _():
 
 class SimpleEvent(Event):
     seq = 0
-    invokes = defaultdict[str, list[int]](lambda: [])
+    invokes = defaultdict[str, list[int]](list)
 
     @override
     def invoke(self) -> None:


### PR DESCRIPTION
This PR introduces `Request.epr_count` attribute that specifies the desired quantity of entangled pairs, implemented for Proactive-Centralized mode only.
If this attribute is specified as a finite positive integer, the controller instructs end-node forwarders to count how many entangled pairs have been delivered to the application for consumption.
Once the count has reached the desired quantity, the forwarder ceases to deliver additional entangled pairs to the application, and sends a report to the controller.
Once the controller hears from both end-node forwarders, it uninstalls the path(s) associated with the request.

FIB has been restructured: it now tracks both **FIB request entry** (for per-request information, formerly `FibRequestGroup`) and **FIB path entry** (for per-path information, formerly `FibEntry`).
If there would be multiple paths associated with a request, the controller must gather the instructions for all paths targeting each forwarder, and send them to the forwarder together in a single PATH_INSERT command.
Upon receiving this command, the forwarder creates a FIB request entry along with one or more FIB path entries.
The `epr_count` setting is tracked at FIB request entry level.

Minor changes include:

* GitHub Actions are upgraded; Ruff invocation is through the official `ruff-action`.
* `getattr` usage is reduced for better execution speed.
* `build_rect_network` test helper is transformed to `build_grid_network` to support other shapes.
* `Request()` constructor and `Network.add_request()` method can directly accept `RoutingPath` instance, which allows more concise syntax.

refs #124