### PR TITLE
examples: MatrixTrafficGenerator demo

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,0 +1,9 @@
+!mqns_ref.pdf
+!vora_evaluation.voraswap.json
+!scalability_randomtopo/params-full.toml
+!scalability_randomtopo/params-short.toml
+*.csv
+*.json
+*.pdf
+*.png
+*.toml

--- a/examples/3_nodes_purif.py
+++ b/examples/3_nodes_purif.py
@@ -5,7 +5,7 @@ from tap import Tap
 from mqns.network.builder import CTRL_DELAY, NetworkBuilder
 from mqns.network.protocol.consumer import RequestCounters
 from mqns.simulator import Simulator
-from mqns.utils import log, rng
+from mqns.utils import log, rng, seed_seq_env
 
 
 # Command line arguments
@@ -18,13 +18,11 @@ args = Args().parse_args()
 
 log.set_default_level("DEBUG")
 
-SEED_BASE = 100
-
 # parameters
 sim_duration = 5
 
 
-def run_simulation(t_cohere: float, seed: int):
+def run_simulation(seed: int, t_cohere: float):
     rng.reseed(seed)
 
     net = (
@@ -58,10 +56,9 @@ t_cohere_values = [1]
 for t_cohere in t_cohere_values:
     rates = []
     fids = []
-    for i in range(args.runs):
-        print(f"T_cohere={t_cohere:.4f}, run {i + 1}")
-        seed = SEED_BASE + i
-        rate, f = run_simulation(t_cohere, seed)
+    for seed in seed_seq_env(args.runs, 100):
+        print(f"T_cohere={t_cohere:.4f}, seed={seed}")
+        rate, f = run_simulation(seed, t_cohere)
         rates.append(rate)
         fids.append(f)
 

--- a/examples/3_nodes_thruput.py
+++ b/examples/3_nodes_thruput.py
@@ -35,7 +35,7 @@ from mqns.network.builder import CTRL_DELAY, ChannelParam, EprTypeLiteral, LinkA
 from mqns.network.protocol.consumer import RequestCounters
 from mqns.network.protocol.link_layer import LinkLayerCounters
 from mqns.simulator import Simulator
-from mqns.utils import log, rng
+from mqns.utils import log, rng, seed_seq_env
 
 from examples_common.plotting import plt, plt_save
 
@@ -95,9 +95,6 @@ class Args(Tap):
         )
 
 
-SEED_BASE = 100
-
-
 class Stats(TypedDict):
     t_cohere: float
     throughput_eps: float
@@ -146,12 +143,7 @@ def run_simulation(seed: int, args: Args, t_cohere: float) -> Stats:
 
 
 def run_row(args: Args, t_cohere: float) -> list[Stats]:
-    results: list[Stats] = []
-    for i in range(args.runs):
-        print(f"T_cohere={t_cohere:.4f}, run {i + 1}")
-        stats = run_simulation(SEED_BASE + i, args, t_cohere)
-        results.append(stats)
-    return results
+    return [run_simulation(seed, args, t_cohere) for seed in seed_seq_env(args.runs, 100)]
 
 
 def plot(df: pd.DataFrame, *, save_plt: str):

--- a/examples/3_nodes_wait.py
+++ b/examples/3_nodes_wait.py
@@ -51,7 +51,7 @@ from mqns.network.fw import CutoffSchemeWaitTime
 from mqns.network.proactive import ProactiveForwarder
 from mqns.network.protocol.consumer import RequestCounters
 from mqns.simulator import Simulator
-from mqns.utils import json_default, log, rng, unwrap
+from mqns.utils import json_default, log, rng, seed_seq_env, unwrap
 
 from examples_common.plotting import Axes, Axes1D, SubFigure, SubFigure1D, plt, plt_save
 
@@ -84,7 +84,6 @@ class Args(Tap):
 
 
 SIMULATOR_ACCURACY = 1000000
-SEED_BASE = 100
 
 
 def run_simulation(seed: int, args: Args, t_cohere: float, t_wait: float):
@@ -163,9 +162,9 @@ class Details(TypedDict):
 
 def run_row(args: Args, t_cohere: float, t_wait: float) -> tuple[Stats, Details]:
     columns: list[list[float]] = [[] for _ in range(4)]
-    for i in range(args.runs):
-        print(f"T_cohere={t_cohere:.4f}, T_wait={t_wait:.4f}, run {i + 1}")
-        results = run_simulation(SEED_BASE + i, args, t_cohere, t_wait)
+    for seed in seed_seq_env(args.runs, 100):
+        print(f"T_cohere={t_cohere:.4f}, T_wait={t_wait:.4f}, seed={seed}")
+        results = run_simulation(seed, args, t_cohere, t_wait)
         for col, res in zip(columns, results, strict=True):
             col.extend(res)
 

--- a/examples/asymmetric_channel_3_nodes.py
+++ b/examples/asymmetric_channel_3_nodes.py
@@ -23,7 +23,7 @@ from mqns.entity.qchannel import LinkArch, LinkArchDimBk, LinkArchSim, LinkArchS
 from mqns.network.builder import CTRL_DELAY, ChannelParam, NetworkBuilder
 from mqns.network.protocol.consumer import RequestCounters
 from mqns.simulator import Simulator
-from mqns.utils import log, rng, unwrap
+from mqns.utils import log, rng, seed_seq_env, unwrap
 
 from examples_common.plotting import Axes2D, mpl, plt, plt_save
 
@@ -31,7 +31,6 @@ log.set_default_level("CRITICAL")
 
 # Constants
 sim_duration = 0.5
-SEED_BASE = 42
 ch_lengths: list[float] = [30, 30]
 
 # Experiment parameters
@@ -45,12 +44,7 @@ channel_configs: dict[str, list[LinkArch]] = {
 }
 
 
-def run_simulation(
-    ch_capacities: list[tuple[int, int]],
-    link_architectures: list[LinkArch],
-    t_cohere: float,
-    seed: int,
-):
+def run_simulation(seed: int, ch_capacities: list[tuple[int, int]], link_architectures: list[LinkArch], t_cohere: float):
     rng.reseed(seed)
 
     net = (
@@ -85,14 +79,9 @@ def run_row(
 
     rates: list[float] = []
     fids: list[float] = []
-    for i in range(n_runs):
-        print(f"{arch_label}, T_cohere={t_cohere:.3f}, Mem alloc={[left, right]}, run {i + 1}")
-        rate, fidelity = run_simulation(
-            ch_capacities=[(total_qubits, left), (right, total_qubits)],
-            link_architectures=link_archs,
-            t_cohere=t_cohere,
-            seed=SEED_BASE + i,
-        )
+    for seed in seed_seq_env(n_runs, 42):
+        print(f"{arch_label}, T_cohere={t_cohere:.3f}, Mem alloc={[left, right]}, seed={seed}")
+        rate, fidelity = run_simulation(seed, [(total_qubits, left), (right, total_qubits)], link_archs, t_cohere)
         rates.append(rate)
         fids.append(fidelity)
     return t_cohere, arch_label, rates, fids

--- a/examples/asymmetric_channel_memory.py
+++ b/examples/asymmetric_channel_memory.py
@@ -23,16 +23,13 @@ from mqns.network.builder import CTRL_DELAY, NetworkBuilder
 from mqns.network.protocol.consumer import RequestCounters
 from mqns.network.protocol.link_layer import LinkLayerCounters
 from mqns.simulator import Simulator
-from mqns.utils import log, rng
+from mqns.utils import log, rng, seed_env
 
 log.set_default_level("DEBUG")
 
 
 class Args(Tap):
     sim_duration: float = 3  # simulation duration in seconds
-
-
-SEED_BASE = 100
 
 
 def run_simulation(seed: int, args: Args):
@@ -62,6 +59,6 @@ def run_simulation(seed: int, args: Args):
 if __name__ == "__main__":
     args = Args().parse_args()
 
-    e2e_rate, decoh_ratio = run_simulation(SEED_BASE, args)
+    e2e_rate, decoh_ratio = run_simulation(seed_env(100), args)
     print(f"E2E etg rate: {e2e_rate}")
     print(f"Expired memories: {decoh_ratio}")

--- a/examples/examples_common/topo_multiplexing.py
+++ b/examples/examples_common/topo_multiplexing.py
@@ -1,0 +1,42 @@
+from mqns.network.builder import NetworkBuilder
+
+END_NODES = ("A", "B", "C", "D", "G", "H", "I", "K", "L", "M")
+"""Nodes with degree=1."""
+
+TX_QUBITS = 50
+RX_QUBITS = 32
+
+
+def define_topo(b: NetworkBuilder) -> None:
+    """
+    Build a 13-node tree/star topology characterized by two highly contested central backbone routing links.
+
+    .. figure:: /_static/examples/multiplexing.svg
+        :alt: topology diagram
+        :align: center
+        :width: 100%
+    """
+    b.topo(
+        channels=[
+            # left spokes -> E
+            (("A", "E"), 30, (TX_QUBITS, RX_QUBITS)),
+            (("B", "E"), 30, (TX_QUBITS, RX_QUBITS)),
+            (("C", "E"), 30, (TX_QUBITS, RX_QUBITS)),
+            (("D", "E"), 30, (TX_QUBITS, RX_QUBITS)),
+            # middle trunks
+            (("E", "F"), 30, (RX_QUBITS, TX_QUBITS)),
+            (("F", "J"), 30, (TX_QUBITS, RX_QUBITS)),
+            # right spokes from J
+            (("J", "K"), 30, (TX_QUBITS, RX_QUBITS)),
+            (("J", "L"), 30, (TX_QUBITS, RX_QUBITS)),
+            (("J", "M"), 30, (TX_QUBITS, RX_QUBITS)),
+            # bottom spokes from F
+            (("G", "F"), 30, (RX_QUBITS, TX_QUBITS)),
+            (("F", "H"), 30, (TX_QUBITS, RX_QUBITS)),
+            (("F", "I"), 30, (TX_QUBITS, RX_QUBITS)),
+        ],
+        fiber_alpha=0.17,
+        eta_d=0.5,
+        eta_s=0.8,
+        t_cohere=0.1,
+    )

--- a/examples/extctrl/extctrl_dp.py
+++ b/examples/extctrl/extctrl_dp.py
@@ -9,7 +9,7 @@ from mqns.network.fw import Forwarder, ForwarderCounters
 from mqns.network.protocol.classicbridge import ClassicBridge
 from mqns.network.protocol.consumer import RequestCounters
 from mqns.simulator import Simulator
-from mqns.utils import log, rng
+from mqns.utils import log, rng, seed_env
 
 log.set_default_level("INFO")
 
@@ -17,7 +17,6 @@ log.set_default_level("INFO")
 class Args(Tap):
     nats_prefix: str = ClassicBridge.DEFAULT_NATS_PREFIX  # prefix of NATS subjects
     sim_accuracy: int = 1_000_000  # simulation accuracy in time slots per second
-    seed: int | None = None  # random seed
     mode: Literal["PCA", "RCS"] = "PCA"
     sync_timing: list[float]
     L: tuple[float, float] = (50, 10)  # qchannel lengths (km)
@@ -49,7 +48,7 @@ class Stats(NamedTuple):
 
 
 def run_simulation(args: Args) -> Stats:
-    rng.reseed(args.seed)
+    rng.reseed(seed_env())
 
     b = NetworkBuilder(
         epr_type=args.epr_type,

--- a/examples/linear_attempts.py
+++ b/examples/linear_attempts.py
@@ -36,7 +36,7 @@ from tap import Tap
 from mqns.network.builder import CTRL_DELAY, LINK_ARCH_MAP, LinkArchLiteral, NetworkBuilder
 from mqns.network.protocol.link_layer import LinkLayer
 from mqns.simulator import Simulator
-from mqns.utils import log, rng
+from mqns.utils import log, rng, seed_seq_env
 
 from examples_common.plotting import Axes1D, plt, plt_save
 
@@ -57,9 +57,6 @@ class Args(Tap):
     @override
     def configure(self) -> None:
         self.add_argument("--link_arch", type=str, nargs="+", choices=LINK_ARCH_MAP.keys())
-
-
-SEED_BASE = 100
 
 
 class ChannelResult(TypedDict):
@@ -117,11 +114,7 @@ def run_row(args: Args, M: int, link_arch: LinkArchLiteral) -> list[list[Channel
     Run N simulations.
     Return details from single simulations.
     """
-    row: list[list[ChannelResult]] = []
-    for i in range(args.runs):
-        res = run_simulation(SEED_BASE + i, args.sim_duration, args.L, M, link_arch)
-        row.append(res)
-    return row
+    return [run_simulation(seed, args.sim_duration, args.L, M, link_arch) for seed in seed_seq_env(args.runs, 100)]
 
 
 def gather_channel_stats(row: list[list[ChannelResult]], i: int) -> dict:

--- a/examples/mtg.py
+++ b/examples/mtg.py
@@ -1,0 +1,172 @@
+"""
+Demonstrate ``MatrixTrafficGenerator`` usage.
+
+1. Generate an empty traffic definition file:
+
+    python mtg.py --tm_gen >mtg.tm.toml
+
+2. Modify the traffic definition file.
+   At least one traffic flow must have non-zero probability.
+
+3. Run the simulation with traffic definition file.
+
+    python mtg.py --tm mtg.tm.toml --csv mtg.csv --sim_duration 10 --rate 10
+
+CSV output includes per-request statistics:
+
+* Request attributes: end-nodes, active period, requested EPR quantity.
+* Consumed EPR quantity, average fidelity.
+* Latency since request arrival (start of active period) and first/last EPR delivery.
+  * This includes ``CTRL_DELAY`` in Proactive-Centralized mode.
+"""
+
+import csv
+import itertools
+import sys
+import tomllib
+from typing import Literal, TypedDict, cast, override
+
+import tomli_w
+from tap import Tap
+
+from mqns.network.builder import NetworkBuilder
+from mqns.network.fw import MuxSchemeBufferSpace, MuxSchemeStatistical
+from mqns.network.network import MatrixTrafficGenerator, QuantumNetwork, Request, TrafficMatrixMapping
+from mqns.network.protocol.consumer import RequestCounters
+from mqns.simulator import Simulator, Time
+from mqns.utils import log, rng, seed_env
+
+from examples_common.topo_multiplexing import END_NODES, define_topo
+
+log.set_default_level("CRITICAL")
+
+
+class Args(Tap):
+    tm_gen: bool = False  # write empty traffic definition to stdout
+    tm: str = ""  # network traffic definition file
+    sim_duration: float = 1.0  # simulation duration in seconds
+    mux: Literal["B", "S"] = "B"  # multiplexing scheme
+    rate: float = 1.0  # request arrival rate (req/s)
+    csv: str = ""  # save results as CSV file
+
+    @override
+    def process_args(self) -> None:
+        if not self.tm_gen and not self.tm:
+            raise ValueError("--tm is required if --tm_gen is absent")
+
+
+class NetTrafficDef(TypedDict):
+    matrix: dict[str, float]
+    """
+    Traffic matrix.
+    Key: source and destination node, delimited by hyphen.
+    Value: relative weight.
+    """
+    duration: float
+    """
+    Active duration per request, in seconds.
+    """
+    epr_count: int
+    """
+    Desired quantity of entangled pairs per request.
+    ``-1`` means infinite.
+    """
+
+
+def gen_tm() -> None:
+    d = NetTrafficDef(matrix={}, duration=1, epr_count=-1)
+    for src, dst in itertools.product(END_NODES, END_NODES):
+        if src == dst:
+            continue
+        d["matrix"][f"{src}-{dst}"] = 0.0
+    tomli_w.dump(d, sys.stdout.buffer)
+
+
+def build_network(args: Args) -> QuantumNetwork:
+    b = NetworkBuilder()
+    define_topo(b)
+    match args.mux:
+        case "B":
+            b.proactive_centralized(mux=MuxSchemeBufferSpace(), mv_auto=1)
+        case "S":
+            b.proactive_centralized(mux=MuxSchemeStatistical())
+    return b.make_network()
+
+
+type Result = list[tuple[Request, RequestCounters]]
+
+
+def run_simulation(seed: int, args: Args, tm: NetTrafficDef) -> Result:
+    rng.reseed(seed)
+    net = build_network(args)
+
+    mtg = MatrixTrafficGenerator(
+        net,
+        cast(TrafficMatrixMapping, tm["matrix"]),
+        sched="eager",
+        rate=args.rate,
+        duration=tm["duration"],
+        epr_count=tm["epr_count"],
+    )
+
+    s = Simulator(0, args.sim_duration, accuracy=1000000, install_to=(log, net, mtg))
+    s.run()
+
+    return [(req, RequestCounters.of(net, req)) for req in net.requests]
+
+
+def save_csv(args: Args, result: Result) -> None:
+    with open(args.csv, "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(
+            (
+                "req_id",
+                "src",
+                "dst",
+                "active_since",
+                "active_until",
+                "req_epr_count",
+                "n_consumed",
+                "fid",
+                "lat_first",
+                "lat_last",
+            )
+        )
+        for req, cnt in result:
+            active_since = cast(Time, req.active_since)
+            active_until = cast(Time, req.active_until)
+            lat_first, lat_last = cnt.get_latency(active_since)
+            w.writerow(
+                (
+                    req.req_id,
+                    req.src,
+                    req.dst,
+                    active_since,
+                    active_until,
+                    req.epr_count,
+                    cnt.n_consumed,
+                    cnt.consumed_avg_fidelity,
+                    lat_first,
+                    lat_last,
+                )
+            )
+
+
+def main(args: Args) -> None:
+    if args.tm_gen:
+        return gen_tm()
+
+    with open(args.tm, "rb") as f:
+        tm = cast(NetTrafficDef, tomllib.load(f))
+
+    result = run_simulation(seed_env(0), args, tm)
+    if args.csv:
+        save_csv(args, result)
+
+    total_consumed = sum(cnt.n_consumed for _, cnt in result)
+    print(f"Simulation completed, {len(result)} requests, {total_consumed} consumed")
+
+
+if __name__ == "__main__":
+    args = Args().parse_args()
+    main(args)

--- a/examples/multi_request_single_path.py
+++ b/examples/multi_request_single_path.py
@@ -30,7 +30,7 @@ from mqns.network.builder import CTRL_DELAY, NetworkBuilder
 from mqns.network.fw import MuxScheme, MuxSchemeDynamicEpr, MuxSchemeStatistical
 from mqns.network.protocol.consumer import RequestCounters
 from mqns.simulator import Simulator
-from mqns.utils import log, rng
+from mqns.utils import log, rng, seed_seq_env
 
 from examples_common.plotting import Axes2D, mpl, plt, plt_save
 
@@ -45,7 +45,6 @@ class Args(Tap):
     plt: str = ""  # save plot as image file
 
 
-SEED_BASE = 100
 PATH_TITLES = ("S1-D1", "S2-D2")
 N_PATHS = len(PATH_TITLES)
 
@@ -98,9 +97,9 @@ def run_row(args: Args, strategy: str, t_cohere: float) -> list[PathStats]:
     path_rates: list[list[float]] = [[] for _ in range(N_PATHS)]
     path_fids: list[list[float]] = [[] for _ in range(N_PATHS)]
 
-    for i in range(args.runs):
-        print(f"{strategy}, T_cohere={t_cohere:.3f}, run #{i}")
-        res = run_simulation(SEED_BASE + i, args, mux, t_cohere)
+    for seed in seed_seq_env(args.runs, 100):
+        print(f"{strategy}, T_cohere={t_cohere:.3f}, seed={seed}")
+        res = run_simulation(seed, args, mux, t_cohere)
         for path, (rate, fid) in enumerate(res):
             path_rates[path].append(rate)
             path_fids[path].append(fid)

--- a/examples/multiplexing.py
+++ b/examples/multiplexing.py
@@ -52,7 +52,7 @@ from mqns.network.proactive import ProactiveForwarder
 from mqns.network.protocol.consumer import RequestCounters
 from mqns.network.protocol.link_layer import LinkLayer
 from mqns.simulator import Simulator
-from mqns.utils import log, rng
+from mqns.utils import log, rng, seed_seq_env
 
 from examples_common.plotting import mpl, plt, plt_save
 
@@ -68,7 +68,6 @@ class Args(Tap):
     plt_buff: str = ""  # save Buffer-Space plot as image file
 
 
-SEED_BASE = 100
 TX_QUBITS = 50
 RX_QUBITS = 32
 
@@ -253,9 +252,9 @@ def run_row(args: Args, strategy: str, scenario: Scenario) -> list[FlowStats]:
     flow_rates = [[] for _ in range(N_FLOWS)]
     flow_fids = [[] for _ in range(N_FLOWS)]
 
-    for i in range(args.runs):
-        flow_stats, total_decoh, total_swap_conflict = run_simulation(SEED_BASE + i, args, mux, flows)
-        print(f"{strategy}, {label}, run #{i}, decoh={total_decoh}, swap-conflict={total_swap_conflict}")
+    for seed in seed_seq_env(args.runs, 100):
+        flow_stats, total_decoh, total_swap_conflict = run_simulation(seed, args, mux, flows)
+        print(f"{strategy}, {label}, seed={seed}, decoh={total_decoh}, swap-conflict={total_swap_conflict}")
         for idx, (rate, fid) in enumerate(flow_stats):
             flow_rates[idx].append(rate)
             flow_fids[idx].append(fid)

--- a/examples/multiplexing.py
+++ b/examples/multiplexing.py
@@ -48,6 +48,7 @@ from tap import Tap
 
 from mqns.network.builder import CTRL_DELAY, NetworkBuilder
 from mqns.network.fw import MultiplexingVector, MuxScheme, MuxSchemeBufferSpace, MuxSchemeStatistical, RoutingPathStatic
+from mqns.network.network import QuantumNetwork
 from mqns.network.proactive import ProactiveForwarder
 from mqns.network.protocol.consumer import RequestCounters
 from mqns.network.protocol.link_layer import LinkLayer
@@ -55,6 +56,7 @@ from mqns.simulator import Simulator
 from mqns.utils import log, rng, seed_seq_env
 
 from examples_common.plotting import mpl, plt, plt_save
+from examples_common.topo_multiplexing import RX_QUBITS, TX_QUBITS, define_topo
 
 log.set_default_level("CRITICAL")
 
@@ -66,10 +68,6 @@ class Args(Tap):
     json: str = ""  # save results as JSON file
     plt_stat: str = ""  # save Statistical plot as image file
     plt_buff: str = ""  # save Buffer-Space plot as image file
-
-
-TX_QUBITS = 50
-RX_QUBITS = 32
 
 
 class FlowDef:
@@ -111,14 +109,14 @@ STRATEGIES: dict[str, MuxScheme] = {
 }
 
 
-def _mv_for_flow(flow: str, route: list[str], active_flows: set[str]):
+def _mv_for_flow(flow: str, route: list[str], active_flows: set[str]) -> MultiplexingVector:
     """
     Build a MultiplexingVector for one flow under Buffer-Space multiplexing,
     applying the per-link qubit allocations.
     For Statistical mux, this is ignored.
     """
     mv: MultiplexingVector = []
-    for u, v in zip(route[:-1], route[1:]):
+    for u, v in itertools.pairwise(route):
         pair = f"{u}{v}"
         # Default: full TX/RX on uncontested links
         tx_rx = (RX_QUBITS, TX_QUBITS) if pair == "GF" else (TX_QUBITS, RX_QUBITS)
@@ -168,32 +166,9 @@ def _mv_for_flow(flow: str, route: list[str], active_flows: set[str]):
     return mv
 
 
-def build_network(mux: MuxScheme, active_flows: Sequence[FlowDef], active_flows_set: set[str]):
+def build_network(mux: MuxScheme, active_flows: Sequence[FlowDef], active_flows_set: set[str]) -> QuantumNetwork:
     b = NetworkBuilder()
-    b.topo(
-        channels=[
-            # left spokes -> E
-            (("A", "E"), 30, (TX_QUBITS, RX_QUBITS)),
-            (("B", "E"), 30, (TX_QUBITS, RX_QUBITS)),
-            (("C", "E"), 30, (TX_QUBITS, RX_QUBITS)),
-            (("D", "E"), 30, (TX_QUBITS, RX_QUBITS)),
-            # middle trunks
-            (("E", "F"), 30, (RX_QUBITS, TX_QUBITS)),
-            (("F", "J"), 30, (TX_QUBITS, RX_QUBITS)),
-            # right spokes from J
-            (("J", "K"), 30, (TX_QUBITS, RX_QUBITS)),
-            (("J", "L"), 30, (TX_QUBITS, RX_QUBITS)),
-            (("J", "M"), 30, (TX_QUBITS, RX_QUBITS)),
-            # bottom spokes from F
-            (("G", "F"), 30, (RX_QUBITS, TX_QUBITS)),
-            (("F", "H"), 30, (TX_QUBITS, RX_QUBITS)),
-            (("F", "I"), 30, (TX_QUBITS, RX_QUBITS)),
-        ],
-        fiber_alpha=0.17,
-        eta_d=0.5,
-        eta_s=0.8,
-        t_cohere=0.1,
-    )
+    define_topo(b)
 
     b.proactive_centralized(mux=mux)
 

--- a/examples/s2uc.py
+++ b/examples/s2uc.py
@@ -46,7 +46,7 @@ from mqns.network.network import QuantumNetwork
 from mqns.network.protocol.consumer import RequestCounters
 from mqns.network.protocol.link_layer import LinkLayer
 from mqns.simulator import Simulator
-from mqns.utils import log, rng, unwrap
+from mqns.utils import log, rng, seed_seq_env, unwrap
 
 from examples_common.plotting import plt, plt_save
 
@@ -76,7 +76,6 @@ class Args(Tap):
 
 
 SIMULATOR_ACCURACY = 1000000
-SEED_BASE = 100
 
 
 @dataclass
@@ -280,8 +279,8 @@ def run_row(args: Args, ri: RowInput, lam_mean: list[float]) -> Row:
     rate_mdl, fid_mdl = run_model(lam_mean, ri.w)
 
     runs: list[Stats] = []
-    for i in range(args.runs):
-        runs += run_evaluation(SEED_BASE + i, args, ri)
+    for seed in seed_seq_env(args.runs, 100):
+        runs += run_evaluation(seed, args, ri)
 
     rates = np.fromiter((s["rate"] for s in runs), dtype=float)
     fids = np.fromiter((s["fid_mean"] if s["rate"] > 0 else np.nan for s in runs), dtype=float)
@@ -303,7 +302,7 @@ def run_row(args: Args, ri: RowInput, lam_mean: list[float]) -> Row:
 def main(args: Args) -> Report:
     # Run calibration step to determine LinkLayer arrival rates of each channel.
     with Pool(processes=args.workers) as pool:
-        lam_runs = pool.starmap(run_calibration, itertools.product(range(SEED_BASE, SEED_BASE + args.runs), [args]))
+        lam_runs = pool.starmap(run_calibration, itertools.product(seed_seq_env(args.runs, 100), [args]))
     lam_mean: list[float] = []
     lam_std: list[float] = []
     # Collect mean LinkLayer arrival rates of each channel.

--- a/examples/single_request_multipath.py
+++ b/examples/single_request_multipath.py
@@ -21,7 +21,7 @@ from mqns.network.protocol.consumer import RequestCounters
 from mqns.network.protocol.link_layer import LinkLayerCounters
 from mqns.network.route import YenRouteAlgorithm
 from mqns.simulator import Simulator
-from mqns.utils import log, rng
+from mqns.utils import log, rng, seed_env
 
 log.set_default_level("DEBUG")
 
@@ -29,8 +29,6 @@ log.set_default_level("DEBUG")
 class Args(Tap):
     sim_duration: float = 3  # simulation duration in seconds
 
-
-SEED_BASE = 100
 
 # Quantum channel lengths
 ch_S_R1 = 10
@@ -79,6 +77,6 @@ def run_simulation(seed: int, args: Args):
 if __name__ == "__main__":
     args = Args().parse_args()
 
-    e2e_rate, decoh_ratio = run_simulation(SEED_BASE, args)
+    e2e_rate, decoh_ratio = run_simulation(seed_env(100), args)
     print(f"E2E etg rate: {e2e_rate}")
     print(f"Expired memories: {decoh_ratio}")

--- a/examples/swapping_policies_6_nodes.py
+++ b/examples/swapping_policies_6_nodes.py
@@ -32,14 +32,13 @@ from mqns.network.builder import CTRL_DELAY, NetworkBuilder
 from mqns.network.fw import SwapPolicy
 from mqns.network.protocol.consumer import RequestCounters
 from mqns.simulator import Simulator
-from mqns.utils import log, rng
+from mqns.utils import log, rng, seed_seq_env
 
 from examples_common.plotting import Axes1D, mpl, plt, plt_save
 
 log.set_default_level("CRITICAL")
 
 
-SEED_BASE = 100
 N_NODES = 6
 TOTAL_QUBITS = 6
 CHANNEL_LENGTHS: list[float] = [32, 18, 35, 16, 24]
@@ -161,8 +160,7 @@ if __name__ == "__main__":
             print(f"\n>>> Testing order: {order}, Channel Mem allocation: {mem_label}")
             for t_cohere in t_cohere_values:
                 run_rates = []
-                for i in range(args.runs):
-                    seed = SEED_BASE + i
+                for seed in seed_seq_env(args.runs, 100):
                     swapping_config = order
 
                     ch_capacities = mem_allocs

--- a/examples/template_linear.py
+++ b/examples/template_linear.py
@@ -26,7 +26,7 @@ from mqns.network.fw import SwapSequenceInput
 from mqns.network.protocol.consumer import RequestCounters
 from mqns.network.protocol.link_layer import LinkLayerCounters
 from mqns.simulator import Simulator
-from mqns.utils import log, rng
+from mqns.utils import log, rng, seed_env, seed_seq_env
 
 from examples_common.plotting import plt, plt_save
 
@@ -45,8 +45,8 @@ log.set_default_level("CRITICAL")
 # USER CONFIG: Experiment defaults
 # ──────────────────────────────────────────────────────────────────────────────
 
-# Reproducibility
-SEED_BASE = 100  # each run uses SEED_BASE + run_index
+# Reproducibility: each run uses SEED_BASE + run_index
+DEFAULT_SEED_BASE = 100  # Can be changed via MQNS_SEED environment variable
 
 # Simulation controls
 SIM_DURATION = 3.0  # Duration of one simulation run in seconds
@@ -139,8 +139,8 @@ MEASURES: list[MetricName] = ["throughput", "mean_fidelity", "expired_ratio"]
 # Core simulation runner
 # ──────────────────────────────────────────────────────────────────────────────
 def run_simulation(
-    *,
     seed: int,
+    *,
     t_cohere: float,
     swap: SwapSequenceInput,
     channel_capacity: int,
@@ -213,12 +213,11 @@ def run_row(
     """
     metrics_per_run: list[dict[str, float]] = []
 
-    for i in range(n_runs):
-        seed = SEED_BASE + i
+    for i, seed in enumerate(seed_seq_env(n_runs, DEFAULT_SEED_BASE)):
         print(f"t_cohere={t_cohere:.6f}, swap={swap}, cap={channel_capacity}, run {i + 1}/{n_runs}")
 
         m = run_simulation(
-            seed=seed,
+            seed,
             t_cohere=t_cohere,
             swap=swap,
             channel_capacity=channel_capacity,
@@ -342,7 +341,7 @@ if __name__ == "__main__":
     if not SWEEP:
         # Single scenario run
         metrics = run_simulation(
-            seed=SEED_BASE,
+            seed_env(DEFAULT_SEED_BASE),
             t_cohere=T_COHERE,
             swap=SWAP,
             channel_capacity=CHANNEL_CAPACITY,

--- a/examples/template_routing.py
+++ b/examples/template_routing.py
@@ -63,7 +63,7 @@ from mqns.network.network.timing import TimingModeSync
 from mqns.network.protocol.consumer import RequestCounters
 from mqns.network.route import DijkstraRouteAlgorithm, YenRouteAlgorithm
 from mqns.simulator import Simulator
-from mqns.utils import log, rng
+from mqns.utils import log, rng, seed_seq_env
 
 _ = TimingModeSync
 
@@ -82,7 +82,7 @@ log.set_default_level("CRITICAL")
 # =============================================================================
 # Fixed simulation parameters (users can edit these)
 # =============================================================================
-SEED_BASE = 100
+DEFAULT_SEED_BASE = 100  # Can be changed via MQNS_SEED environment variable
 SIM_DURATION = 3.0
 
 FIBER_ALPHA_DB_PER_KM = 0.2
@@ -288,7 +288,7 @@ def build_network(route_algo: Any, t_cohere: float) -> QuantumNetwork:
 # =============================================================================
 # One run + metric extraction
 # =============================================================================
-def run_one(t_cohere: float, seed: int) -> dict[str, tuple[float, float]]:
+def run_one(seed: int, t_cohere: float) -> dict[str, tuple[float, float]]:
     rng.reseed(seed)
 
     net = build_network(SC.route_algorithm, t_cohere)
@@ -319,7 +319,7 @@ def run_sweep():
 
     for t in T_COHERE_SWEEP:
         # runs: list of {label: (rate,fid)}
-        runs = [run_one(t, SEED_BASE + i) for i in range(args.runs)]
+        runs = [run_one(seed, t) for seed in seed_seq_env(args.runs, DEFAULT_SEED_BASE)]
 
         for lab in labels:
             rates = [tr[lab][0] for tr in runs]

--- a/examples/vora_evaluation.py
+++ b/examples/vora_evaluation.py
@@ -57,7 +57,7 @@ from mqns.network.proactive import compute_vora_swap_sequence
 from mqns.network.protocol.consumer import RequestCounters
 from mqns.network.protocol.link_layer import LinkLayerCounters
 from mqns.simulator import Simulator
-from mqns.utils import log, rng
+from mqns.utils import log, rng, seed_seq_env
 
 from examples_common.plotting import Axes2D, plt, plt_save
 
@@ -88,7 +88,6 @@ For each distance proportion, function to generate relative weights of qchannel 
 
 class ParameterSet:
     def __init__(self):
-        self.seed_base = 100
         self.n_runs = 10
 
         self.sim_duration = 5.0
@@ -185,7 +184,7 @@ def vora_regen_row(p: ParameterSet, num_routers: int, dist_prop: str, indir: str
     )
 
 
-def run_simulation(p: ParameterSet, seed: int) -> tuple[float, float]:
+def run_simulation(seed: int, p: ParameterSet) -> tuple[float, float]:
     rng.reseed(seed)
 
     net = p.build_network()
@@ -207,10 +206,9 @@ def run_row(p: ParameterSet, num_routers: int, dist_prop: str, swap_conf: str) -
 
     entanglements: list[float] = []
     expired: list[float] = []
-    for i in range(p.n_runs):
-        print(f"Simulation: {num_routers} routers | {dist_prop} distances | {swap_conf} | run #{i + 1}")
-        seed = p.seed_base + i
-        e2e_count, expired_count = run_simulation(p, seed)
+    for seed in seed_seq_env(args.runs, 100):
+        print(f"Simulation: {num_routers} routers | {dist_prop} distances | {swap_conf} | seed {seed}")
+        e2e_count, expired_count = run_simulation(seed, p)
         entanglements.append(e2e_count)
         expired.append(expired_count)
 

--- a/mqns/entity/base_channel.py
+++ b/mqns/entity/base_channel.py
@@ -101,9 +101,9 @@ class BaseChannel[N: Node](Entity):
         """
         if len(self.node_list) != 2:
             raise ValueError(f"{self} does not have exactly 2 nodes")
-        if self.node_list[0] == own:
+        if self.node_list[0] is own:
             return self.node_list[1]
-        if self.node_list[1] == own:
+        if self.node_list[1] is own:
             return self.node_list[0]
         raise ValueError(f"{self} does not connect to {own}")
 

--- a/mqns/network/builder.py
+++ b/mqns/network/builder.py
@@ -459,6 +459,8 @@ class NetworkBuilder:
 
     def proactive_centralized(
         self,
+        *,
+        mv_auto: MultiplexingVectorInput | None = None,
         **kwargs: Unpack[AppsForwarderArgs],
     ) -> Self:
         """
@@ -472,11 +474,12 @@ class NetworkBuilder:
         kwargs.setdefault("p_swap", 0.5)
 
         mux = kwargs.get("mux")
-        mv_auto: MultiplexingVectorInput = "none"
-        if mux is None or isinstance(mux, MuxSchemeBufferSpace):
-            mv_auto = "max"
-        elif isinstance(self.route, YenRouteAlgorithm):
-            raise TypeError("YenRouteAlgorithm is only compatible with MuxSchemeBufferSpace")
+        if mv_auto is None:
+            mv_auto = "none"
+            if mux is None or isinstance(mux, MuxSchemeBufferSpace):
+                mv_auto = "max"
+            elif isinstance(self.route, YenRouteAlgorithm):
+                raise TypeError("YenRouteAlgorithm is only compatible with MuxSchemeBufferSpace")
 
         self._add_link_layer()
         self.qnode_apps.append(

--- a/mqns/network/fw/cutoff.py
+++ b/mqns/network/fw/cutoff.py
@@ -36,8 +36,6 @@ class CutoffScheme(ForwarderModule, ABC):
         Args:
             round: -1 for swap_cutoff; nonnegative number for purif round.
         """
-        fw = self.fw
-
         o_key = unwrap_cast(qubit.key)
 
         # Find EPR partner.
@@ -49,11 +47,11 @@ class CutoffScheme(ForwarderModule, ABC):
 
         # Inform SwapProc.
         if round == -1:
-            fw.swap.handle_decohere(o_key)
+            self.fw.swap.handle_decohere(o_key)
 
         # Discard primary qubit.
-        fw.cnt.increment_n_cutoff(round, True)
-        fw.release_qubit(qubit, need_remove=True)
+        self.fw_cnt.increment_n_cutoff(round, True)
+        self.fw.release_qubit(qubit, need_remove=True)
 
         # Ask partner to discard secondary qubit.
         msg: CutoffDiscardMsg = {
@@ -72,16 +70,15 @@ class CutoffScheme(ForwarderModule, ABC):
         This is called by ProactiveForwarder upon receiving a CUTOFF_DISCARD message.
         """
         _ = fp
-        fw = self.fw
         o_key = msg["key"]
         round = msg["round"]
 
         # Inform SwapProc.
         if round == -1:
-            fw.swap.handle_decohere(o_key)
+            self.fw.swap.handle_decohere(o_key)
 
         # Find qubit.
-        qm_tuple = fw.memory.read(o_key, remove=True)
+        qm_tuple = self.memory.read(o_key, remove=True)
         if qm_tuple is None:
             self.log_debug("remote cutoff discard key=%s not exist", o_key)
             return
@@ -89,8 +86,8 @@ class CutoffScheme(ForwarderModule, ABC):
         self.log_debug("remote cutoff discard key=%s addr=%s round=%s", o_key, qubit.addr, round)
 
         # Discard secondary qubit.
-        fw.cnt.increment_n_cutoff(round, False)
-        fw.release_qubit(qubit)
+        self.fw_cnt.increment_n_cutoff(round, False)
+        self.fw.release_qubit(qubit)
 
     @abstractmethod
     def before_store_eligible(self, mq: MemoryQubit, dir: PathDirection, fp: FibPath | None) -> None:

--- a/mqns/network/fw/fib.py
+++ b/mqns/network/fw/fib.py
@@ -329,7 +329,7 @@ class Fib:
 
         for entry in fr.paths:
             if entry.path_id in self._paths:
-                raise ValueError(f"FibEntry({entry.path_id}) already exists")
+                raise ValueError(f"FibPath({entry.path_id}) already exists")
             self._paths[entry.path_id] = entry
 
         if opposite := self._req_opposite_end(fr):

--- a/mqns/network/fw/fw_module.py
+++ b/mqns/network/fw/fw_module.py
@@ -1,4 +1,3 @@
-import functools
 from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING, Any
 
@@ -9,7 +8,7 @@ from mqns.models.epr import Entanglement
 from mqns.network.fw.fib import Fib, FibPath
 from mqns.network.network import QuantumNetwork
 from mqns.simulator import Simulator
-from mqns.utils import LogSelfMixin, log
+from mqns.utils import LogSelfMixin
 
 if TYPE_CHECKING:
     from mqns.network.fw.forwarder import Forwarder, ForwarderCounters
@@ -23,12 +22,11 @@ def fw_control_cmd_handler(cmd: str):
     """
 
     def decorator(f: Callable[[Any, Any], Any]):
-        @functools.wraps(f)
-        def wrapper(self: "Forwarder|ForwarderModule", pkt: ClassicPacket, msg: dict):
-            self.log_debug("received control message from %s | %s", pkt.src.name, msg)
+        def fw_control_cmd_handler_wrapper(self: "Forwarder|ForwarderModule", pkt: ClassicPacket, msg: Mapping):
+            self.log_debug("RECV_%s from=%s | %s", cmd, pkt.src.name, msg)
             f(self, msg)
 
-        return classic_cmd_handler(cmd)(wrapper)
+        return classic_cmd_handler(cmd)(fw_control_cmd_handler_wrapper)
 
     return decorator
 
@@ -41,25 +39,34 @@ def fw_signaling_cmd_handler(cmd: str):
     """
 
     def decorator(f: Callable[[Any, Any, FibPath], Any]):
-        @functools.wraps(f)
-        def wrapper(self: "ForwarderModule", pkt: ClassicPacket, msg: dict):
+        def fw_signaling_cmd_handler_wrapper(self: "Forwarder|ForwarderModule", pkt: ClassicPacket, msg: Mapping):
             path_id: int = msg["path_id"]
+            src_name = pkt.src.name
+            dest_name = pkt.dest.name
             try:
                 fp = self.fib.get_path(path_id)
             except LookupError:
-                self.log_debug("dropping signaling message from %s, reason=no-fib-entry | %s", pkt.src.name, msg)
+                self.log_debug("DROP_%s from=%s reason=no-fib-path | %s", cmd, src_name, msg)
                 return
 
-            if pkt.dest != self.node:
-                self.send_msg(pkt.dest, msg, fp, forward_from=pkt.src)
-                return
+            if pkt.dest is self.node:
+                self.log_debug("RECV_%s from=%s | %s", cmd, src_name, msg)
+                f(self, msg, fp)
+            else:
+                next_hop, via_str = _find_next_hop(self.network, fp, dest_name)
+                self.log_debug("FORW_%s from=%s %sto=%s path=%s | %s", cmd, src_name, via_str, dest_name, path_id, msg)
+                self.node.send_cpacket(next_hop, pkt)
 
-            self.log_debug("received signaling message from %s | %s", pkt.src.name, msg)
-            f(self, msg, fp)
-
-        return classic_cmd_handler(cmd)(wrapper)
+        return classic_cmd_handler(cmd)(fw_signaling_cmd_handler_wrapper)
 
     return decorator
+
+
+def _find_next_hop(net: QuantumNetwork, fp: FibPath, dest_name: str) -> tuple[Node, str]:
+    dest_idx = fp.route.index(dest_name)
+    nh_idx = fp.own_idx + 1 if dest_idx > fp.own_idx else fp.own_idx - 1
+    nh_name = fp.route[nh_idx]
+    return net.get_node(nh_name), "" if nh_idx == dest_idx else f"via={nh_name} "
 
 
 class ForwarderModule(LogSelfMixin, ClassicCommandModule):
@@ -89,27 +96,21 @@ class ForwarderModule(LogSelfMixin, ClassicCommandModule):
     def __repr__(self):
         return Application.__repr__(self)
 
-    def send_ctrl(self, msg: Mapping):
+    def send_ctrl(self, msg: Mapping) -> None:
+        """
+        Send a control message to the network controller.
+        """
         ctrl = self.network.get_controller()
-        log.debug("%s: sending control message to controller | %s", self, msg)
+        self.log_debug("SEND_%s to=%s | %s", msg["cmd"], ctrl.name, msg)
         self.node.send_cpacket(ctrl, ClassicPacket(msg, src=self.node, dest=ctrl))
 
-    def send_msg(self, dest: Node, msg: Mapping, fp: FibPath, *, forward_from: Node | None = None):
+    def send_msg(self, dest: Node, msg: Mapping, fp: FibPath) -> None:
         """
-        Send/forward a signaling message along the path specified in FIB path entry.
+        Send a signaling message along the path specified in FIB path entry.
         """
-        dest_idx = fp.route.index(dest.name)
-        nh_idx = fp.own_idx + 1 if dest_idx > fp.own_idx else fp.own_idx - 1
-        next_hop = self.network.get_node(fp.route[nh_idx])
+        dest_name = dest.name
+        next_hop, via_str = _find_next_hop(self.network, fp, dest_name)
+        self.log_debug("SEND_%s %sto=%s path=%s | %s", msg["cmd"], via_str, dest_name, fp.path_id, msg)
 
-        pkt = ClassicPacket(msg, src=forward_from or self.node, dest=dest)
-        log.debug(
-            "%s: %s signaling message from %s to %s%s | %s",
-            self,
-            "forwarding" if forward_from else "sending",
-            pkt.src.name,
-            pkt.dest.name,
-            "" if nh_idx == dest_idx else f" via {next_hop.name}",
-            msg,
-        )
+        pkt = ClassicPacket(msg, src=self.node, dest=dest)
         self.node.send_cpacket(next_hop, pkt)

--- a/mqns/network/fw/fw_swap.py
+++ b/mqns/network/fw/fw_swap.py
@@ -364,7 +364,7 @@ class ForwarderSwapProc(ForwarderModule):
         SwapUpdates received prior to QubitEntangledEvent.
 
         * Key: MemoryQubit reservation key.
-        * Value: SwapUpdateMsg and FibEntry.
+        * Value: SWAP_UPDATE message and related fields.
         """
 
         self.remote_swapped: dict[str, Entanglement] = {}

--- a/mqns/network/fw/mux_dynamic_epr.py
+++ b/mqns/network/fw/mux_dynamic_epr.py
@@ -9,13 +9,8 @@ from mqns.models.epr import Entanglement
 from mqns.network.fw.fib import Fib, FibPath
 from mqns.network.fw.mux_buffer_space import MuxSchemeFibBase
 from mqns.network.fw.mux_statistical import MuxSchemeDynamicBase
-from mqns.network.fw.select import call_select, parse_select
+from mqns.network.fw.select import call_select, parse_select, select_random
 from mqns.utils import rng, unwrap_cast
-
-
-def _select_path_random(path_ids: list[int], epr: Entanglement, fib: Fib) -> int:
-    _ = epr, fib
-    return rng.choice(path_ids)
 
 
 def _select_path_swap_weighted(path_ids: list[int], epr: Entanglement, fib: Fib) -> FibPath:
@@ -43,10 +38,10 @@ class MuxSchemeDynamicEpr(MuxSchemeFibBase, MuxSchemeDynamicBase):
         path_ids: List of candidate path IDs for this EPR.
 
     Returns:
-        The selected path ID or FibEntry.
+        The selected path ID or FIB path entry.
     """
 
-    SelectPath_random: SelectPath = _select_path_random
+    SelectPath_random: SelectPath = select_random
     """
     Path selection strategy: random allocation.
     """

--- a/mqns/network/network/network.py
+++ b/mqns/network/network/network.py
@@ -296,9 +296,6 @@ class QuantumNetwork:
         req.active_since = Time.from_time_or_sec(req.active_since, accuracy=self.simulator.accuracy)
         req.active_until = Time.from_time_or_sec(req.active_until, accuracy=self.simulator.accuracy)
 
-        if not self.controller:
-            return
-
         t_enter = self.simulator.tc if req.active_since is Time.MIN else req.active_since
         self.simulator.sched(RequestActiveEvent(self.controller, req, t=t_enter))
 

--- a/mqns/network/network/request.py
+++ b/mqns/network/network/request.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Final, Self, TypedDict, Unpack, cast, final, o
 
 from mqns.entity.node import Controller, NodePair, split_node_pair
 from mqns.simulator import Event, EventHandleSlot, Time
+from mqns.utils import log
 
 if TYPE_CHECKING:
     from mqns.network.fw.routing import RoutingPath, RoutingPathInitArgs
@@ -170,36 +171,39 @@ class Request:
         return self.rp.req_id if self.rp else self.rp_args.get("req_id", -1)
 
     def __repr__(self) -> str:
-        return (
-            f"Request({self.src}-{self.dst}, "
-            f"active_period={self.active_since}-{self.active_until}), "
-            f"epr_count={self.epr_count})"
-        )
+        tokens = [f"{self.src}-{self.dst}", f"active_period={self.active_since}-{self.active_until}"]
+        if self.epr_count > 0:
+            tokens.append(f"epr_count={self.epr_count}")
+        return f"Request({', '.join(tokens)})"
 
 
 @final
 class RequestActiveEvent(Event):
     """Event when a request becomes active."""
 
-    def __init__(self, node: Controller, req: Request, *, t: Time):
+    def __init__(self, node: Controller | None, req: Request, *, t: Time):
         super().__init__(t, f"{req}")
         self.node = node
         self.req = req
 
     @override
     def invoke(self) -> None:
-        self.node.handle(self)
+        log.info("NETWORK: REQ_ACTIVE %s", self.req)
+        if self.node:
+            self.node.handle(self)
 
 
 @final
 class RequestInactiveEvent(Event):
     """Event when a request becomes inactive."""
 
-    def __init__(self, node: Controller, req: Request, *, t: Time):
+    def __init__(self, node: Controller | None, req: Request, *, t: Time):
         super().__init__(t, f"{req}")
         self.node = node
         self.req = req
 
     @override
     def invoke(self) -> None:
-        self.node.handle(self)
+        log.info("NETWORK: REQ_INACTIVE %s", self.req)
+        if self.node:
+            self.node.handle(self)

--- a/mqns/network/network/timing.py
+++ b/mqns/network/network/timing.py
@@ -1,4 +1,3 @@
-import functools
 import itertools
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Sequence
@@ -255,10 +254,9 @@ def sync_phase_handler(phase: TimingPhase, enter: bool):
     """
 
     def decorator(f: Callable[[Any], None]):
-        @functools.wraps(f)
-        def wrapper(self: Any, _: Event) -> None:
+        def sync_phase_handler_wrapper(self: Any, _: Event) -> None:
             f(self)
 
-        return event_handler(_PHASE_EVENTS[phase, enter])(wrapper)
+        return event_handler(_PHASE_EVENTS[phase, enter])(sync_phase_handler_wrapper)
 
     return decorator

--- a/mqns/network/network/traffic_matrix.py
+++ b/mqns/network/network/traffic_matrix.py
@@ -75,7 +75,7 @@ class MatrixTrafficGenerator:
         self._duration = kwargs.get("duration", 1.0)
         self._epr_count = kwargs.get("epr_count", 1)
 
-    def _convert_tm_map(self, tm: TrafficMatrixMapping):
+    def _convert_tm_map(self, tm: TrafficMatrixMapping) -> TrafficMatrixInput:
         n = len(self.node_names)
         array = np.zeros((n, n), dtype=np.float64)
         for pair, prob in tm.items():

--- a/mqns/network/protocol/consumer.py
+++ b/mqns/network/protocol/consumer.py
@@ -7,7 +7,7 @@ from mqns.entity.memory import QubitState
 from mqns.entity.node import Application, NodePair, QNode, split_node_pair
 from mqns.network.network import QuantumNetwork
 from mqns.network.protocol.event import QubitConsumeEvent, QubitReleasedEvent
-from mqns.simulator import event_handler
+from mqns.simulator import Time, event_handler
 from mqns.utils import json_encodable
 
 
@@ -39,6 +39,14 @@ class RequestCounters:
     consumed_fidelity_values: list[float] | None = None
     """
     Fidelity values of consumed entanglements, None disables collection.
+    """
+    t_first = Time.MAX
+    """
+    Timestamp of first consumption.
+    """
+    t_last = Time.MIN
+    """
+    Timestamp of last consumption.
     """
 
     @staticmethod
@@ -85,6 +93,8 @@ class RequestCounters:
         g.consumed_sum_fidelity = a.consumed_sum_fidelity + b.consumed_sum_fidelity
         if a.consumed_fidelity_values is b.consumed_fidelity_values:
             g.consumed_fidelity_values = a.consumed_fidelity_values
+        g.t_first = min(a.t_first, b.t_first)
+        g.t_last = max(a.t_last, b.t_last)
         return g
 
     @staticmethod
@@ -120,7 +130,10 @@ class RequestCounters:
         assert b.consumed_fidelity_values is None
         a.consumed_fidelity_values = b.consumed_fidelity_values = []
 
-    def increment_n_consumed(self, fidelity: float) -> None:
+    def save(self, t: Time, fidelity: float) -> None:
+        if self.n_consumed == 0:
+            self.t_first = t
+        self.t_last = t
         self.n_consumed += 1
         self.consumed_sum_fidelity += fidelity
         if self.consumed_fidelity_values is not None:
@@ -143,6 +156,19 @@ class RequestCounters:
         Returns: Entanglement rate in entanglements per second.
         """
         return self.n_consumed / duration
+
+    def get_latency(self, active_since: Time) -> tuple[float, float]:
+        """
+        Calculate satisfaction latency.
+
+        Args:
+            active_since: When did the request become active.
+
+        Returns: Latency of first and last EPR; nan if ``n_consumed`` is zero.
+        """
+        if self.n_consumed == 0:
+            return np.nan, np.nan
+        return (self.t_first - active_since).sec, (self.t_last - active_since).sec
 
     def get_per_consumed(self, x: float) -> float:
         """
@@ -172,17 +198,18 @@ class Consumer(Application[QNode]):
         """Quantum memory of the node."""
 
     @event_handler
-    def handle_ready(self, event: QubitConsumeEvent) -> None:
+    def handle_consume(self, event: QubitConsumeEvent) -> None:
+        now = event.t
         qubit = event.qubit
         epr = event.epr
         req_id = event.req_id
 
         role_str = "first"
-        if epr.consume_with_store_decay_side(self.simulator.tc, side=0 if epr.src is self.node else 1):
+        if epr.consume_with_store_decay_side(now, side=0 if epr.src is self.node else 1):
             role_str = "second"
-            self.cnt[req_id].increment_n_consumed(epr.fidelity)
+            self.cnt[req_id].save(now, epr.fidelity)
         self.log_debug("consume EPR %s for request %s: %s", role_str, req_id, epr)
 
         self.memory.read(qubit.addr, remove=True)
         qubit.state = QubitState.RELEASE
-        self.simulator.sched(QubitReleasedEvent(self.node, qubit, t=self.simulator.tc))
+        self.simulator.sched(QubitReleasedEvent(self.node, qubit, t=now))

--- a/mqns/utils/__init__.py
+++ b/mqns/utils/__init__.py
@@ -18,7 +18,7 @@
 from mqns.utils.autoid import AutoIncrementIdentifier
 from mqns.utils.json import json_default, json_encodable
 from mqns.utils.logger import LogSelfMixin, log
-from mqns.utils.random import rng
+from mqns.utils.random import rng, seed_env, seed_seq_env
 from mqns.utils.timeout import WallClockTimeout
 from mqns.utils.types import DecoratorDispatchBuilder, unwrap, unwrap_cast
 
@@ -30,6 +30,8 @@ __all__ = [
     "log",
     "LogSelfMixin",
     "rng",
+    "seed_env",
+    "seed_seq_env",
     "unwrap_cast",
     "unwrap",
     "WallClockTimeout",

--- a/mqns/utils/random.py
+++ b/mqns/utils/random.py
@@ -1,6 +1,7 @@
 import os
 import sys
-from typing import Any, Literal, cast
+from collections.abc import Sequence
+from typing import Any, Literal, cast, overload
 
 import numpy.random as npr
 
@@ -24,6 +25,55 @@ _FAST_METHODS = (
 Method names on ``rng`` to avoid getattr overhead.
 """
 
+_ENV_NAME = "MQNS_SEED"
+
+
+@overload
+def seed_env() -> int | None:
+    """
+    Parse random seed from MQNS_SEED environment variable.
+
+    Returns:
+        Integer random seed, or ``None`` if unset.
+    """
+
+
+@overload
+def seed_env(dflt: int) -> int:
+    """
+    Parse random seed from MQNS_SEED environment variable.
+
+    Returns:
+        Integer random seed, or ``dflt`` if unset.
+    """
+
+
+def seed_env(dflt: int | None = None):
+    env = os.getenv(_ENV_NAME)
+    if env is None:
+        return dflt
+    try:
+        return int(env)
+    except ValueError:
+        raise ValueError(f"{_ENV_NAME} environment variable is set but not an integer")
+
+
+def seed_seq_env(n_runs: int, dflt_base: int) -> Sequence[int]:
+    """
+    Generate a sequence of random seeds for consecutive experiment runs.
+    The first seed is parsed from MQNS_SEED environment variable if present.
+
+    Args:
+        n_runs: How many experiment runs.
+        dflt_base: The first seed, if MQNS_SEED environment variable is unset.
+
+    Returns:
+        An increasing sequence of integers.
+    """
+    seed_base = seed_env(dflt_base)
+    return range(seed_base, seed_base + n_runs)
+
+
 _next_seed_env: list[int] = []
 """
 This list must contain zero or one integer.
@@ -34,14 +84,13 @@ It is populated by the first ``rng.reseed("env")`` call, and incremented on subs
 def _reseed_env() -> int | None:
     if _next_seed_env:
         seed = _next_seed_env[0]
-    elif env := os.getenv("MQNS_SEED"):
-        seed = int(env)
-        _next_seed_env.append(seed)
     else:
-        return None
+        seed = seed_env()
+        if seed is None:
+            return None
 
     if "pytest" in sys.modules:
-        print(f"MQNS_SEED={seed}")
+        print(f"{_ENV_NAME}={seed}")
 
     _next_seed_env[0] = seed + 1
     return seed

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,11 +2,12 @@ build
 matplotlib>=3.11.1,<4
 numpy>=2.5.2,<3
 pandas[plot]>=2.3.3,<3
-pytest>=9.1.1,<10
 pytest-cov>=7.1.0,<8
 pytest-repeat>=0.9.4,<0.10.0
 pytest-timeout>=2.4.0,<3
-scipy>=1.18.0,<2
+pytest>=9.1.1,<10
 scipy-stubs>=1.18.0.1,<2
+scipy>=1.18.0,<2
 setuptools>=84.0.0
+tomli-w>=1.2.0,<2
 typed-argument-parser>=1.12.0,<2


### PR DESCRIPTION
This PR initiates the **mtg** example that demonstrates `MatrixTrafficGenerator` usage.
It starts with basic usage and will be expanded together with the traffic matrix feature.
The workflow pipeline is written at the top of this example script.

Due to the preliminary nature of the traffic matrix feature, several limitations apply:

* Due to lack of [resource admission and blocking policy](https://github.com/usnistgov/mqns/issues/124#issuecomment-4856292449), if the requests arrival rate is too high, memory oversubscription could occur when using buffer-space multiplexing scheme and cause the simulator to crash.
* To avoid any node from serving as both an end-node and an intermediate node, the traffic matrix only contains nodes with degree of 1.

Other changes include:

* Forwarder's classical packet handling is simplified with fewer indirections.
* The `MQNS_SEED` environment variable may be used in most examples (all except `scalability_randomtopo`) in place of `SEED_BASE` global variable.